### PR TITLE
fix: add agentforce skills @W-21341167@

### DIFF
--- a/skills/agent-development/README.md
+++ b/skills/agent-development/README.md
@@ -1,0 +1,33 @@
+# Agent Development Skills
+
+Skills for building, testing, and deploying Salesforce Agentforce agents using Agent Script — the scripting language for the Atlas Reasoning Engine.
+
+## Focus
+
+Agent Script is a new scripting language introduced in 2025 for authoring AI agents on the Salesforce platform. These skills provide comprehensive workflows for:
+
+- Creating and modifying Agent Script agents
+- Designing topic graphs and conversation flows
+- Validating and debugging agent behavior
+- Writing and running agent tests
+- Managing agent lifecycle (publish, activate, deactivate)
+
+## Available Skills
+
+### agent-script-skill
+
+Complete workflow for Agent Script development, from design to deployment. Includes:
+
+- Agent design and specification creation
+- Topic graph design patterns
+- Validation and debugging workflows
+- Testing with AiEvaluationDefinitions
+- CLI command reference for automation
+
+**Use when:** Working with `.agent` files, AiAuthoringBundle metadata, or any Agent Script development task.
+
+## Related Content
+
+See also:
+- [Agent Development Rules](../../rules/agent-development/) - Guardrails for Agent Script syntax, debugging, preview, and testing
+- [Testing Automation Skills](../testing-automation/) - General testing skills that complement agent-specific testing

--- a/skills/agent-development/agent-script-skill/SKILL.md
+++ b/skills/agent-development/agent-script-skill/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: agent-script-skill
+description: "Use this skill when working with Salesforce Agent Script — the scripting language for authoring Agentforce agents using the Atlas Reasoning Engine. Triggers include: creating, modifying, or comprehending Agent Script agents; working with AiAuthoringBundle files or .agent files; designing topic graphs or flow control; producing or updating an Agent Spec; validating Agent Script or diagnosing compilation errors; previewing agents or debugging behavioral issues; deploying, publishing, activating, or deactivating agents; deleting or renaming agents; authoring AiEvaluationDefinition test specs or running agent tests. This skill teaches Agent Script from scratch — AI models have zero prior training data on this language. Do NOT use for Apex development, Flow building, Prompt Template authoring, Experience Cloud configuration, or general Salesforce CLI tasks unrelated to Agent Script."
+---
+
+# Agent Script Skill
+
+## What This Skill Is For
+
+Agent Script is Salesforce's scripting language for authoring next-generation AI agents that run on the Atlas Reasoning Engine. Introduced in 2025, it has zero training data in any AI model.
+
+**⚠️CRITICAL:** Agent Script is NOT AppleScript, JavaScript, Python, or any other language. Do NOT confuse Agent Script syntax or semantics with any other language you have been trained on.
+
+An Agent Script agent is defined by `AiAuthoringBundle` metadata — a directory containing a `.agent` file (topics, actions, instructions, flow control, config) and `bundle-meta.xml` file. The agent processes utterances by routing through topics, each with instructions and actions backed by Apex, Flows, or Prompt Templates.
+
+## How to Use This Skill
+
+This file identifies the user's task and directs you to reference files. All detailed knowledge lives in reference files. Identify intent from task descriptions below, read indicated reference files, then start work.
+
+**CLI Convention**: All `sf` commands use `--json` as the FIRST flag for machine-readable output. See [CLI for Agents](references/salesforce-cli-for-agents.md) for exact syntax.
+
+## Common Patterns
+
+These patterns are referenced across multiple task domains below:
+
+### Backing Logic Scan
+
+When designing or modifying agents with new actions:
+1. Ask user if you should scan for existing backing logic
+2. If approved, read `sfdx-project.json` to identify package directories
+3. Search each package: `classes/` for `@InvocableMethod`, `flows/` for `AutoLaunchedFlow`, `promptTemplates/` for templates
+4. Mark matches as `EXISTS`, unmatched as `NEEDS STUB`
+
+### Validation Pattern
+
+1. **Compile**: `sf agent validate authoring-bundle --json --api-name <Developer_Name>`
+   - If fails, read [Validation & Debugging](references/agent-validation-and-debugging.md), fix, re-validate
+2. **Behavior**: `sf agent preview start --json --authoring-bundle <Developer_Name>` then `sf agent preview send --json --authoring-bundle <Developer_Name> --session-id <ID> -u "<message>"`
+   - Do NOT use bare `sf agent preview` (interactive REPL)
+   - **Once published**: Use `--api-name <Developer_Name>` instead of `--authoring-bundle` for more accurate results
+
+### Stub and Deploy Pattern
+
+For each action marked NEEDS STUB:
+1. Generate: `sf generate apex class --name <ClassName> --output-dir <PACKAGE_DIR>/main/default/classes`
+2. Implement `@InvocableMethod` pattern from Design & Agent Spec reference
+3. Deploy: `sf project deploy start --json --metadata ApexClass:<ClassName>`
+
+---
+
+## Task Domains
+
+Follow Required Steps verbatim, in order. Do not substitute your own plan.
+
+### Create an Agent
+
+User wants to build a new agent, typically describing purpose/topics/actions in plain language.
+
+#### Required Steps
+
+1. **Design** — Read [Design & Agent Spec](references/agent-design-and-spec-creation.md). Draft Agent Spec. Apply **Backing Logic Scan** pattern. **Save Agent Spec as file** before requesting user approval. Do not write Agent Script until approved.
+2. **Generate**: `sf agent generate authoring-bundle --json --no-spec --name "<Label>" --api-name <Developer_Name>`
+3. **Write code** — Read [Core Language](references/agent-script-core-language.md). Edit `.agent` file. Do not create files manually.
+4. **Validate** — Apply **Validation Pattern** (compile + behavior)
+5. **Stub and Deploy** — Apply **Stub and Deploy Pattern**
+6. **Publish**: `sf agent publish authoring-bundle --json --api-name <Developer_Name>`
+7. **Activate**: `sf agent activate --json --api-name <Developer_Name>`
+
+#### References
+
+- [CLI for Agents](references/salesforce-cli-for-agents.md)
+- [Core Language](references/agent-script-core-language.md) — execution model, syntax, anti-patterns
+- [Design & Agent Spec](references/agent-design-and-spec-creation.md) — topic graph, Agent Spec, backing logic
+- [Topic Map Diagrams](references/agent-topic-map-diagrams.md) — Mermaid conventions
+- [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md) — Section 3 (directory structure)
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — validate, preview
+
+---
+
+### Comprehend an Existing Agent
+
+User wants to understand an agent they didn't write or need to revisit.
+
+#### Required Steps
+
+1. **Locate** — Read `sfdx-project.json` for package directories. Find `AiAuthoringBundle` directory. Read `.agent` and `bundle-meta.xml`.
+2. **Read code** — Read [Core Language](references/agent-script-core-language.md). Parse `.agent` file.
+3. **Map backing logic** — Locate implementations (Apex/Flow/Prompt Template). Note input/output contracts.
+4. **Reverse-engineer Agent Spec** — Read [Design & Agent Spec](references/agent-design-and-spec-creation.md). Produce and save Agent Spec file.
+5. **Topic Map** — Read [Topic Map Diagrams](references/agent-topic-map-diagrams.md). Generate Mermaid flowchart.
+6. **Annotate** — Ask if user wants source annotations. If yes, add inline comments.
+7. **Present** — Share Agent Spec, Topic Map, annotated source. Flag anti-patterns from Core Language reference.
+
+#### References
+
+- [Core Language](references/agent-script-core-language.md) — syntax, execution model, anti-patterns
+- [Design & Agent Spec](references/agent-design-and-spec-creation.md) — Agent Spec structure
+- [Topic Map Diagrams](references/agent-topic-map-diagrams.md) — Mermaid conventions
+- [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md) — directory conventions
+
+---
+
+### Modify an Existing Agent
+
+User wants to add/remove/change topics, actions, instructions, or flow control.
+
+#### Required Steps
+
+1. **Comprehend** — If no Agent Spec exists, follow "Comprehend an Existing Agent" steps first.
+2. **Update Agent Spec** — Read [Design & Agent Spec](references/agent-design-and-spec-creation.md). Modify Agent Spec for intended changes. For new actions, apply **Backing Logic Scan** pattern. **Save updated Agent Spec** before requesting user approval. Do not write Agent Script until approved.
+3. **Edit code** — Read [Core Language](references/agent-script-core-language.md). Edit `.agent` file.
+4. **Validate** — Apply **Validation Pattern**
+5. **Stub and Deploy** — If new actions, apply **Stub and Deploy Pattern**
+6. **Publish**: `sf agent publish authoring-bundle --json --api-name <Developer_Name>`
+7. **Activate** (if was active): `sf agent activate --json --api-name <Developer_Name>`
+
+#### References
+
+- [CLI for Agents](references/salesforce-cli-for-agents.md)
+- [Core Language](references/agent-script-core-language.md) — syntax, anti-patterns
+- [Design & Agent Spec](references/agent-design-and-spec-creation.md) — Agent Spec updates, backing logic
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — validate, preview
+
+---
+
+### Diagnose Compilation Errors
+
+User has Agent Script that won't compile.
+
+#### Required Steps
+
+1. **Reproduce**: `sf agent validate authoring-bundle --json --api-name <Developer_Name>`
+2. **Classify** — Read [Validation & Debugging](references/agent-validation-and-debugging.md) for error taxonomy. Map errors to root causes.
+3. **Locate fault** — Read [Core Language](references/agent-script-core-language.md). Find offending lines.
+4. **Fix** — Apply targeted fixes. Check Anti-Patterns section to avoid introducing bad patterns.
+5. **Re-validate** — Repeat steps 2–5 until passes.
+6. **Explain** — Tell user what was wrong, what changed, root cause in terms of execution model.
+
+#### References
+
+- [Core Language](references/agent-script-core-language.md) — syntax, anti-patterns
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — error taxonomy
+
+---
+
+### Diagnose Behavioral Issues
+
+Agent compiles but doesn't behave as expected (e.g., wrong topic routing, actions not called).
+
+#### Required Steps
+
+1. **Baseline** — Read Agent Spec. If none exists, reverse-engineer one (Comprehend steps).
+2. **Hypotheses** — Read [Core Language](references/agent-script-core-language.md) for execution model. List candidate root causes: topic routing, gating, action availability, instructions, variable state, transition timing.
+3. **Reproduce** — Read [Validation & Debugging](references/agent-validation-and-debugging.md). Start preview, send test messages.
+4. **Analyze traces** — Examine trace output: topic selected, actions available, LLM reasoning, divergence from Agent Spec.
+5. **Root cause** — Match trace evidence to hypothesis. Consult Anti-Patterns (Core Language) and Gating Patterns ([Design & Agent Spec](references/agent-design-and-spec-creation.md)).
+6. **Fix** — Apply targeted fix. Update Agent Spec if flow control changed.
+7. **Re-validate** — Apply **Validation Pattern**. Test changed paths and adjacent paths.
+8. **Explain** — Tell user what happened, what changed, root cause in terms of execution model.
+
+#### References
+
+- [Core Language](references/agent-script-core-language.md) — execution model, anti-patterns
+- [Design & Agent Spec](references/agent-design-and-spec-creation.md) — Agent Spec baseline, gating patterns
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — preview, trace analysis
+
+---
+
+### Deploy, Publish, and Activate
+
+User wants to take working agent from local development to running state in org.
+
+#### Required Steps
+
+1. **Validate**: `sf agent validate authoring-bundle --json --api-name <Developer_Name>` — do not proceed if fails.
+2. **Deploy** — Read [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md). Deploy `AiAuthoringBundle` and dependencies (Apex/Flow/Prompt Templates).
+3. **Preview** — Read [Validation & Debugging](references/agent-validation-and-debugging.md). Test key conversation paths. **Do not publish until preview passes.**
+4. **Publish**: `sf agent publish authoring-bundle --json --api-name <Developer_Name>` — **every publish creates permanent version number**
+5. **Activate**: `sf agent activate --json --api-name <Developer_Name>`
+6. **Verify** — Confirm agent is live and reachable (Experience Site, API, etc.)
+
+#### References
+
+- [CLI for Agents](references/salesforce-cli-for-agents.md)
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — validate, preview
+- [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md) — deploy, dependencies
+
+---
+
+### Delete or Rename an Agent
+
+User wants to remove or rename an agent.
+
+#### Required Steps
+
+1. **Understand state** — Read [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md) for versioning, delete/rename mechanics. Identify if published, version count, activation status.
+2. **Deactivate** (if active): `sf agent deactivate --json --api-name <Developer_Name>`
+3. **Execute** — Follow delete or rename mechanics from Metadata & Lifecycle reference.
+4. **Clean up orphans** — Remove orphaned metadata (Bot, BotVersion, GenAiPlannerBundle, GenAiPlugin, GenAiFunction). See Metadata & Lifecycle reference.
+5. **Validate** — Confirm operation completed. For rename, validate new bundle compiles and preview behavior.
+
+#### References
+
+- [CLI for Agents](references/salesforce-cli-for-agents.md)
+- [Validation & Debugging](references/agent-validation-and-debugging.md) — validate, preview
+- [Metadata & Lifecycle](references/agent-metadata-and-lifecycle.md) — delete, rename, orphan cleanup
+
+---
+
+### Test an Agent
+
+User wants automated tests (`AiEvaluationDefinition` test specs in YAML).
+
+#### Required Steps
+
+1. **Coverage baseline** — Read Agent Spec. If none exists, reverse-engineer (Comprehend steps). Map every topic, action, flow control path.
+2. **Design scenarios** — Read [Test Authoring](references/agent-test-authoring.md). For each coverage target, write scenarios: utterance, expected topic routing, expected action invocations, expected response. Include happy paths and edge cases.
+3. **Write YAML** — Start from `assets/template-testSpec.yaml`. Follow Test Authoring reference. Save to `specs/<Agent_API_Name>-testSpec.yaml`.
+4. **Create metadata** — Generate `AiEvaluationDefinition` from spec via CLI.
+5. **Deploy test** — Deploy `AiEvaluationDefinition` to org.
+6. **Run tests** — Execute test run via CLI. Capture results.
+7. **Analyze** — Compare actual vs. expected. Identify issue source: agent code, backing logic, or test spec.
+8. **Iterate** — Fix as needed, redeploy, re-run until coverage met.
+
+#### References
+
+- [CLI for Agents](references/salesforce-cli-for-agents.md) — test create, run, results
+- [Core Language](references/agent-script-core-language.md) — agent structure for test design
+- [Design & Agent Spec](references/agent-design-and-spec-creation.md) — Agent Spec as coverage baseline
+- [Test Authoring](references/agent-test-authoring.md) — YAML format, expectations, metrics
+- [assets/template-testSpec.yaml](assets/template-testSpec.yaml) — template
+
+---
+
+## The Agent Spec
+
+The **Agent Spec** is the central artifact this skill produces and consumes. It's a structured design document representing agent purpose, topic graph, actions with backing logic, variables, gating logic, behavioral intent.
+
+The Agent Spec evolves: sparse at creation (purpose, topics), filled during build (flowchart, backing logic, gating), reverse-engineered during comprehension, reference for diagnosis, coverage map for testing.
+
+Always produce or update Agent Spec as first step of operations that change or analyze agents. It's the ground truth you work from and the artifact the developer reviews.
+
+For structure and methodology, read [Design & Agent Spec](references/agent-design-and-spec-creation.md).
+
+---
+
+## Assets
+
+Templates and examples in `assets/`:
+
+- **`agent-spec-template.md`** — Template with all sections. Copy to `<AgentName>-AgentSpec.md`, fill during design. Save as file for proper rendering (Mermaid diagrams).
+- **`template.agent`** — Universal agent template supporting both single-topic and multi-topic agents. Shows all major constructs with inline comments. For single-topic agents, keep only the 'main' topic and remove others. For multi-topic agents, add, remove, or rename topics as needed.
+- **`template-testSpec.yaml`** — Test spec template with placeholders and field explanations. Copy to `specs/<Agent_API_Name>-testSpec.yaml`, customize.
+
+---
+
+## Important Constraints
+
+- **Use only Salesforce CLI and Salesforce org.** No other skills, MCP servers, external tooling. All commands use `sf` (Salesforce CLI) with `--json` flag.
+- **Only certain backing logic types are valid.** E.g., only invocable Apex (not arbitrary classes) can back actions. Consult Design & Agent Spec reference for valid types and stubbing.
+- **`sf agent generate test-spec` is not for agentic use.** Interactive REPL-style for humans. Use `assets/template-testSpec.yaml` instead.

--- a/skills/agent-development/agent-script-skill/assets/agent-spec-template.md
+++ b/skills/agent-development/agent-script-skill/assets/agent-spec-template.md
@@ -1,0 +1,66 @@
+# Agent Spec: Agent_API_Name
+
+## Purpose & Scope
+
+Describe the agent's purpose in 1-2 sentences. What does it help users do?
+What domain does it operate in?
+
+## Behavioral Intent
+
+Describe the key behavioral rules that govern the agent:
+- What must the agent know before taking action?
+- What backing logic types are used (Apex, Flow, Prompt Template)?
+- What guardrails apply (off-topic handling, escalation)?
+- What information persists across topic switches?
+
+## Topic Map
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+
+    A -->|description of routing condition| B[topic_name<br/>Topic]
+    A -->|unclear intent| C[ambiguous_question<br/>Topic]
+    A -->|out of scope| D[off_topic<br/>Topic]
+    A -->|needs escalation| E[escalation<br/>Topic]
+```
+
+Expand the diagram to show actions, gating logic, and variable state changes
+within each topic. See the Topic Map Diagrams reference for conventions.
+
+## Variables
+
+- `variable_name` (mutable type = default) — What this variable tracks.
+  Set by: which action or utility. Read by: which topics for gating or
+  conditional instructions.
+
+## Actions & Backing Logic
+
+### action_name (topic_name topic)
+
+- **Target:** `apex://ClassName` or `flow://FlowName` or `prompt://PromptTemplateName`
+- **Backing Status:** EXISTS / NEEDS STUB / NEEDS IMPLEMENTATION
+- **Inputs:** List each input with type and description
+- **Outputs:** List each output with type and description
+- **Stubbing requirement:** If NEEDS STUB, describe the stub class/flow needed
+
+Repeat for each action.
+
+## Gating Logic
+
+- `action_name` visibility: `available when @variables.variable_name != ""`
+  — Rationale for why this gate exists.
+
+List all gating conditions with their rationale.
+
+## Architecture Pattern
+
+State the architecture pattern: hub-and-spoke, chain, hybrid, etc.
+Describe the routing strategy and how topics relate to each other.
+
+## Agent Configuration
+
+- **developer_name:** `Agent_API_Name`
+- **agent_label:** `Agent Display Name`
+- **default_agent_user:** Verify this user exists in the target org

--- a/skills/agent-development/agent-script-skill/assets/template-testSpec.yaml
+++ b/skills/agent-development/agent-script-skill/assets/template-testSpec.yaml
@@ -1,0 +1,78 @@
+# Agent Test Specification Template
+# Creates an AiEvaluationDefinition in your org for agent testing.
+# Copy this template and customize for your agent.
+# Usage: sf agent test create --spec specs/<Agent_API_Name>-testSpec.yaml --api-name <Test_Name> --force-overwrite
+
+name: Agent Tests
+description: Functional tests for the agent
+subjectType: AGENT
+subjectName: Agent_API_Name
+
+testCases:
+  # Basic topic routing test
+  - utterance: Example user request for main topic
+    expectedTopic: main
+    expectedActions:
+      - do_action
+    expectedOutcome: Describe what the agent should do. Be specific about what data should be included and how it should be formatted.
+    metrics:
+      - coherence
+      - conciseness
+      - output_latency_milliseconds
+
+  # Gating pattern test - action should NOT fire without required data
+  - utterance: Example request without providing required information
+    expectedTopic: topic_b
+    expectedActions: []
+    expectedOutcome: The agent should ask for the required information before calling the gated action.
+    metrics:
+      - coherence
+      - instruction_following
+      - output_latency_milliseconds
+
+  # Gating pattern test - action SHOULD fire with required data
+  - utterance: Example request with required information
+    expectedTopic: topic_b
+    expectedActions:
+      - action_b
+    expectedOutcome: The agent should call the gated action and provide results.
+    metrics:
+      - coherence
+      - conciseness
+      - output_latency_milliseconds
+
+  # Escalation test
+  - utterance: I need to speak with a human
+    expectedTopic: escalation
+    expectedActions: []
+    expectedOutcome: The agent should escalate the conversation to a human agent.
+    metrics:
+      - coherence
+      - output_latency_milliseconds
+
+  # Off-topic test
+  - utterance: What is the capital of France?
+    expectedTopic: off_topic
+    expectedActions: []
+    expectedOutcome: The agent should NOT answer the off-topic question. The agent should redirect the user to topics it can help with.
+    metrics:
+      - coherence
+      - instruction_following
+      - output_latency_milliseconds
+
+  # Conversation history test
+  - utterance: Follow-up question referencing previous context
+    expectedTopic: main
+    expectedActions:
+      - do_action
+    expectedOutcome: The agent should handle the follow-up question in context of the conversation history.
+    conversationHistory:
+      - role: user
+        message: Initial user message
+      - role: agent
+        message: Agent response to initial message
+        topic: main
+    metrics:
+      - coherence
+      - conciseness
+      - output_latency_milliseconds

--- a/skills/agent-development/agent-script-skill/assets/template.agent
+++ b/skills/agent-development/agent-script-skill/assets/template.agent
@@ -1,0 +1,155 @@
+# Agent Script Template
+# Copy this file to your AiAuthoringBundle directory and rename it to match
+# your agent's developer_name. Replace all placeholder values with real ones.
+#
+# This template supports both single-topic and multi-topic agents:
+# - For single-topic agents: Keep only the 'main' topic and remove others
+# - For multi-topic agents: Add, remove, or rename topics as needed
+
+system:
+    instructions: "You are a helpful assistant. Describe the agent's persona and purpose here."
+    messages:
+        welcome: "Hello! How can I help you today?"
+        error: "Sorry, it looks like something has gone wrong."
+
+config:
+    developer_name: "Agent_API_Name"
+    agent_label: "Agent Display Name"
+    description: "Description of the agent's purpose"
+    default_agent_user: "username@identifier.org"
+
+variables:
+    collected_input: mutable string = ""
+        description: "Replace with a description of what this variable tracks"
+
+language:
+    default_locale: "en_US"
+    additional_locales: ""
+    all_additional_locales: False
+
+start_agent topic_selector:
+    description: "Welcome the user and determine the appropriate topic based on user input"
+    reasoning:
+        actions:
+            # For single-topic agents, keep only go_to_main
+            go_to_main: @utils.transition to @topic.main
+            # For multi-topic agents, add more transitions as needed
+            go_to_topic_a: @utils.transition to @topic.topic_a
+            go_to_topic_b: @utils.transition to @topic.topic_b
+            go_to_escalation: @utils.transition to @topic.escalation
+            go_to_off_topic: @utils.transition to @topic.off_topic
+
+topic main:
+    label: "Main Topic"
+    description: "Describe what this topic handles. The Atlas Reasoning Engine matches user utterances against this description."
+
+    reasoning:
+        instructions: ->
+            | Replace this with instructions for how the agent should handle requests in this topic.
+              Reference actions with the syntax shown below.
+
+        actions:
+            do_action: @actions.do_action
+                with input_param = ...
+
+    actions:
+        do_action:
+            description: "Describe what this action does"
+            label: "Action Display Name"
+            target: "apex://ClassName"
+            inputs:
+                input_param: string
+                    description: "Describe this parameter"
+                    label: "Parameter Display Name"
+                    is_required: True
+            outputs:
+                output_field: string
+                    label: "Output Display Name"
+                    description: "Describe this output"
+                    is_displayable: True
+                    filter_from_agent: False
+
+topic topic_a:
+    label: "Topic A"
+    description: "Describe what this topic handles"
+
+    reasoning:
+        instructions: ->
+            | Replace this with instructions for topic A.
+
+        actions:
+            action_a: @actions.action_a
+                with input_param = ...
+
+    actions:
+        action_a:
+            description: "Describe what this action does"
+            label: "Action A"
+            target: "apex://ClassName"
+            inputs:
+                input_param: string
+                    description: "Describe this parameter"
+                    label: "Parameter Name"
+                    is_required: True
+            outputs:
+                output_field: string
+                    label: "Output Name"
+                    description: "Describe this output"
+                    is_displayable: True
+                    filter_from_agent: False
+
+topic topic_b:
+    label: "Topic B"
+    description: "Describe what this topic handles"
+
+    reasoning:
+        instructions: ->
+            | Replace this with instructions for topic B. This topic demonstrates the gating pattern.
+
+        actions:
+            # Collect data into a variable first
+            collect_data: @utils.setVariables
+                description: "Collect user input into a variable"
+                with collected_input = ...
+
+            # Gate the main action behind the variable
+            main_action: @actions.action_b
+                description: "Describe what this gated action does"
+                available when @variables.collected_input != ""
+                with query_param = @variables.collected_input
+
+    actions:
+        action_b:
+            description: "Describe what this action does"
+            label: "Action B"
+            target: "prompt://PromptTemplateName"
+            inputs:
+                query_param: string
+                    description: "Describe this parameter"
+                    label: "Parameter Name"
+                    is_required: True
+            outputs:
+                result_text: string
+                    description: "Describe this output"
+                    label: "Result"
+                    is_displayable: False
+
+topic escalation:
+    label: "Escalation"
+    description: "Handles requests from users who want to transfer or escalate their conversation to a live human agent."
+
+    reasoning:
+        instructions: ->
+            | If a user explicitly asks to transfer to a live agent, escalate the conversation.
+        actions:
+            escalate_to_human: @utils.escalate
+                description: "Escalate to a human agent."
+
+topic off_topic:
+    label: "Off Topic"
+    description: "Redirect conversation to relevant topics when user request goes off-topic"
+
+    reasoning:
+        instructions: ->
+            | The user request is off-topic. Do not answer general knowledge questions.
+              Redirect the conversation by asking how you can help with topics this agent supports.

--- a/skills/agent-development/agent-script-skill/references/agent-design-and-spec-creation.md
+++ b/skills/agent-development/agent-script-skill/references/agent-design-and-spec-creation.md
@@ -1,0 +1,393 @@
+# Agent Design and Spec Creation
+
+## Table of Contents
+
+1. Agent Spec Overview
+2. Topic Architecture
+3. Backing Logic and Type Mapping
+4. Flow Control and Gating
+5. Action Loop Prevention
+
+---
+
+## 1. Agent Spec Overview
+
+An **Agent Spec** is a structured design document describing agent purpose, topics, actions, state, control flow, and behavioral intent. Produce before writing Agent Script (creation) or reverse-engineer from `.agent` file (comprehension/diagnosis).
+
+### Contents
+
+- **Purpose & Scope** — what agent does, plain language
+- **Behavioral Intent** — what agent should achieve (requirements/constraints), not just what code does
+- **Topic Map** — Mermaid flowchart: topics, transitions (labeled: handoff or delegation), when transitions occur
+- **Actions & Backing Logic** — name, backing implementation (Apex/Flow/Prompt Template), inputs/outputs, EXISTS or NEEDS STUB
+- **Variables** — declarations, types, defaults, which topics set/read, what gates they control
+- **Gating Logic** — conditions governing action visibility or instruction evaluation, with rationale. If no gating, state "No gating required"
+
+### Lifecycle
+
+- **Creation (sparse)**: Purpose, topic names, rough descriptions, directional notes ("needs Apex class accepting X, returning Y"). No flowchart.
+- **Build (filled)**: Flowchart with transition types. Backing logic mapped (existing = filenames, missing = protocols/I/O specs). Variables documented. Gating explained.
+- **Comprehension (reverse-engineered)**: Parse `.agent` file → complete Agent Spec
+- **Diagnosis (reference)**: Compare runtime behavior against Agent Spec to find divergence
+
+**Template**: `assets/agent-spec-template.md`
+
+---
+
+## 2. Topic Architecture
+
+Topics are FSM states. Plan structure before coding.
+
+### Topic Roles
+
+- **Domain** — core work areas (orders, billing, weather, events). Most agents have 1-5 domain topics.
+- **Guardrail** — enforce boundaries. Standard template includes `off_topic` (redirect to scope) and `ambiguous_question` (ask for clarification). Preserve these.
+- **Escalation** — hand off to human via `@utils.escalate`. Permanent exit, agent session ends.
+
+### Patterns
+
+**Hub-and-Spoke**: Central router (`start_agent`) transitions to specialized domain topics. Use when agent handles multiple distinct domains.
+
+```agentscript
+start_agent topic_selector:
+    reasoning:
+        actions:
+            go_weather: @utils.transition to @topic.local_weather
+            go_events: @utils.transition to @topic.local_events
+```
+
+**Linear Flow**: Topics form pipeline (start → step1 → step2 → end). Use for multi-step workflows with mandatory ordering.
+
+**Escalation Chain**: Tiered support (level1 → level2 → human). First level uses basic actions, higher levels have more power.
+
+**Verification Gate**: Security/permission check before protected topics. Gate validates, then transitions to protected topic or denies.
+
+```agentscript
+start_agent security_gate:
+    reasoning:
+        actions:
+            go_admin: @utils.transition to @topic.admin_panel
+                available when @variables.user_role == "admin"
+            go_denied: @utils.transition to @topic.access_denied
+                available when @variables.user_role != "admin"
+```
+
+**Single-Topic**: No transitions. Use for focused QA agents where all interactions stay in same domain.
+
+Real agents often combine patterns. Each topic serves exactly one role (domain, guardrail, escalation) — architecture determines how they connect.
+
+---
+
+## 3. Backing Logic and Type Mapping
+
+Every action needs backing logic. Identify existing implementations or stub missing ones.
+
+### Valid Types
+
+**Apex**: Only **invocable** classes. Regular classes don't work.
+
+```apex
+// RIGHT — invocable with annotations
+public class WeatherFetcher {
+    public class Request {
+        @InvocableVariable(label='Date' description='Date to check' required=true)
+        public Date dateToCheck;
+    }
+    public class Result {
+        @InvocableVariable(label='Max Temp')
+        public Decimal maxTemp;
+    }
+    @InvocableMethod(label='Fetch Weather')
+    public static List<Result> getWeather(List<Request> requests) { ... }
+}
+```
+
+Wire: `target: "apex://ClassName"`
+
+**Flows**: Only **autolaunched** Flows. Screen/trigger/schedule Flows don't work.
+
+Wire: `target: "flow://FlowApiName"`
+
+**Prompt Templates**: Salesforce Prompt Templates.
+
+Wire: `target: "prompt://TemplateName"`
+
+### Finding Existing Logic
+
+Read `sfdx-project.json` → `packageDirectories` → `path` (typically `force-app/main/default/`).
+
+- **Invocable Apex**: Search `classes/` for `@InvocableMethod`. Read `@InvocableVariable` annotations for I/O contract.
+- **Autolaunched Flows**: Search `flows/` for `.flow-meta.xml` with `<processType>AutoLaunchedFlow</processType>`. Check variables for inputs (`isInput=true`) and outputs (`isOutput=true`).
+- **Prompt Templates**: Search `promptTemplates/` for template metadata.
+
+### Critical Naming Constraint
+
+**Input/output names MUST exactly match Apex `@InvocableVariable` field names, character-for-character.** Mismatches cause publish failures.
+
+```agentscript
+# WRONG — snake_case doesn't match Apex field names
+actions:
+    check_order:
+        inputs:
+            order_id: string     # Apex field is orderId
+
+# CORRECT — matches Apex exactly
+actions:
+    check_order:
+        inputs:
+            orderId: string      # matches Request.orderId
+```
+
+### Type Mapping (Apex → Agent Script)
+
+Some Apex types require `object` + `complex_data_type_name` to pass publish validation. Local compilation doesn't check these — mismatches surface at publish.
+
+| Apex Type  | Agent Script type | complex_data_type_name        |
+|------------|-------------------|-------------------------------|
+| String     | string            | (omit)                        |
+| Boolean    | boolean           | (omit)                        |
+| Decimal    | number            | (omit)                        |
+| Integer    | object            | lightning__integerType         |
+| Long       | object            | lightning__longType            |
+| Date       | object            | lightning__dateType            |
+| Datetime   | object            | lightning__dateTimeType        |
+
+Example:
+```agentscript
+inputs:
+    attendeeCount: object
+        complex_data_type_name: "lightning__integerType"
+    eventDate: object
+        complex_data_type_name: "lightning__dateType"
+```
+
+### Stubbing Missing Logic
+
+Always stub as invocable Apex:
+
+1. Record in Agent Spec:
+```
+fetch_invoice action:
+  Backing: (needs creation)
+  Target: apex://InvoiceFetcher
+  Inputs: invoiceId (string, required)
+  Outputs: invoiceAmount (number), dueDate (object, lightning__dateType)
+```
+
+2. Find default package directory from `sfdx-project.json` (`"default": true` entry's `path`)
+
+3. Generate: `sf generate apex class --name InvoiceFetcher --output-dir <PACKAGE_DIR>/main/default/classes`
+
+4. Replace body with invocable structure (see Apex example above)
+
+5. Deploy: `sf project deploy start --json --metadata ApexClass:InvoiceFetcher`
+
+---
+
+## 4. Flow Control and Gating
+
+### Transition Types
+
+**Handoff (one-way)**: Use `@utils.transition to` in `reasoning.actions`. Control never returns. Use for mode switches, entry routing, linear workflows.
+
+```agentscript
+reasoning:
+    actions:
+        go_checkout: @utils.transition to @topic.checkout
+```
+
+**Delegation (with return intent)**: Use `@topic.X` in `reasoning.actions`. **Critical: Return does NOT happen automatically.** Delegated topic must explicitly transition back to caller.
+
+```agentscript
+# Caller
+topic main:
+    reasoning:
+        actions:
+            consult: @topic.specialist
+
+# Delegated topic MUST transition back
+topic specialist:
+    reasoning:
+        actions:
+            return_to_main: @utils.transition to @topic.main
+```
+
+### Deterministic vs. Subjective
+
+**Deterministic** (runtime-enforced) — use when requirement is non-negotiable:
+- Security: "only admin users"
+- Financial: "never approve >$10K without human"
+- State: "don't show payment until address provided"
+
+**Subjective** (LLM decides) — use when flexibility acceptable:
+- Conversational tone
+- Natural language generation
+- User preferences
+
+**Test**: What happens if LLM gets it wrong? Security breach/financial error → deterministic. Awkward response/suboptimal tone → subjective.
+
+### Gating Mechanisms
+
+**`available when`** — Action visibility gate (strongest). Runtime hides action when condition false. LLM cannot call unavailable actions.
+
+```agentscript
+reasoning:
+    actions:
+        confirm: @actions.confirm_booking
+            available when @variables.booking_pending == True
+```
+
+**Conditional Instructions** — Prompt text gate. Changes what LLM is told, doesn't hide actions.
+
+```agentscript
+reasoning:
+    instructions: ->
+        | You're helping a customer.
+        if @variables.is_vip:
+            | This is a VIP. Prioritize their request.
+```
+
+**`before_reasoning` Guards** — Early exit. Runs before LLM invoked. LLM never sees it, cannot override, cannot skip.
+
+```agentscript
+topic admin_panel:
+    before_reasoning:
+        if @variables.user_role != "admin":
+            transition to @topic.access_denied
+
+    reasoning:
+        instructions: | You are in admin panel.
+```
+
+**Multi-Condition Gating** — Combine mechanisms:
+
+```agentscript
+topic checkout:
+    before_reasoning:
+        if @variables.is_demo_mode:
+            transition to @topic.demo_complete
+
+    reasoning:
+        instructions: ->
+            if @variables.items_in_cart == 0:
+                | Your cart is empty.
+
+        actions:
+            pay: @actions.process_payment
+                available when @variables.authenticated == True
+                    and @variables.items_in_cart > 0
+```
+
+**Sequential Gate Pattern** — Track progress through validation stages:
+
+```agentscript
+variables:
+    step1_verified: mutable boolean = False
+    step2_verified: mutable boolean = False
+
+topic verification:
+    reasoning:
+        actions:
+            verify_step1: @actions.run_check_1
+            verify_step2: @actions.run_check_2
+                available when @variables.step1_verified == True
+            proceed: @utils.transition to @topic.confirmed
+                available when @variables.step2_verified == True
+```
+
+### Same-Turn Behavior After Gates
+
+When gate topic transitions via `after_reasoning` to router, both process in **same user turn**. Router receives original message (that satisfied gate), not fresh utterance.
+
+**Mitigation**: Write router instructions defensively. Tell LLM if user just arrived from gate, greet and ask how to help instead of routing the triggering message.
+
+### Writing Effective Instructions
+
+**Instruction Ordering**: Runtime resolves top-to-bottom before LLM sees result. Put post-action checks first, data references next, dynamic conditional text last.
+
+**Grounding**: Platform validates response matches action output data. Use specific values (`"Event is on {!@variables.event_date}"`), don't transform (`"next week"` may fail). Avoid embellishment instructions (`"respond like pirate"`). Test with **live mode** (`--use-live-actions`) — simulated mode has no real data.
+
+**Post-Action Behavior**: When action completes without transition, topic stays active. Runtime re-evaluates entire topic with updated variables, passes new prompt to LLM. LLM may call same action again (see Section 5).
+
+---
+
+## 5. Action Loop Prevention
+
+An action loop occurs when LLM calls same action repeatedly without new user input. Three causes:
+
+- **No `available when` gate**: Action appears every reasoning cycle, nothing automatically hides it
+- **Variable-bound input**: Action "ready to go" (`with param = @variables.x`), no friction
+- **No post-action instructions**: LLM doesn't know to stop
+
+**WRONG: All three present**
+```agentscript
+topic events:
+    reasoning:
+        instructions: ->
+            | Use {!@actions.check_events} to find events.
+
+        actions:
+            check_events: @actions.check_events
+                with interest = @variables.guest_interest  # Variable-bound
+```
+
+### Three Mitigations
+
+**1. Explicit Post-Action Instructions (most common)**
+
+```agentscript
+topic events:
+    reasoning:
+        instructions: ->
+            | Use {!@actions.check_events} to find events.
+              After receiving results, present them to guest.
+              Do NOT call action again — you have the information.
+
+        actions:
+            check_events: @actions.check_events
+                with interest = @variables.guest_interest
+```
+
+**2. Post-Action Transitions (state-based)**
+
+```agentscript
+topic events:
+    reasoning:
+        actions:
+            check_events: @actions.check_events
+                with interest = @variables.guest_interest
+
+    after_reasoning:
+        if @outputs.events_found:
+            transition to @topic.results_displayed
+```
+
+**3. LLM Slot-Filling Over Variable Binding (friction-based)**
+
+```agentscript
+topic search:
+    reasoning:
+        instructions: ->
+            | Ask what they're looking for, then use {!@actions.search}.
+
+        actions:
+            search: @actions.search
+                with query = ...  # LLM must extract each time
+```
+
+**Combine for reinforcement:**
+
+```agentscript
+topic lookup:
+    reasoning:
+        instructions: ->
+            | Once you have result, present it. Do NOT call again.
+
+        actions:
+            lookup: @actions.find_data
+                with key = ...  # Requires extraction
+
+    after_reasoning:
+        if @outputs.data_found:
+            transition to @topic.done  # Exit topic
+```

--- a/skills/agent-development/agent-script-skill/references/agent-metadata-and-lifecycle.md
+++ b/skills/agent-development/agent-script-skill/references/agent-metadata-and-lifecycle.md
@@ -1,0 +1,667 @@
+# Agent Metadata and Lifecycle Reference
+
+## Table of Contents
+
+1. Agent Metadata Structure
+2. Agent Metadata Lifecycle Overview
+3. Creating an Agent
+4. Working With Authoring Bundles
+5. Publishing Authoring Bundles
+6. Activating Published Agents
+7. Lifecycle Operations
+
+---
+
+## 1. Agent Metadata Structure
+
+Agent Script agents are defined across two independent metadata domains. Understanding this distinction is critical for every lifecycle operation.
+
+### Two-Domain Entity Graph
+
+```
+AUTHORING DOMAIN (developer-owned, exists before any publish)
+  AiAuthoringBundle
+    ├── .agent (Agent Script source — editable text file)
+    └── .bundle-meta.xml (metadata; optional <target> links to published version)
+
+RUNTIME DOMAIN (created by publish)
+  Bot (top-level container, one per agent)
+    └── BotVersion (one per published version)
+          └── GenAiPlannerBundle (versioned bundle, contains compiled agent definition)
+                └── local topics and actions (scoped to this version only)
+```
+
+The authoring domain is where you work. The runtime domain is what the org creates when you publish. These two domains are separate until you publish, which is when they connect.
+
+[SOURCE: rf4-context-refined Section B — Metadata Entity Graph]
+
+### The Authoring Domain: AiAuthoringBundle
+
+An `AiAuthoringBundle` is a Salesforce metadata source component represented as a directory in your local project containing two files:
+
+**1. `.agent` file** —  Agent Script source code. This is the editable text file where you define topics, actions, variables, and flow control. It is human-readable and supports multiple versions.
+
+**2. `.bundle-meta.xml` file** — Metadata about the bundle. Contains a `bundleType` element set to `AGENT` and optionally a `<target>` element that controls whether the bundle is DRAFT (editable) or locked to a published version:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<AiAuthoringBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <bundleType>AGENT</bundleType>
+    <target>Agent_Name.v2</target>
+</AiAuthoringBundle>
+```
+
+When `<target>` is present, the bundle is locked to that published version and cannot be modified. Draft-state bundles omit `<target>` entirely.
+
+[SOURCE: rf4-context-refined Fact 14 — Target controls draft/locked state]
+
+Authoring bundles are stored in `<packageDirectory>/main/default/aiAuthoringBundles/` where `<packageDirectory>` comes from `sfdx-project.json`.
+
+[SOURCE: sfdx-project.json, agent-dx-metadata.md]
+
+### Two Forms of AiAuthoringBundle Locally
+
+**Naked AiAuthoringBundle** (e.g., `Agent_Name`) — No version suffix in the directory name. In the org, this always points to the highest DRAFT version. This is the only writable surface for pro-code developers.
+
+[SOURCE: rf4-context-refined Fact 18 — Naked AiAuthoringBundle always points to highest DRAFT]
+
+**Version-suffixed AiAuthoringBundle** (e.g., `Agent_Name_1`, `Agent_Name_2`) — Published snapshots retrieved from the org after publication. Locked by a `<target>` element in their `bundle-meta.xml`. Read-only — modified deploys fail; unmodified deploys succeed as misleading no-ops. Use these for version history inspection, diffing, and auditing. NEVER edit a version-suffixed authoring bundle expecting your changes to persist.
+
+[SOURCE: rf4-context-refined Fact 20 — Version-suffixed AiAuthoringBundles are immutable snapshots]
+
+### The Runtime Domain: Bot → BotVersion → GenAiPlannerBundle
+
+Publishing creates the runtime entities that make an agent usable in the org.
+
+**Bot** — Top-level container (one per agent). Links to all published versions.
+
+**BotVersion** — One per published version (e.g., `v1`, `v2`, `v3`). Only one version can be active at a time.
+
+**GenAiPlannerBundle** — Compiled agent definition for a specific version. Contains topics, actions, and all runtime metadata, scoped to that version only.
+
+Runtime entities are org-generated and never edited directly.
+
+[SOURCE: rf4-context-refined Section B.3 — Runtime Domain Explanation]
+
+### Agent Pseudo Metadata Type
+
+When using the Salesforce CLI, `Agent:X` is a pseudo-metadata type that covers the runtime domain components: `Bot`, `BotVersion`, `GenAiPlannerBundle`, and related GenAiPlugin/GenAiFunction metadata. This saves you from specifying each type individually during retrieve/deploy.
+
+**CRITICAL GOTCHA:** `Agent:X` retrieve does NOT include `AiAuthoringBundle`. If you need the authoring bundle (to see the `<target>` element or to work with the source), use `AiAuthoringBundle:X` explicitly.
+
+[SOURCE: rf4-context-refined Fact 16 — Agent pseudo-type omits AiAuthoringBundle]
+
+---
+
+## 2. Agent Metadata Lifecycle Overview
+
+### Recommended Pipeline
+
+The end-to-end pipeline for creating and activating an agent:
+
+1. `sf agent generate authoring-bundle --json --no-spec --name "<Label>" --api-name <Developer_Name>`
+2. Edit the `.agent` file locally
+3. `sf project deploy start --json --metadata AiAuthoringBundle:<Developer_Name>`
+4. `sf agent validate authoring-bundle --json --api-name <Developer_Name>`
+5. `sf agent publish authoring-bundle --json --api-name <Developer_Name>`
+6. `sf agent activate --json --api-name <Bot_API_Name>`
+
+Each phase is detailed in the sections that follow.
+
+[SOURCE: rf4-context-refined Fact 13 — Publish is self-contained]
+
+### Lifecycle Phases
+
+**Phase 1: Generate** — Create a boilerplate `AiAuthoringBundle` in your local project with `sf agent generate authoring-bundle`. The authoring bundle exists locally only; the org is unaffected. See Section 3.
+
+**Phase 2: Deploy** — Push the `AiAuthoringBundle` to the org using `sf project deploy start`. This populates the authoring domain only — the authoring bundle becomes visible in Agent Builder (part of Agentforce Studio) for low-code authoring and preview. The `Bot` and `GenAiPlannerBundle` metadata entities are NOT created yet. 
+
+**Phase 3: Publish** — Compile the `AiAuthoringBundle` and create the full runtime entity graph with `sf agent publish authoring-bundle`. This populates the runtime domain: `Bot`, `BotVersion`, and `GenAiPlannerBundle` are created. See Section 5.
+
+**Phase 4: Activate** — Make a published version live with `sf agent activate`. Only one version can be active at a time. Published agents must be activated before they can be previewed with `--api-name` or used in production. See Section 6.
+
+[SOURCE: rf4-context-refined Fact 1 — Published agents require activation for preview]
+
+**Phase 5: Test** — Create test specs (`sf agent test create`), run tests against the activated agent (`sf agent test run`), and check results (`sf agent test resume`). Tests run against activated published agents only — DRAFT authoring bundles cannot be tested. The `sf agent test create` command compiles an Agent Test Spec (YAML) into `AiEvaluationDefinition` metadata in the org. See Section 7 (Test Lifecycle).
+
+[SOURCE: agent-testing-rules-no-edit.md, rf4-context-refined Fact 1]
+
+### Deploy vs. Publish: The Critical Distinction
+
+These are two different operations that populate different domains.
+
+**Deploy** (`sf project deploy start`): Metadata operation only. Puts the `AiAuthoringBundle` source file into the org's authoring domain. Does NOT create Bot, BotVersion, or GenAiPlannerBundle. The authoring bundle IS visible in Agentforce Studio for low-code users to edit and preview as a DRAFT. Deploy is a staging step — useful for pro-code/low-code collaboration where pro-code developers author locally and deploy to get the authoring bundle into Builder for low-code refinement.
+
+[SOURCE: rf4-context-refined Fact 15a — Deploy vs. publish distinction]
+
+**Publish** (`sf agent publish authoring-bundle`): Full entity creation. Deploys the `AiAuthoringBundle`, compiles Agent Script to Agent DSL, and creates the entire runtime entity graph (Bot + BotVersion + GenAiPlannerBundle + GenAiPlugins). Publish is self-contained — a brand-new `AiAuthoringBundle` can be published directly with no prior deploy or org state.
+
+Mental model: the `AiAuthoringBundle` is the recipe; the runtime domain entities are the cooked dish; publish is the act of cooking. Deploy stages the recipe in the org's kitchen — publish actually cooks it.
+
+[SOURCE: rf4-context-refined Fact 13 — Publish is self-contained]
+
+---
+
+## 3. Creating an Agent
+
+Use the `sf agent generate authoring-bundle` command to create a new agent. This command requires three flags.
+
+### Command Syntax
+
+```bash
+sf agent generate authoring-bundle --json --no-spec --name "<Label>" --api-name <Developer_Name>
+```
+
+**Required flags:**
+
+- `--json` — Always set first. Produces machine-readable output.
+
+- `--no-spec` — This flag must be present, or the command hangs waiting for input.
+
+- `--name "<Label>"` — The human-readable display name. This becomes `agent_label` in the Agent Script `config` block. Example: `"Agent Display Name"`. Wrap in quotes if the label contains spaces.
+
+- `--api-name <Developer_Name>` — The unique API identifier (no spaces, letters/numbers/underscores only). This becomes `developer_name` in the `config` block. Example: `Agent_Name`.
+
+[SOURCE: rf4-context-refined Fact 5 — Generation command syntax]
+
+### What the Command Creates
+
+The command creates two files in a directory named after your `--api-name`:
+
+```
+aiAuthoringBundles/
+  └── Agent_Name/
+        ├── Agent_Name.agent (editable source)
+        └── Agent_Name.bundle-meta.xml (metadata)
+```
+
+The `.agent` file contains boilerplate with `system`, `config`, `start_agent`, and placeholder topics. You edit this file to define your agent.
+
+The `.bundle-meta.xml` file is initially minimal (bundleType only, no `<target>`), indicating DRAFT state.
+
+[SOURCE: rf4-context-refined Fact 6 — What generation creates]
+
+### Common Failure Modes with WRONG/RIGHT Pairs
+
+**1. Omitting `--no-spec`**
+
+```bash
+# WRONG — CLI waits for spec file (hangs)
+sf agent generate authoring-bundle --json --name "Agent Display Name" --api-name Agent_Name
+
+# CORRECT — explicit --no-spec
+sf agent generate authoring-bundle --json --no-spec --name "Agent Display Name" --api-name Agent_Name
+```
+
+Without `--no-spec`, the CLI expects interactive input. Always include `--no-spec`.
+
+[SOURCE: rf4-context-refined Fact 5 — Generation command syntax]
+
+**2. Confusing `--name` and `--api-name`**
+
+```bash
+# WRONG — swapped; produces invalid developer_name
+sf agent generate authoring-bundle --json --no-spec \
+    --name Agent_Name \
+    --api-name "Agent Display Name"
+
+# CORRECT — name is human-readable (spaces OK), api-name is identifier
+sf agent generate authoring-bundle --json --no-spec \
+    --name "Agent Display Name" \
+    --api-name Agent_Name
+```
+
+`--name` is the label (human-readable, can include spaces, goes in `agent_label`). `--api-name` is the developer name (identifier, no spaces, goes in `developer_name`).
+
+[SOURCE: rf4-context-refined Fact 5]
+
+---
+
+## 4. Working With Authoring Bundles
+
+This section covers the non-obvious behaviors and constraints of authoring bundles.
+
+### First Deploy Creates DRAFT V1
+
+When you deploy an `AiAuthoringBundle` to an org for the first time (if it has never been published), the org creates DRAFT V1. This is your starting state. Subsequent deploys update this DRAFT. When you publish, V1 becomes locked and a new DRAFT is created for future edits.
+
+[SOURCE: rf4-context-refined Fact 11 — First deploy creates DRAFT V1]
+
+### The "Naked" AiAuthoringBundle Always Points to the Highest DRAFT
+
+Your local agent directory (without a version suffix) represents the editable working copy in the org. In the org, this "naked" `AiAuthoringBundle` is always linked to the highest DRAFT version. When you deploy, you update this DRAFT. When you publish, a new DRAFT version is created for the next round of edits.
+
+[SOURCE: rf4-context-refined Fact 18 — Naked AiAuthoringBundle always points to highest DRAFT]
+
+### Version-Suffixed AiAuthoringBundles Are Frozen Snapshots
+
+After you publish, version-suffixed authoring bundles appear in your local project (e.g., `Agent_Name_1`, `Agent_Name_2`). These are org-generated snapshots locked by a `<target>` element in their `bundle-meta.xml`:
+
+```xml
+<AiAuthoringBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <bundleType>AGENT</bundleType>
+    <target>Agent_Name.v1</target>
+</AiAuthoringBundle>
+```
+
+The presence of `<target>` locks this authoring bundle to that specific published version. It is read-only. Modified deploys fail with an error like "content cannot be changed on a locked version." Unmodified deploys succeed as meaningless no-ops.
+
+Use version-suffixed authoring bundles for auditing and diffing version history, NOT for editing. All edits must go through the naked `AiAuthoringBundle`.
+
+[SOURCE: rf4-context-refined Fact 20 — Version-suffixed AiAuthoringBundles are immutable snapshots]
+
+### No Pro-Code Way to Create New DRAFT Versions
+
+Once a DRAFT version exists in the org, there is no CLI command to create additional DRAFT versions. The only way to create multiple DRAFTs is via Agentforce Studio's "create new DRAFT version" button on a published version. These additional DRAFTs can then be retrieved with their version number.
+
+In pro-code workflows, you have one DRAFT per agent at any given time. The DRAFT evolves: you deploy, the DRAFT updates. You publish, the DRAFT becomes locked. You deploy again, a new DRAFT is created.
+
+[SOURCE: rf4-context-refined Fact 12 — No pro-code way to create new DRAFT versions]
+
+### Deploy-Before-Publish Is Legitimate (For Pro-Code/Low-Code Collaboration)
+
+Deploy-before-publish is the foundation for pro-code/low-code collaboration:
+
+1. Pro-code developer authors Agent Script locally
+2. Pro-code developer deploys the authoring bundle (no publish step)
+3. Low-code user opens the authoring bundle in Agentforce Studio and refines it
+4. Low-code user saves changes
+5. Pro-code developer retrieves the updated authoring bundle and continues
+
+Deploy/retrieve are one-way overwrites with no sync warnings. This is by design for cross-tool collaboration.
+
+[SOURCE: rf4-context-refined Fact 8 — Deploy-before-publish is legitimate for pro-code/low-code collaboration]
+
+### NEVER Deploy `AiAuthoringBundle` in Routine Backing-Code Operations
+
+When deploying backing code (Apex, Flows, Prompt Templates), NEVER include agent metadata (`.agent` files or `AiAuthoringBundle` metadata) unless you explicitly intend to update the agent.
+
+Accidental deployment of an outdated authoring bundle will overwrite in-progress work in the org.
+
+[SOURCE: .a4drules/agent-script-rules-no-edit.md line 64]
+
+### `default_agent_user` Configuration: Immutable and Restricted
+
+The `default_agent_user` field in your Agent Script `config` block must reference a Salesforce user with the "Einstein Agent" license type. Standard Salesforce-licensed users, even System Administrators, will fail at publish time with a misleading error message: "Internal Error, try again later."
+
+This error message does NOT indicate a license issue — it masks the true problem.
+
+To find a valid user, query the org for active users with the Einstein Agent license:
+
+```bash
+sf data query --json -q "SELECT Username FROM User WHERE Profile.UserLicense.Name = 'Einstein Agent' AND IsActive = true LIMIT 5"
+```
+
+The second critical fact: `default_agent_user` is immutable after first publish. Once you publish with a specific user assigned, you cannot change it. Both CLI and Agentforce Studio enforce this immutability.
+
+[SOURCE: rf4-context-refined Fact 3, 3a — default_agent_user license and immutability]
+
+### Two Validation Layers: Compile vs. API Validation
+
+The CLI `sf agent validate authoring-bundle` checks syntax and Agent Script compilation only. It does NOT validate `default_agent_user` or backing logic references.
+
+API validation runs during `sf agent publish` and in Agentforce Studio. This is where `default_agent_user` license requirements are checked and backing logic references are fully validated.
+
+The result: A developer can validate successfully and still fail at publish due to invalid `default_agent_user` or missing backing logic.
+
+[SOURCE: rf4-context-refined Fact 3c — Two validation layers]
+
+### Deploy Validates Backing Logic via Invocable Action Registry Lookup
+
+When you deploy an `AiAuthoringBundle`, the deployment process validates that every backing logic reference (Apex class, Flow, Prompt Template) resolves to a registered Invocable Action in the org. The referenced class or flow or prompt must exist.
+
+For Apex classes, the class must have an `@InvocableMethod`-annotated method.
+
+**Critical gap:** Deploy validation does NOT check parameter names, types, return types, or whether the method has the correct number of parameters. Stub classes with `@InvocableMethod` are sufficient to unblock deployment.
+
+This means you can deploy an authoring bundle with completely wrong I/O definitions and not discover the problem until conversation or preview. Parameter mismatches are caught only at runtime.
+
+A minimal stub class with `@InvocableMethod` unblocks pro-code/low-code collaboration, but defers type validation to runtime.
+
+[SOURCE: rf4-context-refined Fact 4 — Deploy validates backing logic via Invocable Action registry lookup]
+
+### Server-Side `AiAuthoringBundle` Filename Versioning
+
+When deploying a local authoring bundle (`Agent_Name.agent`), the server uses a version-suffixed filename (`Agent_Name_4.agent`), triggering a CLI warning:
+
+```
+"AiAuthoringBundle, Agent_Name_4.agent, returned from org, but not found in the local project"
+```
+
+This is not an error — it's normal behavior. It reflects the "naked `AiAuthoringBundle` = highest DRAFT" behavior. The warning is misleading but harmless.
+
+[SOURCE: rf4-context-refined Fact 10 — Server-side AiAuthoringBundle filename versioning]
+
+### Post-Publish Workflow Is Seamless
+
+After publishing, your local source remains unchanged. The `bundle-meta.xml` does NOT get `<target>` set automatically. You can immediately continue editing the `.agent` file and deploy again. The platform auto-creates a new DRAFT version on the server.
+
+The intended workflow is: publish → keep editing → deploy (auto-creates new DRAFT).
+
+[SOURCE: rf4-context-refined Fact 19 — Post-publish workflow is seamless]
+
+### Edge Case: Retrieve After Publish Locks the Authoring Bundle
+
+If you explicitly retrieve the authoring bundle after publishing (e.g., `sf project retrieve start --json --metadata AiAuthoringBundle:Agent_Name`), the retrieved `bundle-meta.xml` WILL have `<target>` set, locking the authoring bundle to that published version. Subsequent deploys with content changes fail.
+
+Recovery: Remove `<target>` from `bundle-meta.xml` and deploy. This unlocks the authoring bundle and allows new edits.
+
+This edge case only happens if you retrieve after publish. Normal post-publish workflows (just keep editing and deploying) never trigger this behavior.
+
+[SOURCE: rf4-context-refined Fact 19-edge — Retrieve after publish locks authoring bundle]
+
+---
+
+## 5. Publishing Authoring Bundles
+
+Publishing converts an agent's design (Agent Script in an `AiAuthoringBundle`) into its runtime existence (Bot, BotVersion, GenAiPlannerBundle). It is self-contained and can be done with no prior deploy.
+
+### Why Publishing Is Needed
+
+Deploy alone puts the authoring bundle source into the org but does NOT create the runtime entity graph. A published agent cannot be previewed with `--api-name` until it is activated.
+
+Publishing compiles the `AiAuthoringBundle` to Agent DSL and creates Bot, BotVersion, and GenAiPlannerBundle. After activation, the agent becomes usable for preview and runtime.
+
+[SOURCE: rf4-context-refined Fact 15a, 15b — Deploy vs. publish distinction]
+
+### Publish Is Self-Contained
+
+You do NOT need to deploy first. A brand-new authoring bundle can be published directly:
+
+```bash
+sf agent generate authoring-bundle --json --no-spec --name "Agent Display Name" --api-name Agent_Name
+# Edit Agent_Name.agent ...
+sf agent publish authoring-bundle --json --api-name Agent_Name
+```
+
+Publish handles the initial deploy, compilation, and entity creation in one step. The simplest pipeline is: generate → edit → validate → publish → activate.
+
+[SOURCE: rf4-context-refined Fact 13 — Publish is self-contained]
+
+### Command Syntax
+
+```bash
+sf agent publish authoring-bundle --json --api-name <Developer_Name>
+```
+
+The `--api-name` is the directory name under `aiAuthoringBundles/` (the `developer_name` from your config block).
+
+[SOURCE: agent-dx-nga-publish.md]
+
+### What Metadata Gets Created
+
+When you publish, the org creates:
+
+- **Bot** — Top-level container (one per agent)
+- **BotVersion** — Versioned instance (e.g., `v1`, `v2`, `v3`)
+- **GenAiPlannerBundle** — Compiled agent definition for this version of the agent, with a `localActions/` directory containing topic-scoped action definitions.
+
+Example directory structure after publishing:
+
+```
+bots/
+  └── Agent_Name/
+      ├── Agent_Name.bot-meta.xml
+      ├── v1.botVersion-meta.xml
+      ├── v2.botVersion-meta.xml
+      └── v3.botVersion-meta.xml
+genAiPlannerBundles/
+  ├── Agent_Name_v1/
+  │   ├── localActions/
+  │   └── Agent_Name_v1.genAiPlannerBundle
+  ├── Agent_Name_v2/
+  │   ├── localActions/
+  │   └── Agent_Name_v2.genAiPlannerBundle
+  └── Agent_Name_v3/
+      ├── localActions/
+      └── Agent_Name_v3.genAiPlannerBundle
+```
+
+These are separate top-level directories. Each publish adds a BotVersion and a version-named GenAiPlannerBundle subdirectory. All are org-generated and read-only.
+
+[SOURCE: real published metadata from afdx-pro-code-testdrive project]
+
+### Multiple Published Versions Accumulate
+
+Each publish creates a new version. Older versions remain in the org but become inactive. You can have v1, v2, v3, etc. coexisting.
+
+After first publish: `v1.botVersion-meta.xml` and `Agent_Name_v1.genAiPlannerBundle` exist.
+After second publish: `v2.botVersion-meta.xml` and `Agent_Name_v2.genAiPlannerBundle` exist. (v1 still exists but is inactive.)
+
+This is version inflation — versions accumulate whether content changed or not (when no existing DRAFT exists on server).
+
+[SOURCE: rf4-context-refined Fact 26 — Publishing creates new version with no DRAFT on server]
+
+### Gotcha: Publish Response Lacks Version Number
+
+The `sf agent publish authoring-bundle` response does NOT tell you which version number was created. You must retrieve with `AiAuthoringBundle:` (NOT `Agent:`) to see what version was published:
+
+```bash
+sf project retrieve start --json --metadata AiAuthoringBundle:Agent_Name
+```
+
+Examine the returned `bundle-meta.xml` to see the `<target>` version (e.g., `Agent_Name.v2`).
+
+[SOURCE: rf4-context-refined Fact 17 — Publish response lacks version number]
+
+### The `Agent` Pseudo-Type Retrieves Runtime Metadata Only
+
+Retrieving with `Agent:Agent_Name` returns the runtime entity graph: `Bot`, `BotVersion`, and `GenAiPlannerBundle` metadata. It does not include `AiAuthoringBundle` metadata.
+
+To retrieve the authoring bundle (e.g., to inspect `<target>` after publish), use the `AiAuthoringBundle` metadata type directly:
+
+```bash
+sf project retrieve start --json --metadata AiAuthoringBundle:Agent_Name
+```
+
+[SOURCE: rf4-context-refined Fact 16 — Agent pseudo-type omits AiAuthoringBundle]
+
+---
+
+## 6. Activating Published Agents
+
+After publishing, the agent exists but is inactive. Activation makes a published version live for preview, runtime access, and testing.
+
+### Activation Commands
+
+```bash
+# Activate a specific published version
+sf agent activate --json --api-name <Bot_API_Name>
+
+# Deactivate (take a version offline without deleting it)
+sf agent deactivate --json --api-name <Bot_API_Name>
+```
+
+The `--api-name` is the Bot's API name (from your Agent Script `config` block's `developer_name`).
+
+[SOURCE: rf4-context-refined Fact 2 — Activate/deactivate commands]
+
+### Activation Requirements
+
+Only one published version can be active at a time. Activating a new version automatically deactivates the previous one. Running `sf agent preview start --api-name <Bot_API_Name>` requires the Bot to have an activated version. If no version is activated, attempting to start a preview with `--api-name` fails.
+
+[SOURCE: rf4-context-refined Fact 1 — Published agents require activation for preview]
+
+### Agent Test Execution Requires an Activated Agent
+
+Tests run against activated published agents only. If you try to run a test against an unpublished or inactive agent, it fails.
+
+[SOURCE: rf4-context-refined Fact 1 — Published agents require activation for preview]
+
+### Post-Publish Preview Workflow
+
+Once your agent is published and activated, prefer using `--api-name` over `--authoring-bundle` for preview commands:
+
+```bash
+sf agent preview start --json --api-name <Bot_API_Name>
+sf agent preview send --json --api-name <Bot_API_Name> --session-id <SESSION_ID> -u "User message"
+sf agent preview end --json --api-name <Bot_API_Name> --session-id <SESSION_ID>
+```
+
+The `--api-name` flag uses the runtime API and provides more accurate results than the compiled authoring bundle. Published agents always execute real actions — do NOT pass `--use-live-actions` with `--api-name`.
+
+---
+
+## 7. Lifecycle Operations
+
+This section consolidates CLI commands for deploy, retrieve, delete, rename, test execution, and opening in Builder.
+
+### Deploy
+
+Deploy puts the `AiAuthoringBundle` into the org as metadata. It does NOT create runtime entities.
+
+**Deploy action-backing code only:**
+
+```bash
+sf project deploy start --json --metadata ApexClass Flow
+```
+
+Use `--metadata` to scope routine deploys to backing code. A bare `sf project deploy start` deploys all changed local metadata, including agent metadata.
+
+**Deploy agent metadata (pro-code/low-code collaboration):**
+
+```bash
+sf project deploy start --json --metadata AiAuthoringBundle:Agent_Name
+```
+
+Explicitly including agent metadata is useful when collaborating with low-code users in Agentforce Studio.
+
+[SOURCE: rf4-context-refined Fact 8b — Never deploy AiAuthoringBundle in routine backing-code operations]
+
+### Retrieve
+
+Retrieve pulls metadata from the org to your local project.
+
+**Retrieve authoring bundle (highest version):**
+
+```bash
+sf project retrieve start --json --metadata AiAuthoringBundle:Agent_Name
+```
+
+This retrieves the authoring bundle source files (`.agent` and `.bundle-meta.xml`). Use this to see the `<target>` element or to get the latest source from the org.
+
+**Retrieve authoring bundles (all versions):**
+
+```bash
+sf project retrieve start --json --metadata "AiAuthoringBundle:Agent_Name_*"
+```
+
+The wildcard `*` retrieves every version of an authoring bundle (e.g., `Agent_Name_1`, `Agent_Name_2`). Without the wildcard, only the naked `AiAuthoringBundle` is returned.
+
+Use this pattern to inspect/compare different versions of an authoring bundle.
+
+[SOURCE: rf4-context-refined Fact 21 — Wildcard retrieve returns all version-suffixed AiAuthoringBundles]
+
+**Retrieve runtime metadata with the `Agent` pseudo-type:**
+
+```bash
+sf project retrieve start --json --metadata Agent:Agent_Name
+```
+
+The `Agent` pseudo-type retrieves Bot, BotVersion, GenAiPlannerBundle, and GenAiPlugin — the full runtime entity graph. It does not include `AiAuthoringBundle`. Use the `AiAuthoringBundle` metadata type directly when you need source files.
+
+[SOURCE: rf4-context-refined Fact 16 — Agent pseudo-type omits AiAuthoringBundle]
+
+### Delete
+
+Deletion behavior differs based on whether the agent has been published.
+
+**Delete unpublished authoring bundle:**
+
+```bash
+sf project delete source --json --metadata AiAuthoringBundle:Agent_Name
+```
+
+This works for DRAFT-only agents that have never been published.
+
+**Published agents cannot be deleted via CLI:**
+
+Published agents cannot be deleted via the Metadata API due to circular dependencies between metadata types. There is no CLI path to delete a published NGA agent. Cleanup requires the Salesforce Setup UI or scratch org expiration.
+
+Use unique names for test agents to avoid collisions.
+
+[SOURCE: rf4-context-refined Fact 24 — Published agents cannot be deleted via Metadata API]
+
+**Backing Code Deletion Enforcement:**
+
+The org tracks dependencies between `AiAuthoringBundle` versions and their backing Apex classes. Attempting to delete a backing class while any version references it fails with a dependency error.
+
+To delete a backing class:
+
+1. Update the authoring bundle to remove the reference
+2. Deploy the updated authoring bundle
+3. Delete the backing class
+
+[SOURCE: rf4-context-refined Fact 9 — Backing code deletion enforcement]
+
+### Rename
+
+Renaming is hazardous due to the metadata hierarchy. The platform creates dependencies between `AiAuthoringBundle` names and published versions.
+
+Do not attempt an in-place rename. Create a new agent with the desired name and migrate content. Document the old agent as deprecated and schedule deletion after a grace period.
+
+### Test Lifecycle
+
+Agent testing requires a test spec (YAML), which gets compiled into `AiEvaluationDefinition` metadata in the org. Test specs are NOT Salesforce metadata — they are local YAML files that the CLI uses as input.
+
+**Test spec location:** `specs/` directory at the SFDX project root (not inside a package directory).
+
+**Create a test spec from the skill template:**
+
+Copy the skill's `assets/template-testSpec.yaml` (relative to this skill's root directory) to `specs/<Agent_API_Name>-testSpec.yaml` in the user's SFDX project. Update `name`, `description`, `subjectName`, and `testCases` to match the agent being tested.
+
+Do NOT use `sf agent generate test-spec` to create a new test spec. This command requires interactive input and cannot be used programmatically. It can reverse-engineer a test spec from an existing `AiEvaluationDefinition` when supplied with the `--from-definition` flag:
+
+```bash
+sf agent generate test-spec --from-definition force-app/main/default/aiEvaluationDefinitions/Agent_Name_Test.aiEvaluationDefinition-meta.xml --output-file specs/Agent_Name-testSpec.yaml
+```
+
+**Create the test in the org:**
+
+```bash
+sf agent test create --json --spec specs/Agent_Name-testSpec.yaml --api-name Agent_Name_Test --force-overwrite
+```
+
+This compiles the test spec YAML into `AiEvaluationDefinition` metadata and automatically deploys it to the target org. The `--force-overwrite` flag ensures the CLI does not enter interactive mode if an `AiEvaluationDefinition` with the same `--api-name` already exists. Use `--preview` to generate the `AiEvaluationDefinition` locally without deploying to the org.
+
+Iterating on a test spec is a common workflow: edit the YAML, re-run `sf agent test create` with the same `--api-name` and `--force-overwrite`, then run the test again.
+
+A local test spec YAML does NOT mean the test exists in the org. You must run `sf agent test create` before you can run the test.
+
+**Run tests:**
+
+```bash
+sf agent test run --json --api-name Agent_Name_Test --wait 5
+```
+
+The `--api-name` is the `AiEvaluationDefinition` name (set by `--api-name` during `sf agent test create`). The `--wait 5` flag forces synchronous execution with a 5-minute timeout — the command blocks until the test completes or times out. Without `--wait`, the command returns a job ID immediately and the agent must poll `sf agent test results` for completion. Tests run against activated published agents only.
+
+**Check test results (async fallback):**
+
+```bash
+sf agent test results --json --job-id <JOB_ID>
+```
+
+Only needed if `--wait` was not used or the wait timed out. Use the job ID from the `sf agent test run` response.
+
+[SOURCE: rf4-context-refined Fact 1, .a4drules/agent-testing-rules-no-edit.md]
+
+### Open in Builder
+
+These commands launch the user's local browser to Agentforce Studio. Do NOT use `--json` with these commands — JSON mode outputs the target URL but does not open the browser.
+
+**View all authoring bundles:**
+
+```bash
+sf org open authoring-bundle
+```
+
+Opens Agentforce Studio showing all authoring bundles in the org.
+
+**View a specific published agent:**
+
+```bash
+sf org open agent --api-name <Bot_API_Name>
+```
+
+Opens the published agent in Agentforce Studio. Only works for published agents. Unpublished (DRAFT-only) authoring bundles must be opened via `sf org open authoring-bundle`.

--- a/skills/agent-development/agent-script-skill/references/agent-script-core-language.md
+++ b/skills/agent-development/agent-script-skill/references/agent-script-core-language.md
@@ -1,0 +1,613 @@
+# Agent Script: Core Language Reference
+
+## Table of Contents
+
+1. Execution Model
+2. Syntax Basics
+3. Configuration and Variables
+4. Topics and Flow Control
+5. Actions and Utilities
+6. Anti-Patterns
+
+---
+
+## 1. Execution Model
+
+Agent Script operates in two phases:
+
+**Phase 1: Deterministic Resolution** — Runtime executes reasoning instructions top-down: evaluates `if`/`else`, runs actions via `run`, sets variables via `set`. Builds prompt string by accumulating `|` pipe text and resolving conditionals. If `transition` occurs, discards current prompt and starts with target topic. **LLM not involved yet.**
+
+**Phase 2: LLM Reasoning** — Runtime passes resolved prompt + reasoning actions (tools) to LLM. LLM decides what to do — can call available actions but cannot modify prompt text.
+
+**Example:**
+
+```agentscript
+topic check_order:
+    reasoning:
+        instructions: ->
+            if @variables.order_id != "":
+                run @actions.fetch_order
+                    with id = @variables.order_id
+                    set @variables.status = @outputs.status
+
+            | Your order status is {!@variables.status}.
+              You can modify it using {!@actions.update_order}.
+
+        actions:
+            update: @actions.update_order
+                with order_id = @variables.order_id
+```
+
+If `order_id = "1001"` and `fetch_order` returns `status = "shipped"`, runtime resolves to:
+
+```
+Your order status is shipped.
+You can modify it using update_order.
+```
+
+LLM receives this prompt + `update` tool and decides whether to call based on user's next message.
+
+**Key insight**: Deterministic logic controls WHAT the agent knows (resolved prompt). LLM controls WHETHER/HOW to act.
+
+---
+
+## 2. Syntax Basics
+
+### File Structure
+
+Mandatory order (system, config, start_agent, topic required; others optional):
+
+```agentscript
+system:
+    instructions: "Global LLM directives"
+    messages:
+        welcome: "..."
+        error: "..."
+
+config:
+    developer_name: "Name"
+    agent_type: "AgentforceServiceAgent"  # or AgentforceEmployeeAgent
+    default_agent_user: "user@example.com"  # For ServiceAgent only
+
+variables:
+    my_var: mutable string = ""
+    session_id: linked string
+        source: @session.sessionID
+
+start_agent topic_selector:
+    description: "..."
+    reasoning:
+        instructions: -> ...
+        actions: ...
+
+topic my_topic:
+    description: "..."
+    actions: ...              # Optional: action definitions
+    before_reasoning: ...     # Optional: pre-reasoning logic
+    reasoning:
+        instructions: -> ...  # Required
+        actions: ...          # Optional: tools for LLM
+    after_reasoning: ...      # Optional: post-reasoning logic
+```
+
+### Naming Rules
+
+All names (developer_name, topics, variables, actions): letters, numbers, underscores. Start with letter. No consecutive underscores. No trailing underscore. Max 80 chars. `snake_case` recommended.
+
+**Indentation**: 4 spaces per level. Never tabs. **Comments**: `#`
+
+### Operators
+
+- **Comparison**: `==`, `!=`, `<`, `<=`, `>`, `>=`, `is`, `is not`
+- **Logical**: `and`, `or`, `not`
+- **Arithmetic**: `+`, `-` (no `*`, `/`, `%`)
+- **Access**: `.` (property), `[]` (index)
+- **Conditional**: `x if condition else y`
+- **Template injection**: `{!expression}` in `|` pipe text
+
+**Resource references**: `@actions.X`, `@topic.X`, `@variables.X`, `@outputs.X`, `@utils.X`
+
+**Do NOT use `<>` for inequality** — use `!=`:
+
+```agentscript
+# WRONG
+if @variables.status <> "pending":
+
+# CORRECT
+if @variables.status != "pending":
+```
+
+---
+
+## 3. Configuration and Variables
+
+### System Block
+
+Required. Global instructions + messages:
+
+```agentscript
+system:
+    instructions: "You are a helpful assistant. Be professional."
+    messages:
+        welcome: "Hello! How can I help?"
+        error: "Sorry, something went wrong."
+```
+
+### Config Block
+
+Required fields:
+- `developer_name` — MUST match `AiAuthoringBundle` directory name exactly (e.g., directory `Travel_Advisor/` requires `developer_name: "Travel_Advisor"`)
+- `default_agent_user` (for `AgentforceServiceAgent` only) — Salesforce username with Einstein Agent license. Invalid user causes misleading "Internal Error, try again later" at publish. Query valid users: `sf data query --json -q "SELECT Username FROM User WHERE Profile.UserLicense.Name = 'Einstein Agent' AND IsActive = true LIMIT 5"`. **Immutable after first publish.**
+
+Optional fields:
+- `agent_label` — display name
+- `description` — what agent does
+- `agent_type` — `"AgentforceServiceAgent"` (customer-facing, requires `default_agent_user`) or `"AgentforceEmployeeAgent"` (internal, no `default_agent_user`)
+
+Generated boilerplate defaults to Service Agent (includes MessagingSession linked variables, escalation topic). For Employee Agent, remove `default_agent_user`, MessagingSession variables, and escalation topics.
+
+### Variables
+
+**Mutable** (read/write, MUST have default):
+
+```agentscript
+variables:
+    name: mutable string = ""
+        description: "Customer name"  # Optional, for LLM slot-filling context
+    count: mutable number = 0
+    active: mutable boolean = True    # MUST be capitalized!
+    data: mutable object = {}
+    items: mutable list[string] = []
+```
+
+**Linked** (read-only from external context, MUST have source, NO default):
+
+```agentscript
+variables:
+    session_id: linked string
+        source: @session.sessionID
+    user_id: linked string
+        source: @MessagingSession.MessagingEndUserId
+```
+
+**Types**:
+- **Mutable**: `string`, `number`, `boolean`, `object`, `date`, `timestamp`, `currency`, `id`, `list[T]`
+- **Linked**: same except NO `list`
+- **Action params**: mutable types plus `datetime`, `time`, `integer`, `long`
+
+**Boolean capitalization**: Always `True`/`False`, never `true`/`false`
+
+**Publish-time Apex type restriction**: For Apex `Integer`, `Date`, `Datetime` fields, use `object` + `complex_data_type_name`. See type mapping table in `agent-design-and-spec-creation.md` Section 4.
+
+**Template injection**: Use `{!@variables.X}` in prompt text (inside `|` sections):
+
+```agentscript
+instructions: |
+    Hello, {!@variables.name}! Balance: {!@variables.balance}
+```
+
+Bare `@variables.X` (without braces) is valid in logic contexts (`if @variables.X == True:`) but won't interpolate in prompts.
+
+---
+
+## 4. Topics and Flow Control
+
+### Topic Structure
+
+```agentscript
+topic order_lookup:
+    description: "Handle order inquiries"  # Required - LLM uses for relevance
+
+    system:  # Optional - override global system instructions for this topic
+        instructions: "Be detailed about order status."
+
+    actions:  # Optional - define callable actions
+        find_order:
+            target: "flow://SearchOrder"
+            description: "Search by order ID"
+            inputs:
+                order_id: string
+            outputs:
+                status: string
+
+    before_reasoning:  # Optional - runs before LLM reasoning
+        if @variables.session_expired:
+            transition to @topic.login
+
+    reasoning:  # Required
+        instructions: ->
+            | Help customer find order.
+        actions:
+            search: @actions.find_order
+                with order_id = ...
+
+    after_reasoning:  # Optional - runs after LLM reasoning
+        if @variables.order_complete:
+            transition to @topic.confirmation
+```
+
+### Reasoning Instructions
+
+**Arrow syntax (`->`)** for logic + prompt:
+
+```agentscript
+reasoning:
+    instructions: ->
+        if @variables.verified:
+            run @actions.get_account
+                with user_id = @variables.user_id
+                set @variables.account_info = @outputs.account
+
+        | Tell the user their account balance.
+```
+
+**Static `|` pipe** for prompt-only (no logic):
+
+```agentscript
+reasoning:
+    instructions: |
+        Help customer find venue.
+        After receiving results from {!@actions.search_venues}, present them.
+        Do NOT call action again unless customer asks.
+
+    actions:
+        find_venue: @actions.search_venues
+            with location = ...
+```
+
+**The `|` pipe operator works alongside `reasoning.actions`** — both are valid in same reasoning block. Pipe builds prompt text, actions define LLM tools.
+
+**If/Else** (no `else if`):
+
+```agentscript
+if @variables.status == "pending":
+    run @actions.notify_pending
+else:
+    run @actions.notify_complete
+```
+
+Nest conditions with separate `if` blocks:
+
+```agentscript
+if @variables.status == "pending":
+    if @variables.priority == "high":
+        run @actions.escalate
+```
+
+### Flow Control
+
+**Start agent** (mandatory entry point):
+
+```agentscript
+start_agent topic_selector:
+    description: "Route to appropriate topic"
+    reasoning:
+        actions:
+            go_orders: @utils.transition to @topic.order_info
+                description: "For order inquiries"
+```
+
+**LLM-chosen transitions** (in `reasoning.actions` with `@utils.transition to`):
+
+```agentscript
+reasoning:
+    actions:
+        go_next: @utils.transition to @topic.next_topic
+            description: "Move to next topic"
+            available when @variables.ready == True
+```
+
+**Deterministic transitions** (in directive blocks, bare `transition to`):
+
+```agentscript
+before_reasoning:
+    if @variables.not_authenticated:
+        transition to @topic.login
+
+after_reasoning:
+    if @variables.complete:
+        transition to @topic.summary
+```
+
+Do NOT use `@utils.transition to` in directive blocks — causes compilation errors.
+
+**Delegation with return** (use `@topic.X`):
+
+```agentscript
+reasoning:
+    actions:
+        ask_expert: @topic.expert_consultation
+            description: "Consult expert"
+```
+
+Target topic runs reasoning, then returns control. Different from `@utils.transition to` (one-way, no return).
+
+---
+
+## 5. Actions and Utilities
+
+### Action Definition
+
+```agentscript
+actions:
+    get_customer:
+        target: "flow://GetCustomerInfo"  # Required
+        description: "Fetches customer info"
+        label: "Get Customer"  # Optional display name
+        require_user_confirmation: False
+        include_in_progress_indicator: True
+        progress_indicator_message: "Looking up..."
+        inputs:
+            customer_id: string
+                description: "Customer's ID"
+                is_required: True
+        outputs:
+            name: string
+                is_displayable: True
+```
+
+**Target formats** — `"type://Name"`:
+- Common: `flow`, `apex`, `prompt`, `standardInvocableAction`, `externalService`, `api`
+- Others: `quickAction`, `apexRest`, `serviceCatalog`, `integrationProcedureAction`, `expressionSet`, `cdpMlPrediction`, `externalConnector`, `slack`, `namedQuery`, `auraEnabled`, `mcpTool`, `retriever`
+
+**Deterministic invocation** (always runs):
+
+```agentscript
+reasoning:
+    instructions: ->
+        run @actions.get_customer
+            with customer_id = @variables.customer_id
+            set @variables.name = @outputs.name
+```
+
+**LLM exposure** (LLM decides):
+
+```agentscript
+reasoning:
+    actions:
+        lookup: @actions.get_customer
+            description: "Look up customer"
+            with customer_id = @variables.selected_customer
+            set @variables.name = @outputs.name
+```
+
+**Input binding patterns**:
+
+```agentscript
+reasoning:
+    actions:
+        search: @actions.search_products
+            with query = ...             # LLM slot-fills
+            with category = ...          # LLM slot-fills
+            with customer_id = @variables.user_id  # Variable binding
+            with limit = 10              # Literal value
+```
+
+**Gating** — control action visibility:
+
+```agentscript
+reasoning:
+    actions:
+        check_status: @actions.order_status
+            description: "Check order status"
+            available when @variables.order_id != ""
+```
+
+**Post-action directives** (only for `@actions`, NOT `@utils`):
+
+```agentscript
+run @actions.process_order
+    with order_id = @variables.order_id
+    set @variables.result = @outputs.status
+    if @outputs.success == True:
+        transition to @topic.confirmation
+```
+
+### Utility Functions
+
+**`@utils.transition to`** — one-way handoff:
+
+```agentscript
+reasoning:
+    actions:
+        go_checkout: @utils.transition to @topic.checkout
+            description: "Proceed to checkout"
+```
+
+**`@utils.escalate`** — route to human:
+
+```agentscript
+reasoning:
+    actions:
+        get_help: @utils.escalate
+            description: "Connect with live agent"
+```
+
+**`@utils.setVariables`** — LLM slot-filling:
+
+```agentscript
+reasoning:
+    actions:
+        collect: @utils.setVariables
+            description: "Collect preferences"
+            with preferred_color = ...
+            with budget = ...
+```
+
+Variables must be predefined in `variables:` block.
+
+**`@topic.X`** — delegation with return:
+
+```agentscript
+reasoning:
+    actions:
+        consult: @topic.expert_topic
+            description: "Get expert guidance"
+```
+
+**Post-action directives only work with `@actions`, not `@utils` or `@topic`**. Utilities have no outputs, so `set` is invalid.
+
+---
+
+## 6. Anti-Patterns
+
+Each shows WRONG then CORRECT with semantic explanation.
+
+### 1. Using `transition to` in `reasoning.actions`
+
+```agentscript
+# WRONG — doesn't compile
+reasoning:
+    actions:
+        go_next: transition to @topic.next
+
+# CORRECT
+reasoning:
+    actions:
+        go_next: @utils.transition to @topic.next
+```
+
+**Why**: `reasoning.actions` expose LLM tools. LLM needs action reference (`@utils.transition to`), not bare command.
+
+---
+
+### 2. Using `@utils.transition to` in directive blocks
+
+```agentscript
+# WRONG — compile error
+after_reasoning:
+    @utils.transition to @topic.next
+
+# CORRECT
+after_reasoning:
+    transition to @topic.next
+```
+
+**Why**: Directive blocks execute deterministically. Use bare `transition to` syntax.
+
+---
+
+### 3. Lowercase booleans
+
+```agentscript
+# WRONG
+enabled: mutable boolean = true
+if @variables.is_premium == false:
+
+# CORRECT
+enabled: mutable boolean = True
+if @variables.is_premium == False:
+```
+
+**Why**: Agent Script requires capitalized `True`/`False`. Parser rejects lowercase.
+
+---
+
+### 4. Mutable variable without default
+
+```agentscript
+# WRONG
+variables:
+    customer_name: mutable string
+
+# CORRECT
+variables:
+    customer_name: mutable string = ""
+```
+
+**Why**: Runtime needs initial value during deterministic resolution. Mutable variables must have defaults.
+
+---
+
+### 5. Linked variable with default
+
+```agentscript
+# WRONG
+session_id: linked string = ""
+    source: @session.sessionID
+
+# CORRECT
+session_id: linked string
+    source: @session.sessionID
+```
+
+**Why**: Linked variables get values from external context via `source`. Default is invalid.
+
+---
+
+### 6. Linked variable with `list` type
+
+```agentscript
+# WRONG
+items: linked list[string]
+    source: @session.items
+
+# CORRECT
+items: mutable list[string] = []
+```
+
+**Why**: Linked variables cannot be `list` type. Use mutable instead.
+
+---
+
+### 7. Using `...` as variable default
+
+```agentscript
+# WRONG
+variables:
+    name: mutable string = ...
+
+# CORRECT
+variables:
+    name: mutable string = ""
+```
+
+**Why**: `...` is slot-filling syntax for action inputs, not variable defaults. Mutable variables need concrete defaults.
+
+---
+
+### 8. Post-action directives on utilities
+
+```agentscript
+# WRONG — utilities don't support set
+escalate: @utils.escalate
+    set @variables.escalated = True
+
+# CORRECT — only @actions support set
+process: @actions.process_order
+    set @variables.result = @outputs.status
+```
+
+**Why**: Utilities have no outputs. `set` requires `@outputs`, which only `@actions` produce.
+
+---
+
+### 9. Variable binding without brackets in prompts
+
+```agentscript
+# WRONG — won't interpolate
+instructions: |
+    Your balance: @variables.balance
+
+# CORRECT
+instructions: |
+    Your balance: {!@variables.balance}
+```
+
+**Why**: Bare `@variables.X` is valid in logic contexts (`if` conditions) but won't interpolate in prompt text. Use `{!@variables.X}` for template injection.
+
+---
+
+### 10. developer_name mismatch
+
+```agentscript
+# WRONG — directory is Travel_Advisor/, config says Travel_Agent
+config:
+    developer_name: "Travel_Agent"
+
+# CORRECT — must match directory name exactly
+config:
+    developer_name: "Travel_Advisor"
+```
+
+**Why**: `developer_name` must exactly match the `AiAuthoringBundle` directory name. Mismatch causes deploy failures.

--- a/skills/agent-development/agent-script-skill/references/agent-test-authoring.md
+++ b/skills/agent-development/agent-script-skill/references/agent-test-authoring.md
@@ -1,0 +1,570 @@
+# Agent Test Authoring Reference
+
+## Table of Contents
+
+- [Test Spec Structure](#test-spec-structure)
+- [Writing Effective Test Cases](#writing-effective-test-cases)
+- [Metric Selection](#metric-selection)
+- [Multi-Turn Testing](#multi-turn-testing)
+- [Custom Evaluations](#custom-evaluations)
+- [Context Variables](#context-variables)
+- [Coverage Strategy](#coverage-strategy)
+- [Test Authoring Workflow](#test-authoring-workflow)
+- [Platform Constraints](#platform-constraints)
+- [Common Mistakes](#common-mistakes)
+
+---
+
+## Test Spec Structure
+
+A test spec is a YAML file that defines test cases for an agent. The `sf agent test create` command translates this YAML into `AiEvaluationDefinition` metadata in the org. Tests run against **activated published agents** — not authoring bundles or drafts.
+
+Top-level structure:
+
+```yaml
+name: "Human-readable test name"
+description: "Description of what this test spec covers."
+subjectType: AGENT
+subjectName: Agent_API_Name
+subjectVersion: v1
+testCases:
+  - utterance: "User input"
+    expectedTopic: topic_api_name
+    expectedActions: []
+    expectedOutcome: "Natural language description"
+    conversationHistory: []
+    customEvaluations: []
+    contextVariables: []
+    metrics: []
+```
+
+Required top-level fields:
+- `name`: Human-readable identifier for the test spec. Used in CLI output and logs.
+- `subjectType`: Always `AGENT` for agent test specs.
+- `subjectName`: The API name of the agent being tested. Must match the agent's API name exactly.
+- `testCases`: List of individual test cases. At least one required.
+
+Optional top-level fields:
+- `description`: What this test spec validates. Reference the Agent Spec by name.
+- `subjectVersion`: The agent version to test (e.g., `v1`). If omitted, the latest active version is used. Find versions in the `BotVersion` metadata type.
+
+Per-test-case required fields:
+- `utterance`: The user input being tested. Natural language, one-turn input. Do not include multi-turn context here; use `conversationHistory` for that.
+- `expectedTopic`: The topic API name the agent should route to. String, not a list. Single topic per test case.
+- `expectedActions`: List of action API names the agent should invoke. Use empty list `[]` when no action is expected.
+- `expectedOutcome`: Natural language description of the expected result. This is NOT a literal string match; the platform uses semantic comparison — actual text can differ from expected as long as core meaning matches.
+- `metrics`: List of metrics to evaluate. See Metric Selection section.
+
+Optional per-test-case fields:
+- `conversationHistory`: Prior messages providing context for the current utterance. See Multi-Turn Testing section.
+- `customEvaluations`: Custom validation rules beyond standard metrics. See Custom Evaluations section.
+- `contextVariables`: Context variables for Service agents with messaging channels. See Context Variables section.
+
+Default location: `specs/{Agent_API_Name}-testSpec.yaml`.
+
+---
+
+## Writing Effective Test Cases
+
+Each test case exercises one user intent and validates the agent's response.
+
+Utterance design:
+- Write natural conversational input. Avoid scripts or rigid phrasing.
+- Keep each utterance focused on a single user intent. Multi-intent requests belong in separate test cases.
+- Test realistic variations: "What's the weather?" and "Can you tell me the forecast?" both target weather but use different phrasing.
+- Include edge cases: ambiguous input, off-topic queries, requests requiring guardrails.
+
+Example utterances for Agent_Name:
+- Clear intent: "What information do I need?" (maps to a specific topic)
+- Variation: "Can you help me with X?" (alternative phrasing for same intent)
+- Edge case requiring context: "Great, and what about Y?" (requires prior conversation context)
+- Off-topic: "What is the capital of France?"
+- Guardrail test: "I'd like to speak with a real person please."
+
+expectedOutcome phrasing:
+- Describe the expected behavior in natural language. Do not write literal response text.
+- The platform evaluates using semantic comparison — even if the actual outcome text differs, the test passes if core meaning matches.
+- Reference what should happen: "The agent should provide a forecast with a temperature range."
+- Reference what should NOT happen: "The agent should NOT answer the off-topic question."
+- Name the action(s) if relevant: "The agent should call get_resort_hours and return opening times."
+- When guardrails apply, state the constrained behavior: "The agent should escalate to a human agent without attempting to answer."
+
+WRONG: `expectedOutcome: "The result is X."`
+RIGHT: `expectedOutcome: "The agent should provide the requested information with specific details."`
+
+expectedActions rationale:
+- List ONLY actions the agent should invoke. If no action is expected, use `[]`.
+- Base this on the Agent Spec's topic-to-action mapping. If a topic has no actions, expectedActions is `[]`.
+- If a topic conditionally invokes an action (e.g., only if user provides input), think carefully: does your test case provide that input?
+
+WRONG — action listed but test utterance doesn't trigger it:
+```yaml
+- utterance: "Show me the data"
+  expectedTopic: topic_b
+  expectedActions:
+    - action_b
+  expectedOutcome: "The agent should provide the requested data."
+```
+RIGHT — required information not provided, so agent must ask first:
+```yaml
+- utterance: "Show me the data"
+  expectedTopic: topic_b
+  expectedActions: []
+  expectedOutcome: "Because the user has not provided the required information, the agent should politely ask for it before calling the gated action."
+```
+
+---
+
+## Metric Selection
+
+Metrics quantify response quality. Always include `output_latency_milliseconds`. Add others based on test purpose.
+
+Available metrics:
+- `coherence`: Response is grammatically correct and easy to understand. Default choice for all tests.
+- `completeness`: Response includes all essential information. Use when the test expects multiple pieces of data.
+- `conciseness`: Response is brief but comprehensive. Use when verbosity is a concern.
+- `output_latency_milliseconds`: Time from request to response in milliseconds. ALWAYS include.
+- `instruction_following`: How well the response follows topic instructions and guardrails. Use for behavioral tests, constraints, edge cases. **Scoring differs from other metrics** — returns `HIGH`, `LOW`, or `UNCERTAIN` instead of `PASS`/`FAILED`.
+- `factuality`: Response contains verifiably correct data. Use when the agent returns facts (weather, hours, event details).
+
+Selection guide:
+- Baseline set: `coherence`, `conciseness`, `output_latency_milliseconds`.
+- Add `completeness` if the expected outcome references multiple data points.
+- Add `instruction_following` if testing guardrails, constraints, or behavioral rules (e.g., "don't answer off-topic").
+- Add `factuality` if the response must contain real or simulated factual data.
+- Remove unwanted metrics by deleting them from the list. Delete the entire `metrics` section to skip all quality metrics.
+
+Example: Agent_Name off-topic test case:
+```yaml
+metrics:
+  - coherence
+  - instruction_following
+  - output_latency_milliseconds
+```
+Reason: coherence ensures the redirection is clear; instruction_following validates the guardrail (don't answer off-topic) — expect `HIGH` for a well-behaved agent; latency is always included.
+
+---
+
+## Multi-Turn Testing
+
+Test multi-turn conversations using `conversationHistory`. This provides context for the current `utterance`.
+
+Conversation history format:
+```yaml
+conversationHistory:
+  - role: user
+    message: "First user message"
+  - role: agent
+    message: "Agent's response"
+    topic: topic_used_for_response
+  - role: user
+    message: "Second user message"
+  - role: agent
+    message: "Agent's second response"
+    topic: topic_used_for_second_response
+```
+
+Rules:
+- `role`: Either `user` or `agent`. Required.
+- `message`: The text of the message. Required.
+- `topic`: REQUIRED for agent entries. This is the topic the agent used to formulate that response. Omit for user entries.
+- Do NOT include the current test utterance in conversationHistory. The `utterance` field is the final user message.
+- Conversation must begin with a `user` message.
+
+When to use conversationHistory:
+- Test topic transitions that depend on prior context.
+- Test multi-turn flows where earlier responses constrain later behavior.
+- Test contextual clarity: does the agent maintain facts from earlier turns?
+
+Example: Agent_Name contextual follow-up test case:
+```yaml
+- utterance: Great, and what about the second item?
+  expectedTopic: main
+  expectedActions:
+    - do_action
+  expectedOutcome: The agent should provide information about the second item, understanding
+    the context from the previous exchange.
+  conversationHistory:
+    - role: user
+      message: Tell me about the first item
+    - role: agent
+      message: Here is information about the first item with specific details.
+      topic: main
+  metrics:
+    - coherence
+    - conciseness
+    - output_latency_milliseconds
+```
+
+Without conversationHistory, "Great, what time does the restaurant open?" is ambiguous. The prior weather exchange provides context showing the user is satisfied and moving to a new topic.
+
+---
+
+## Custom Evaluations
+
+Custom evaluations validate specific response properties using comparison operators. Two types: `string_comparison` and `numeric_comparison`.
+
+### Parameters
+
+Each custom evaluation has four fields:
+- `label`: Human-readable description of what this evaluation checks.
+- `name`: The comparison type — either `string_comparison` or `numeric_comparison`.
+- `parameters`: List of three parameter objects (below).
+
+Each parameter has `name`, `value`, and `isReference`:
+- `operator`: The comparison operation. `isReference: false` (literal value).
+- `actual`: The value obtained during the test. `isReference: true` when the value is a JSONPath expression referencing runtime data. `isReference: false` when it is a literal.
+- `expected`: The target value to compare against. `isReference: false` (literal value).
+
+The `isReference` field tells the platform whether to evaluate `value` as a JSONPath expression (`true`) or use it as-is (`false`). The `actual` parameter almost always uses `isReference: true` because it references data generated during the test run.
+
+Parameter `value` fields are limited to **100 characters**.
+
+### Constructing JSONPath Expressions
+
+Custom evaluations reference runtime data from the `generatedData` object. To construct the JSONPath, you need to see the generated JSON from a test run.
+
+Step 1 — Run the test with `--verbose` to see generated data:
+```bash
+sf agent test run --json --api-name My_Agent_Test --verbose --wait 10
+```
+
+Step 2 — Find the generated JSON in the output:
+```
+Generated Data
+┌───────────────────────────────────────┐
+│ [                                     │
+│   [                                   │
+│     {                                 │
+│       "function": {                   │
+│         "name": "Check_Weather",      │
+│         "input": {                    │
+│           "dateToCheck": "2025-09-12" │
+│         },                            │
+│         "output": {}                  │
+│       },                              │
+│       "executionLatency": 804         │
+│     }                                 │
+│   ]                                   │
+│ ]                                     │
+└───────────────────────────────────────┘
+```
+
+Step 3 — Build the JSONPath expression. Common pattern:
+```
+$.generatedData.invokedActions[*][?(@.function.name == '{ACTION_NAME}')].function.input.{FIELD}
+```
+
+Useful paths:
+- Action input field: `...function.input.{fieldName}`
+- Action output field: `...function.output.{fieldName}`
+- Action execution latency: `...executionLatency`
+
+### String Comparison
+
+Tests a response property against a string value. All string operators are case-sensitive.
+
+Operators: `equals` (exact match), `contains` (substring), `startswith` (prefix), `endswith` (suffix).
+
+```yaml
+customEvaluations:
+  - label: "Check for correct date"
+    name: string_comparison
+    parameters:
+      - name: operator
+        value: equals
+        isReference: false
+      - name: actual
+        value: "$.generatedData.invokedActions[*][?(@.function.name == 'Check_Weather')].function.input.dateToCheck"
+        isReference: true
+      - name: expected
+        value: "2025-09-12"
+        isReference: false
+```
+
+### Numeric Comparison
+
+Tests a response property against a numeric value.
+
+Operators: `equals`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`.
+
+```yaml
+customEvaluations:
+  - label: "Latency under threshold"
+    name: numeric_comparison
+    parameters:
+      - name: operator
+        value: less_than
+        isReference: false
+      - name: actual
+        value: "$.generatedData.invokedActions[*][?(@.function.name == 'Check_Weather')].executionLatency"
+        isReference: true
+      - name: expected
+        value: "5000"
+        isReference: false
+```
+
+---
+
+## Context Variables
+
+Service agents connected to messaging channels can use context variables — record fields from the `MessagingSession` standard object used as action inputs. If the agent under test uses context variables, include them in the test spec.
+
+```yaml
+testCases:
+  - utterance: Are there any resort experiences that match my interests today?
+    expectedTopic: Experience_Management
+    expectedActions: []
+    expectedOutcome: The agent should politely ask for the guest's email address AND membership number.
+    contextVariables:
+      - name: EndUserLanguage
+        value: Spanish
+    metrics:
+      - coherence
+      - output_latency_milliseconds
+```
+
+The `name` field is the API name of the context variable (found in Agent Builder > Context tab). Most Agent Script agents do not use context variables — omit the section entirely when not needed.
+
+---
+
+## Coverage Strategy
+
+Map test cases to the Agent Spec to ensure comprehensive coverage.
+
+Coverage dimensions:
+- Topics: Test every topic defined in the Agent Spec. Include normal flow and edge cases.
+- Actions: For each action, test at least one case where the action IS invoked AND one where it is NOT (if conditionally gated).
+- Flow control: Test conditional routing (e.g., "if user input missing, ask for clarification").
+- Guardrails: Test that constraints and behavioral rules are enforced (off-topic rejection, escalation, data validation).
+- Variations: Test phrasing variations of the same intent.
+- Multi-turn: Test at least one topic transition with conversationHistory.
+
+Checklist pattern (adapt to the agent under test):
+- [ ] Every topic tested with at least one happy-path utterance.
+- [ ] Every action tested as both invoked and not-invoked (where applicable).
+- [ ] Gated actions tested with and without the required user input.
+- [ ] Off-topic and escalation guardrails tested.
+- [ ] At least one multi-turn test with conversationHistory.
+- [ ] Phrasing variations for highest-traffic topics.
+
+Example for Agent_Name:
+- [ ] `local_weather` — clear intent, invokes `check_weather`.
+- [ ] `local_weather` — date-specific: "What will the weather be like on March 15th?"
+- [ ] `local_events` — without interest (no action; agent asks for clarification).
+- [ ] `local_events` — with interest: "I like movies. What's showing nearby?" (invokes `check_events`).
+- [ ] `resort_hours` — spa hours (invokes `get_resort_hours`, mentions reservation required).
+- [ ] `resort_hours` — pool hours (invokes `get_resort_hours`, mentions walk-in OK).
+- [ ] `escalation` — "I'd like to speak with a real person" (no action; escalate).
+- [ ] `off_topic` — "What is the capital of France?" (no action; redirect).
+- [ ] Multi-turn — weather → restaurant hours with conversationHistory.
+
+---
+
+## Test Authoring Workflow
+
+The CLI commands for the test authoring lifecycle.
+
+### Step 1: Create the test spec YAML
+
+Write the YAML file manually or start from an existing example. Place it in `specs/`.
+
+Do NOT use `sf agent generate test-spec` in agentic workflows. This command is interactive (REPL-style) — it prompts for each field one at a time and cannot be driven programmatically.
+
+If an `AiEvaluationDefinition` XML file already exists in the project, generate a YAML spec from it:
+```bash
+sf agent generate test-spec \
+    --from-definition force-app/main/default/aiEvaluationDefinitions/MyTest.aiEvaluationDefinition-meta.xml \
+    --output-file specs/My_Agent-testSpec.yaml
+```
+
+### Step 2: Preview before creating
+
+Generate a local XML preview without deploying to the org:
+```bash
+sf agent test create --json --preview --target-org my-dev-org
+```
+This creates a `{API_name}-preview-{timestamp}.xml` file for inspection. Use this to verify the YAML translated correctly before committing to the org.
+
+### Step 3: Create the test in the org
+
+The `--api-name` here is the name for the **test definition** (the `AiEvaluationDefinition`), not the agent name. This is the name you use in all subsequent `sf agent test run` commands.
+```bash
+sf agent test create --json --spec specs/My_Agent-testSpec.yaml --api-name My_Agent_Test --target-org my-dev-org
+```
+This deploys the `AiEvaluationDefinition` metadata and syncs it back to the local project under `aiEvaluationDefinitions/`.
+
+### Step 4: Run the test
+
+Tests run asynchronously by default. The `--api-name` is the **test definition name** from Step 3, not the agent name:
+```bash
+sf agent test run --json --api-name My_Agent_Test --target-org my-dev-org
+```
+This returns a `sf agent test resume --job-id {ID}` command. Run it to get results.
+
+For synchronous execution, use `--wait` (minutes):
+```bash
+sf agent test run --json --api-name My_Agent_Test --wait 20 --target-org my-dev-org
+```
+
+For CI/CD, use `--result-format` and `--output-dir`:
+```bash
+sf agent test run --json --api-name My_Agent_Test --wait 20 --result-format JSON --output-dir test-results
+```
+Supported formats: `JSON`, `TAP`, `JUnit`.
+
+### Step 5: Interpret results and iterate
+
+View completed results:
+```bash
+sf agent test results --json --job-id {ID}
+```
+
+Results show four sections: basic info (overall status, pass/fail counts), per-test-case details (topic/action/outcome per case), metrics (quality scores), and summary (duration, pass rates).
+
+Use `--verbose` on `sf agent test run` to see generated data for constructing custom evaluations (see Custom Evaluations section).
+
+### Useful commands
+
+List all tests in the org to confirm test definition API names:
+```bash
+sf agent test list --json --target-org my-dev-org
+```
+
+Open Testing Center UI:
+```bash
+sf org open --path /lightning/setup/TestingCenter/home --target-org my-dev-org
+```
+
+---
+
+## Platform Constraints
+
+- Maximum **1,000 test cases** per `AiEvaluationDefinition`.
+- Maximum **10 in-progress** test runs at any time.
+- Custom evaluation parameter `value` fields limited to **100 characters**.
+- Running tests consumes **Einstein Request credits** (both production and sandbox).
+- Test results **may change on rerun** due to testing service improvements.
+- Tests require an **activated published agent** — not a draft or authoring bundle.
+
+---
+
+## Common Mistakes
+
+Anti-patterns and corrections.
+
+Mistake: Inventing schema fields.
+```yaml
+WRONG:
+type: AGENT
+version: 1
+subject: Agent_Name
+expectations: []
+turns: []
+
+RIGHT:
+subjectType: AGENT
+subjectName: Agent_Name
+```
+
+Mistake: Using snake_case instead of camelCase.
+```yaml
+WRONG:
+expected_topic: local_weather
+expected_actions: []
+expected_outcome: "..."
+conversation_history: []
+
+RIGHT:
+expectedTopic: local_weather
+expectedActions: []
+expectedOutcome: "..."
+conversationHistory: []
+```
+
+Mistake: Omitting expectedActions.
+```yaml
+WRONG:
+- utterance: "What's the weather?"
+  expectedTopic: local_weather
+  expectedOutcome: "..."
+
+RIGHT:
+- utterance: "What's the weather?"
+  expectedTopic: local_weather
+  expectedActions:
+    - check_weather
+  expectedOutcome: "..."
+```
+
+Mistake: Writing expectedOutcome as a literal string match.
+```yaml
+WRONG:
+expectedOutcome: "The temperature is 72 degrees."
+
+RIGHT:
+expectedOutcome: "The agent should provide a forecast with a temperature range for the resort location."
+```
+
+Mistake: Forgetting topic on agent conversationHistory entries.
+```yaml
+WRONG:
+conversationHistory:
+  - role: agent
+    message: "The weather is nice."
+
+RIGHT:
+conversationHistory:
+  - role: agent
+    message: "The weather is nice."
+    topic: local_weather
+```
+
+Mistake: Inventing metric names.
+```yaml
+WRONG:
+metrics:
+  - responsiveness
+  - tone
+  - accuracy
+
+RIGHT:
+metrics:
+  - coherence
+  - instruction_following
+  - output_latency_milliseconds
+```
+Valid metric names: `coherence`, `completeness`, `conciseness`, `output_latency_milliseconds`, `instruction_following`, `factuality`. No others exist.
+
+Mistake: Using wrong operator names in custom evaluations.
+```yaml
+WRONG:
+- name: operator
+  value: eq
+  isReference: false
+
+RIGHT:
+- name: operator
+  value: equals
+  isReference: false
+```
+String operators: `equals`, `contains`, `startswith`, `endswith`. Numeric operators: `equals`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`. No abbreviations.
+
+Mistake: Malformed JSONPath in custom evaluations.
+```
+WRONG:
+$.invokedActions[0].function.input.dateToCheck
+
+RIGHT:
+$.generatedData.invokedActions[*][?(@.function.name == 'Check_Weather')].function.input.dateToCheck
+```
+JSONPath must start with `$.generatedData.invokedActions`, use `[*]` (not a numeric index), and filter by action name with `[?(@.function.name == '{ACTION}')]`.
+
+Mistake: Using `sf agent generate test-spec` in an agentic workflow.
+The command is interactive — it prompts for each field and cannot be scripted. Write the YAML file directly.
+
+Mistake: Running a test before it is created in the org.
+Always create the test in the org first using `sf agent test create`. Then run it with `sf agent test run --api-name {Test_API_Name}`.
+
+Mistake: Guessing the --api-name flag value.
+The `--api-name` on `sf agent test run` is the **test definition** API name assigned when the test was created — not the agent's `subjectName` from the YAML and not the `name` field in the YAML. List tests with `sf agent test list` to confirm the correct API name.

--- a/skills/agent-development/agent-script-skill/references/agent-topic-map-diagrams.md
+++ b/skills/agent-development/agent-script-skill/references/agent-topic-map-diagrams.md
@@ -1,0 +1,323 @@
+# Agent Topic Map Diagrams Reference
+
+## Table of Contents
+
+- [Purpose and Context](#purpose-and-context)
+- [Fundamental Structure Rules](#fundamental-structure-rules)
+- [Node Types and Agent Script Elements](#node-types-and-agent-script-elements)
+- [Topic Map Patterns](#topic-map-patterns)
+- [Complete Example: Multi-Topic Agent](#complete-example-multi-topic-agent)
+- [Validation Checklist](#validation-checklist)
+- [Anti-patterns](#anti-patterns)
+
+---
+
+## Purpose and Context
+
+A Topic Map diagram is a Mermaid flowchart that visualizes an agent's topic graph structure. It shows the architecture of an agent before implementation, displaying:
+
+- The start_agent topic_selector entry point
+- All topics in the agent
+- Topic transitions and routing logic
+- Action calls within topics (with backing type: Apex, Prompt Template, Flow)
+- Gating conditions (available_when expressions)
+- Variable state changes
+- Escalation and off-topic handling
+- Conditional instructions based on variable values
+
+Topic Map diagrams are the primary visual deliverable in an Agent Spec (design document) and serve both specification and comprehension purposes.
+
+---
+
+## Fundamental Structure Rules
+
+### Graph Orientation
+
+- ALWAYS use `graph TD` (Top-Down orientation)
+- Start with start_agent topic_selector at the top
+- Topics flow downward from the selector
+- Never use other orientations
+
+### Node Identification
+
+- Use sequential capital letters (A, B, C, ...) for node IDs
+- Start with `A` for start_agent
+- Increment sequentially through topics and decisions
+- Use descriptive labels within brackets
+
+### Flow Direction
+
+- Primary flow moves top-to-bottom
+- Use `-->` for standard transitions
+- Label decision branches with `|Label|` syntax
+- Separate paths for different topics
+
+---
+
+## Node Types and Agent Script Elements
+
+### Start Agent Topic Selector Node
+
+Format: `[start_agent<br/>topic_selector]`
+
+Represents the entry point where user input is evaluated and routed to appropriate topics.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+```
+
+### Topic Nodes
+
+Format: `[topic_name<br/>Topic]`
+
+Represents a topic within the agent.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+    B[order_status<br/>Topic]
+    C[billing<br/>Topic]
+```
+
+### Action Call Nodes
+
+Format: `[Call action_name<br/>backing: Type]`
+
+Backing types: Apex, Prompt Template, Flow
+
+Example: `[Call check_weather<br/>backing: Apex]`
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[local_weather<br/>Topic] --> B[Call check_weather<br/>backing: Apex]
+```
+
+### Decision/Gating Nodes
+
+Use curly braces `{}` for conditions. Common formats:
+
+- Variable availability gates: `{Check: variable_name != empty?}`
+- Conditional instructions: `{variable_name == value?}`
+- Topic transition logic: `{user_intent matches?}`
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[topic<br/>Topic] --> B{Check: guest_interests<br/>!= empty?}
+    B -->|Yes| C[Call collect_events<br/>backing: Prompt Template]
+    B -->|No| D[Ask for clarification]
+```
+
+### Variable State Change Nodes
+
+Format: `[Set variable_name = value]`
+
+Shows state modifications that affect downstream behavior.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[Call action] --> B[Set reservation_required<br/>= true]
+```
+
+### Utility Call Nodes
+
+Format: `[Call @utils.name]`
+
+For escalation and system utilities.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[escalation<br/>Topic] --> B[Call @utils.escalate]
+```
+
+---
+
+## Topic Map Patterns
+
+### Basic Topic with Single Action
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+    A -->|route to topic| B[simple_topic<br/>Topic]
+    B --> C[Call do_action<br/>backing: Apex]
+    C --> D[Continue]
+```
+
+### Topic with Gating Condition
+
+Available_when expressions prevent action execution until conditions are met.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[topic_with_gate<br/>Topic]
+    A --> B{Check: required_var<br/>!= empty?}
+    B -->|No| C[Instruction: collect info first]
+    B -->|Yes| D[Call action<br/>backing: Prompt Template]
+    C --> E[Wait for input]
+    E --> A
+```
+
+### Topic with Conditional Instructions
+
+Variable values control which instructions apply to a topic.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[Call process_request<br/>backing: Flow]
+    A --> B[Set status_flag = complete]
+    B --> C{Check: status_flag<br/>== complete?}
+    C -->|Yes| D[Apply conditional<br/>instructions]
+    D --> E[Continue]
+```
+
+### Topic Transitions
+
+When logic determines a new topic should be active.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[current_topic<br/>Topic]
+    A --> B{Transition<br/>condition?}
+    B -->|Yes| C[Transition to<br/>next_topic]
+    C --> D[next_topic<br/>Topic]
+    B -->|No| E[Continue in<br/>current_topic]
+```
+
+### Off-Topic and Escalation Routing
+
+How the agent handles out-of-scope requests.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+    A -->|out of scope| B[off_topic<br/>Topic]
+    A -->|needs help| C[escalation<br/>Topic]
+    B --> D[Instruction: redirect user]
+    C --> E[Call @utils.escalate]
+```
+
+---
+
+## Complete Example: Multi-Topic Agent
+
+This example demonstrates a complete Topic Map for a multi-topic agent with gating conditions, variable state, and escalation handling.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TD
+    A[start_agent<br/>topic_selector]
+
+    A -->|topic a query| B[topic_a<br/>Topic]
+    A -->|topic b query| C[topic_b<br/>Topic]
+    A -->|topic c query| D[main<br/>Topic]
+    A -->|unclear intent| E[ambiguous_question<br/>Topic]
+    A -->|out of scope| F[off_topic<br/>Topic]
+    A -->|needs escalation| G[escalation<br/>Topic]
+
+    B --> B1[Call action_a<br/>backing: Apex]
+    B1 --> B2[Continue]
+
+    C --> C1{Check: collected_input<br/>!= empty?}
+    C1 -->|No| C2[Instruction: collect required input]
+    C1 -->|Yes| C3[Call action_b<br/>backing: Prompt Template]
+    C2 --> C4[Pause for input]
+    C4 --> C
+    C3 --> C5[Continue]
+
+    D --> D1[Call do_action<br/>backing: Flow]
+    D1 --> D2[Set result_flag<br/>= true]
+    D2 --> D3{Check: result_flag<br/>== true?}
+    D3 -->|Yes| D4[Apply conditional instructions]
+    D3 -->|No| D5[Apply standard instructions]
+    D4 --> D6[Continue]
+    D5 --> D6
+
+    E --> E1[Instruction: ask for clarification]
+    E1 --> E2[Await user input]
+    E2 --> A
+
+    F --> F1[Instruction: explain available topics]
+    F1 --> F2[Continue]
+
+    G --> G1[Call @utils.escalate]
+    G1 --> G2[Continue]
+```
+
+### Topic Descriptions
+
+**topic_a**: Handles straightforward requests via Apex-backed action. No preconditions.
+
+**topic_b**: Requires collected_input variable to be populated (gating: `available_when collected_input != ""`). Calls Prompt Template-backed action only when gate is satisfied.
+
+**main**: Calls Flow-backed action that sets result_flag variable. Conditional instructions applied based on variable state: specific guidance when true, standard guidance when false.
+
+**ambiguous_question**: No actions. Requests clarification and routes back to start_agent.
+
+**off_topic**: No actions. Explains available topics and continues conversation.
+
+**escalation**: Calls @utils.escalate utility to route to human agent.
+
+**start_agent topic_selector**: Routes incoming user input to appropriate topics based on intent.
+
+---
+
+## Validation Checklist
+
+Before finalizing a Topic Map diagram:
+
+- [ ] Uses `graph TD` syntax
+- [ ] Starts with `%%{init: {'theme':'neutral'}}%%`
+- [ ] start_agent topic_selector is node A at top
+- [ ] Nodes use sequential capital letter IDs
+- [ ] All topics labeled with `[topic_name<br/>Topic]` format
+- [ ] Action calls include backing type (Apex, Prompt Template, Flow)
+- [ ] Gating conditions shown as decision nodes with `{Check: ...?}` format
+- [ ] Variable state changes explicitly labeled with `[Set variable = value]`
+- [ ] Escalation uses `[Call @utils.escalate]` format
+- [ ] All transition branches are labeled
+- [ ] Diagram fits in 20-30 nodes
+- [ ] Topic routing from start_agent is clear
+- [ ] Off-topic and escalation paths are visible
+- [ ] Conditional instruction logic is shown
+
+---
+
+## Anti-patterns
+
+### Don't
+
+- Use `graph LR` or other orientations instead of `graph TD`
+- Place start_agent anywhere except top (node A)
+- Label actions without backing type information
+- Use ambiguous decision node labels (avoid `{Process?}`)
+- Hide gating conditions in node descriptions instead of showing as decisions
+- Omit variable state changes that affect downstream behavior
+- Create topic routing without labels on the decision logic
+- Mix topic nodes with action nodes at same level without clear containment
+- Use custom color styling (breaks in dark mode)
+- Leave off-topic and escalation paths out of diagram
+
+### Do
+
+- Keep start_agent topic_selector at the top
+- Show all topics reachable from start_agent
+- Include backing type for every action call
+- Make gating conditions explicit as decision nodes
+- Show variable updates as separate nodes when they affect logic flow
+- Label all transition branches
+- Include off-topic and escalation topics
+- Show conditional instructions with decision nodes
+- Use `%%{init: {'theme':'neutral'}}%%` for light/dark mode compatibility
+- Focus diagram on topic structure, not detailed action logic

--- a/skills/agent-development/agent-script-skill/references/agent-validation-and-debugging.md
+++ b/skills/agent-development/agent-script-skill/references/agent-validation-and-debugging.md
@@ -1,0 +1,692 @@
+# Agent Validation and Debugging Reference
+
+## Table of Contents
+
+1. Validation
+2. Error Taxonomy and Prevention
+3. Preview
+4. Session Traces
+5. Diagnostic Patterns
+6. Diagnostic Workflow
+
+---
+
+## 1. Validation
+
+The `sf agent validate` command checks Agent Script files for syntax errors, structural issues, and missing declarations before you attempt to preview or deploy an agent.
+
+### Running Validation
+
+After modifying any `.agent` file, always run this command:
+
+```bash
+sf agent validate authoring-bundle --api-name <AGENT_NAME> --json
+```
+
+Replace `<AGENT_NAME>` with the directory name under `aiAuthoringBundles/` (without the `.agent` extension). Always include `--json` so the output is machine-readable.
+
+Example:
+
+```bash
+sf agent validate authoring-bundle --api-name Agent_Name --json
+```
+
+### Interpreting Output
+
+When validation succeeds, the JSON output contains `result.success` set to `true`:
+
+```json
+{
+  "status": 0,
+  "result": {
+    "success": true
+  },
+  "warnings": []
+}
+```
+
+When validation fails, the CLI treats it as an error. The output uses the CLI error format, not a structured validation result. All useful information is in the `message` field. Ignore `stack`, `cause`, `code`, and `commandName` — these are CLI internals, not diagnostic content.
+
+The `message` field contains the compilation errors. These errors may include ANSI terminal color codes (`\u001b[31m`, `\u001b[39m`, etc.) — strip these before interpreting the message. Errors typically include line and column references (e.g., `[Ln 92, Col 13]`) that map to the `.agent` file, but do not assume a fixed error format. Read the `message` content naturally and reason about what it tells you.
+
+Do not attempt to preview or deploy until validation passes.
+
+### Validation Checklist (Pre-Validate Mental Model)
+
+Before running the validation command, mentally check these 14 items. This checklist prevents the most common errors and speeds up the feedback loop:
+
+- Block ordering is correct: `system` → `config` → `variables` → `connections` → `knowledge` → `language` → `start_agent` → `topic` blocks
+- `config` block has `developer_name` (required for service agents: also needs `default_agent_user`)
+- `system` block has `messages.welcome`, `messages.error`, and `instructions`
+- `start_agent` block exists with description and at least one transition action
+- Each `topic` has a `description` and `reasoning` block
+- All `mutable` variables have default values (required)
+- All `linked` variables have `source` specified and NO default value
+- Action `target` uses valid format (`flow://`, `apex://`, `prompt://`, etc.)
+- Boolean values use `True`/`False` (capitalized, not `true`/`false`)
+- `...` is used for LLM slot-filling in reasoning action inputs, not as variable defaults
+- Transition syntax is correct: `@utils.transition to` in `reasoning.actions`, bare `transition to` in directive blocks
+- Indentation is consistent (4 spaces recommended)
+- Names follow naming rules (letters, numbers, underscores only; no spaces; start with letter)
+- No duplicate block names or action names within the same scope
+
+---
+
+## 2. Error Taxonomy and Prevention
+
+Validation errors fall into several categories: block ordering, indentation, syntax, missing declarations, type mismatches, and structural violations. The following examples show the most common mistakes and their fixes.
+
+### Common Mistakes with WRONG/RIGHT Pairs
+
+**1. Wrong Transition Syntax**
+
+```agentscript
+# WRONG — bare transition in reasoning.actions
+go_next: transition to @topic.next
+
+# CORRECT — use @utils.transition to in reasoning.actions
+go_next: @utils.transition to @topic.next
+
+# CORRECT — use bare transition in directive blocks
+after_reasoning:
+    transition to @topic.next
+```
+
+In reasoning actions (where the LLM decides what to do), use `@utils.transition to`. In directive blocks (`before_reasoning`, `after_reasoning`), use bare `transition to`. These are two different syntaxes for two different contexts.
+
+**2. Missing Default for Mutable Variable**
+
+```agentscript
+# WRONG — mutable variables must have default values
+count: mutable number
+
+# CORRECT
+count: mutable number = 0
+```
+
+Mutable variables are initialized at runtime. They must have a default value so the runtime knows the initial state.
+
+**3. Wrong Boolean Capitalization**
+
+```agentscript
+# WRONG — lowercase booleans
+enabled: mutable boolean = true
+
+# CORRECT — capitalized booleans
+enabled: mutable boolean = True
+```
+
+Agent Script requires `True`/`False` (capitalized). This is consistent across all boolean contexts: variable defaults, conditional comparisons, and field values.
+
+**4. Using `...` as Variable Default (It's for Slot-Filling Only)**
+
+```agentscript
+# WRONG — `...` is slot-filling syntax, not a default value
+my_var: mutable string = ...
+
+# CORRECT
+my_var: mutable string = ""
+```
+
+`...` tells the LLM "extract this value from the conversation" during reasoning actions. It cannot be a variable default.
+
+**5. List Type for Linked Variables**
+
+```agentscript
+# WRONG — linked variables cannot be lists
+items: linked list[string]
+
+# CORRECT — mutable can be list
+items: mutable list[string] = []
+```
+
+Linked variables come from external context (session ID, user record, etc.) which are scalar values. Lists must be mutable.
+
+**6. Default Value on Linked Variable**
+
+```agentscript
+# WRONG — linked variables get value from source, no default
+session_id: linked string = ""
+    source: @session.sessionID
+
+# CORRECT — no default, only source
+session_id: linked string
+    source: @session.sessionID
+```
+
+Linked variables are populated from their `source` at runtime. Do not assign a default value.
+
+**7. Post-Action Directives on Utility Actions**
+
+```agentscript
+# WRONG — utilities don't support post-action directives
+go_next: @utils.transition to @topic.next
+    set @variables.navigated = True
+
+# CORRECT — only @actions support post-action directives
+process: @actions.process_order
+    set @variables.result = @outputs.result
+```
+
+Post-action directives (`set`, `run`, `if`, `transition`) only work after `@actions.*` invocations. Utility actions (`@utils.*`) and topic delegates (`@topic.*`) do not produce outputs, so post-action directives are not applicable.
+
+---
+
+## 3. Preview
+
+Preview lets you test an agent's behavior by sending utterances and observing responses. The preview workflow starts a session, sends one or more utterances, and captures session traces for analysis.
+
+### Programmatic Workflow
+
+ALWAYS use `--json` when calling from a script or AI assistant (not interactive REPL).
+
+#### Step 1: Start a Session
+
+```bash
+# For authoring bundles (during development):
+sf agent preview start --authoring-bundle <BUNDLE_NAME> --json
+
+# For published agents (after publishing):
+sf agent preview start --api-name <AGENT_API_NAME> --json
+```
+
+This command returns a session ID. Capture it immediately — you need it for every subsequent command.
+
+Example:
+
+```bash
+sf agent preview start --authoring-bundle Agent_Name --json
+```
+
+#### Step 2: Send Utterances
+
+```bash
+# For authoring bundles:
+sf agent preview send --authoring-bundle <BUNDLE_NAME> --session-id <SESSION_ID> -u "<MESSAGE>" --json
+
+# For published agents:
+sf agent preview send --api-name <AGENT_API_NAME> --session-id <SESSION_ID> -u "<MESSAGE>" --json
+```
+
+Include the same agent identifier (either `--authoring-bundle` or `--api-name`) and the session ID from Step 1. You can send multiple utterances in the same session — do not end and restart between turns.
+
+Example:
+
+```bash
+sf agent preview send --authoring-bundle Agent_Name --session-id abc123def456 -u "What's the weather?" --json
+```
+
+#### Step 3: End a Session (Optional)
+
+```bash
+# For authoring bundles:
+sf agent preview end --authoring-bundle <BUNDLE_NAME> --session-id <SESSION_ID> --json
+
+# For published agents:
+sf agent preview end --api-name <AGENT_API_NAME> --session-id <SESSION_ID> --json
+```
+
+This command returns the path to session trace files. Call it when the conversation is complete. Do not end prematurely — if the user may ask follow-up questions, keep the session open.
+
+### Execution Modes
+
+Agent Script agents in authoring bundles support two preview execution modes: simulated (default) and live.
+
+**Simulated Preview Mode (Default).** The LLM generates fake action outputs. Use simulated preview mode when:
+- Backing Apex, Flows, or Prompt Templates don't exist yet (you're experimenting with instructions and flow before building actions)
+- No default agent user is configured (live preview mode requires a real, active user; simulated preview mode skips this requirement)
+
+Simulated preview mode speeds up inner-loop development but cannot validate real action outputs, variable-driven branching, or grounding behavior.
+
+**Live Preview Mode.** Real backing code executes and returns real outputs. Pass `--use-live-actions`:
+
+```bash
+sf agent preview start --authoring-bundle <BUNDLE_NAME> --use-live-actions --json
+```
+
+Use live preview mode when:
+- Backing code is deployed and a default agent user is configured
+- Your test depends on real action output values (grounding validation, variable-driven branching, output formatting)
+
+Live preview mode is required for reliable grounding testing. The grounding checker runs in both modes, but simulated preview mode generates fake action outputs via LLM, and those outputs can trigger false grounding failures because they don't match real data patterns. If you see grounding failures in simulated preview mode, switch to live preview mode before diagnosing — the failure may be an artifact of simulation, not a real problem.
+
+CRITICAL: `--use-live-actions` is ONLY valid with `--authoring-bundle`. Published agents (`--api-name`) always execute real actions — do NOT pass `--use-live-actions` with `--api-name`.
+
+### Agent Identification
+
+Use exactly one of these mutually exclusive flags:
+
+- `--authoring-bundle <name>` — for a local Agent Script agent. The name is the directory name under `aiAuthoringBundles/` (without the `.agent` extension).
+- `--api-name <name>` — for a published agent in the org. The name is the directory name under `Bots/`.
+
+These flags identify which agent to preview.
+
+**Post-publish workflow:** Once your agent is published and activated, use `--api-name` instead of `--authoring-bundle` for preview. The `--api-name` flag uses the runtime API and provides more accurate results than the compiled authoring bundle. No additional setup is required — the agent automatically runs real actions (do NOT pass `--use-live-actions` with `--api-name`).
+
+### Target Org
+
+The CLI automatically uses the project's default target org. Always omit `--target-org` and rely on the project default. Only pass `--target-org` if the user explicitly tells you which org to use. Never guess or invent an org username.
+
+### Common Preview Mistakes with WRONG/RIGHT Pairs
+
+**1. Using the Interactive REPL from Automation**
+
+```bash
+# WRONG — requires terminal interaction (ESC to exit)
+sf agent preview --authoring-bundle My_Bundle
+
+# CORRECT — programmatic API
+sf agent preview start --authoring-bundle My_Bundle --json
+```
+
+The bare `sf agent preview` command is an interactive REPL for humans. Automation cannot provide terminal input (ESC), so it hangs. Use `start`/`send`/`end` with `--json`.
+
+**2. Combining `--authoring-bundle` and `--api-name`**
+
+```bash
+# WRONG — mutually exclusive flags
+sf agent preview start --authoring-bundle My_Bundle --api-name My_Agent --json
+
+# CORRECT — choose one
+sf agent preview start --authoring-bundle My_Bundle --json
+```
+
+These flags are mutually exclusive. Use the one matching your agent type.
+
+**3. Sending Before Starting**
+
+```bash
+# WRONG — no session exists
+sf agent preview send --authoring-bundle My_Bundle -u "Hello" --json
+
+# CORRECT — start first, capture session ID
+sf agent preview start --authoring-bundle My_Bundle --json
+sf agent preview send --authoring-bundle My_Bundle --session-id <ID> -u "Hello" --json
+```
+
+Each session has a unique ID. You must start before sending.
+
+**4. Forgetting the Agent Identifier on `send` and `end`**
+
+```bash
+# WRONG — missing --authoring-bundle
+sf agent preview send --session-id <ID> -u "Hello" --json
+
+# CORRECT
+sf agent preview send --authoring-bundle My_Bundle --session-id <ID> -u "Hello" --json
+```
+
+Every command after `start` must include the same `--authoring-bundle` or `--api-name` flag.
+
+**5. Omitting `--session-id` on `send` or `end`**
+
+```bash
+# WRONG — concurrent sessions collide
+sf agent preview send --authoring-bundle My_Bundle -u "Hello" --json
+
+# CORRECT — always include session ID
+sf agent preview send --authoring-bundle My_Bundle --session-id <ID> -u "Hello" --json
+```
+
+If multiple agents have concurrent sessions against the same agent, omitting the session ID causes them to interfere. Always pass the session ID from `start`.
+
+---
+
+## 4. Session Traces
+
+After each utterance in a preview session, the runtime writes trace files. Traces show the complete execution path: what topic was selected, what variables were set, what the LLM saw in its prompt, what it decided to do, and whether the response passed grounding.
+
+### Trace File Location
+
+Traces are stored locally at:
+
+```
+.sfdx/agents/<AGENT_NAME>/sessions/<SESSION_ID>/
+├── metadata.json           # Session metadata
+├── transcript.jsonl        # Conversation log (one JSON object per line)
+└── traces/
+    └── <PLAN_ID>.json      # Detailed execution trace for each turn
+```
+
+Replace `<AGENT_NAME>` with your authoring bundle name (e.g., `Agent_Name`). The `<SESSION_ID>` is the value returned by `sf agent preview start`. A separate trace file (identified by `<PLAN_ID>`) is written for each conversation turn.
+
+Traces are available immediately after each `send` — you do NOT need to end the session to read them.
+
+### File Structure
+
+**metadata.json** contains session-level information: `sessionId`, `agentId`, `startTime`, and `mockMode` (either `"Mock"` for simulated or `"Live Test"` for live).
+
+**transcript.jsonl** is a conversation log with one JSON object per line. Each entry includes `timestamp`, `agentId`, `sessionId`, `role` (`"user"` or `"agent"`), and `text`. Agent responses also include a `raw` array with additional metadata — most importantly, the `planId` field that links to the corresponding trace file.
+
+```json
+{"timestamp":"...","agentId":"Agent_Name","sessionId":"abc123","role":"user","text":"What's the weather?"}
+{"timestamp":"...","agentId":"Agent_Name","sessionId":"abc123","role":"agent","text":"The weather on 2026-02-19...","raw":[{"planId":"def456","isContentSafe":true,...}]}
+```
+
+To connect a failed turn to its trace, find the agent response in the transcript and read the `planId` from its `raw` array. That `planId` is the filename under `traces/`.
+
+**traces/<PLAN_ID>.json** is the detailed execution log for a single turn. It contains top-level fields (`type`, `planId`, `sessionId`, `intent`, `topic`) and a `plan` array with execution steps in chronological order.
+
+### Step Types (Reference Table)
+
+Each trace step type reveals specific execution information:
+
+- **`UserInputStep`** — The user's utterance that triggered this turn.
+- **`SessionInitialStateStep`** — Variable values and directive context at turn start.
+- **`NodeEntryStateStep`** — Which agent/topic is executing and its full state snapshot.
+- **`VariableUpdateStep`** — A variable was changed — shows old/new value and reason.
+- **`BeforeReasoningIterationStep`** — `before_reasoning` block ran — lists actions executed.
+- **`EnabledToolsStep`** — Which tools/actions are available to the LLM for this reasoning cycle.
+- **`LLMStep`** — The LLM call — full prompt, response, available tools, latency.
+- **`FunctionStep`** — An action executed — shows input, output, and latency.
+- **`ReasoningStep`** — Grounding check result — `GROUNDED` or `UNGROUNDED` with reason.
+- **`TransitionStep`** — Topic transition — shows from/to topics and transition type.
+- **`PlannerResponseStep`** — Final response delivered to user — includes safety scores.
+
+
+### How to Read a Trace
+
+Read steps in chronological order:
+
+1. Locate `UserInputStep` — the trigger for this turn
+2. Check `NodeEntryStateStep` — which topic is running and what is the current variable state?
+3. Look for `EnabledToolsStep` — what actions are available to the LLM?
+4. Find `LLMStep` — examine `messages_sent` (the full prompt), `tools_sent` (available actions), and `response_messages` (what the LLM chose to do)
+5. If an action was called, find the corresponding `FunctionStep` — compare inputs sent and outputs received
+6. Check `ReasoningStep` — did the response pass grounding?
+7. Look for `TransitionStep` — did the agent move to another topic?
+8. Check `PlannerResponseStep` — what did the user receive?
+
+### The LLMStep in Detail
+
+The `LLMStep` is the most diagnostic step type. It contains:
+
+- `agent_name` — which topic or selector is running
+- `messages_sent` — the FULL prompt sent to the LLM (system message, conversation history, and injected instructions)
+- `tools_sent` — action names available to the LLM
+- `response_messages` — the LLM's response (text or tool invocation)
+- `execution_latency` — milliseconds for the LLM call
+
+The `messages_sent` array shows you exactly what the LLM saw. This is invaluable for debugging because:
+- You can see how Agent Script instructions were compiled into the system prompt
+- You can see the full conversation history (including grounding retry injections)
+- You can verify that variable interpolation (`{!@variables.x}`) worked correctly
+- You can see platform-injected system prompts (tool usage protocol, safety routing, language guidelines) that your Agent Script instructions sit alongside
+
+
+### When to Use Traces vs. Transcript
+
+Use the **transcript** to quickly identify WHICH turn failed (unexpected response, wrong topic, agent crash).
+
+Use the **trace files** when:
+- The agent routes to the wrong topic
+- An action isn't firing
+- The response is unexpectedly worded
+- Grounding is failing
+- You need to understand variable values at a specific point in execution
+- You need to see what the LLM actually saw in its prompt
+
+The transcript is sufficient for conversation-level understanding. Traces provide execution-level detail needed for diagnosis.
+
+---
+
+## 5. Diagnostic Patterns
+
+These patterns map symptoms to trace analysis techniques. Each pattern follows the same structure: symptom → which trace steps to examine → root cause → fix (with code example).
+
+### Pattern: Wrong Topic Routing
+
+**Symptom:** The agent enters the wrong topic. For example, asking about weather sends the agent to the events topic instead.
+
+**Trace Analysis:**
+
+1. Find the `LLMStep` where `agent_name` is `topic_selector` (the entry point that routes to topics)
+2. Examine `tools_sent` — are the transition actions for all expected topics listed? (e.g., `go_to_local_weather`, `go_to_local_events`, `go_to_resort_hours`)
+3. Examine `response_messages` — which action tool did the LLM select?
+4. Examine `messages_sent` — does the system prompt (what topic selector instructions were compiled to) give the LLM enough context to route correctly?
+
+**Root Cause:** Topic selector instructions are ambiguous, missing context, or don't map user requests to the correct topics.
+
+**Fix:** A minimal topic selector with well-named actions often routes correctly. When it doesn't, add routing instructions and action descriptions to give the LLM more context:
+
+```agentscript
+# BEFORE — relies on action names alone for routing
+start_agent topic_selector:
+    description: "Route to appropriate topics"
+    reasoning:
+        actions:
+            go_to_weather: @utils.transition to @topic.local_weather
+            go_to_events: @utils.transition to @topic.local_events
+
+# AFTER — explicit instructions and descriptions improve routing accuracy
+start_agent topic_selector:
+    description: "Route to appropriate topics"
+    reasoning:
+        instructions: ->
+            | If the user asks about weather conditions, temperature, or forecasts, go to the weather topic.
+              If the user asks about local events, activities, or entertainment, go to the events topic.
+              If the user asks about facility hours, reservations, or amenities, go to the hours topic.
+
+        actions:
+            go_to_weather: @utils.transition to @topic.local_weather
+                description: "Route to weather topic for weather questions"
+            go_to_events: @utils.transition to @topic.local_events
+                description: "Route to events topic for local event questions"
+            go_to_hours: @utils.transition to @topic.resort_hours
+                description: "Route to hours topic for facility hours questions"
+```
+
+
+### Pattern: Actions Not Firing
+
+**Symptom:** The agent doesn't call an action you expect it to. For example, the agent should fetch data but responds without calling the action.
+
+**Trace Analysis:**
+
+1. Find the `EnabledToolsStep` for the topic — is the expected action listed?
+2. If missing:
+   - Check the action definition's `available when` condition (e.g., `available when @variables.guest_interests != ""`)
+   - Look at the `NodeEntryStateStep` to see if the gating variable has the expected value
+   - If the variable is empty or has the wrong value, the action is hidden
+3. If listed but not called:
+   - Find the `LLMStep` response — did the LLM choose a different action or respond without using any tool?
+   - Compare `messages_sent` — does the instructions tell the LLM when to use this action?
+
+**Root Cause:** Either the action is gated behind a condition that hasn't been satisfied, or the instructions don't tell the LLM to call it.
+
+**Fix Example:**
+
+```agentscript
+# WRONG — action is hidden until guest_interests is set, but there's no way to set it
+reasoning:
+    actions:
+        check_events: @actions.check_events
+            available when @variables.guest_interests != ""
+            with Event_Type = @variables.guest_interests
+
+# CORRECT — first step collects interests, second action uses them
+reasoning:
+    instructions: ->
+        | Ask about the guest's interests if you don't know them yet.
+          Once you know what they're interested in, look up matching events.
+
+    actions:
+        collect_interests: @utils.setVariables
+            description: "Collect the guest's interests"
+            with guest_interests = ...
+
+        check_events: @actions.check_events
+            description: "Look up local events matching the guest's interests"
+            available when @variables.guest_interests != ""
+            with Event_Type = @variables.guest_interests
+```
+
+
+### Pattern: Behavioral Loops
+
+**Symptom:** The agent keeps asking the same question or repeating the same response across multiple turns, even though the user already provided the requested information.
+
+**Diagnosis:** Observe the conversation output first — the behavioral symptom is often obvious (e.g., the agent asking the same question repeatedly). A common cause is instructions that collect information and act on it within the same topic — when the topic is re-entered, the collection logic runs again even though the data was already gathered.
+
+**Fix Example:** In this real scenario, the `local_events` topic asks about interests and then looks up events. But each time the topic is re-entered, the agent asks about interests again instead of checking whether it already knows them:
+
+```agentscript
+# BEFORE — agent asks about interests every time the topic is entered
+reasoning:
+    instructions: ->
+        | If you do not already know the guest's interests, ask them about their
+          interests so you can provide relevant event information.
+          Use the {!@actions.check_events} action to get a list of events once
+          you know what the guest is interested in.
+
+    actions:
+        collect_interests: @utils.setVariables
+            description: "Collect the guest's interests when they share them"
+            with guest_interests = ...
+
+        check_events: @actions.check_events
+            available when @variables.guest_interests != ""
+            with Event_Type = @variables.guest_interests
+
+# AFTER — condition on the variable, not on re-asking
+reasoning:
+    instructions: ->
+        | If @variables.guest_interests is empty, ask the guest about their interests.
+          If @variables.guest_interests is already set, use {!@actions.check_events}
+          to find matching events and present the results.
+          Do NOT ask about interests again if you already have them.
+
+    actions:
+        collect_interests: @utils.setVariables
+            description: "Collect the guest's interests when they share them"
+            with guest_interests = ...
+
+        check_events: @actions.check_events
+            available when @variables.guest_interests != ""
+            with Event_Type = @variables.guest_interests
+```
+
+The key difference: the AFTER version explicitly references the variable value to decide whether to ask or act, and includes a stop condition ("Do NOT ask about interests again").
+
+Note: repeated `LLMStep` → `ReasoningStep` pairs in a trace may indicate grounding retry rather than a behavioral loop — see Diagnostic Workflow: Grounding subsection.
+
+### Pattern: "Unexpected Error" Responses
+
+**Symptom:** The agent returns "I apologize, but I encountered an unexpected error" instead of a normal response.
+
+**Trace Analysis:**
+
+1. Find the `PlannerResponseStep` — is the message the system error message?
+2. Look backward through the trace for consecutive `ReasoningStep` entries with `category: "UNGROUNDED"` — two consecutive UNGROUNDED results cause this error
+3. If no grounding failures, look for `FunctionStep` entries with error outputs (action execution failed)
+4. Check if a topic transition failed (the target topic doesn't exist or has a circular reference)
+
+**Root Cause:** Grounding failed twice in a row, OR an action returned an error, OR a topic transition is misconfigured.
+
+**Fix:** See Diagnostic Workflow: Grounding subsection for grounding failures. For action errors, verify the backing Apex/Flow/Prompt Template is deployed and handles edge cases correctly. For transition errors, verify all referenced topics exist and are spelled correctly.
+
+
+---
+
+## 6. Diagnostic Workflow
+
+Use this systematic 8-step approach when diagnosing any agent behavior issue.
+
+1. **Reproduce** — Use `sf agent preview start/send/end` with `--json` to recreate the issue with the exact user input that triggered it
+
+2. **Locate** — Open `transcript.jsonl` and find the failing agent turn. Read the `planId` from its `raw` array.
+
+3. **Read the Trace** — Open `traces/<PLAN_ID>.json` for the failing turn. Read the plan array in order.
+
+4. **Follow Execution** — As you read each step, note:
+   - Which topic was selected? (Look at `NodeEntryStateStep`)
+   - What state were variables in? (Look at `SessionInitialStateStep` and `VariableUpdateStep`)
+   - What actions were available vs. invoked? (Look at `EnabledToolsStep` and `LLMStep` response)
+   - What did the LLM see in its prompt? (Look at `LLMStep.messages_sent`)
+   - What did it respond with? (Look at `LLMStep.response_messages`)
+   - Did the response pass grounding? (Look at `ReasoningStep.category`)
+
+5. **Identify the Gap** — Compare expected behavior to actual execution at each step. Use the diagnostic patterns (Section 5) to map symptoms to root causes.
+
+6. **Fix** — Update Agent Script instructions, variable logic, or action definitions based on what you found.
+
+7. **Validate** — Run `sf agent validate authoring-bundle --api-name <AGENT_NAME> --json` to ensure the fix doesn't introduce syntax errors.
+
+8. **Re-Test** — Run a new preview session with the same input and compare traces. Verify the fix resolved the issue.
+
+
+### Grounding
+
+Grounding is a platform service that validates an agent's response against real action output data. When grounding fails, the platform gives the LLM a second chance. Understanding how grounding works, why it fails, and how to fix it is critical for behavioral diagnosis.
+
+#### The Grounding Retry Mechanism
+
+When the platform's grounding checker flags a response as UNGROUNDED:
+
+1. The system injects an error message as a `role: "user"` message:
+   ```
+   Error: The system determined your original response was ungrounded.
+   Reason the response was flagged: [explanation]
+   Try again. Make sure to follow all system instructions.
+   Original query: [original user message]
+   ```
+2. The LLM is given another chance to respond
+3. If the second attempt is also UNGROUNDED, the agent returns the system error message ("I apologize, but I encountered an unexpected error") and gives up
+4. This retry is visible in traces as repeated `LLMStep` → `ReasoningStep` pairs for the same topic
+5. When this happens, the actual action output is still in the trace's `FunctionStep.function.output`. The LLM's failed response attempts are in the `LLMStep.response_messages`. Use these to understand what the agent tried to say versus what the action actually returned.
+
+
+#### Non-Deterministic Behavior
+
+The grounding checker is non-deterministic. The same response may be flagged as UNGROUNDED on one attempt and GROUNDED on the next. When diagnosing intermittent grounding failures, look for responses that require the grounding checker to make inferences (date inference, unit conversions, paraphrased values).
+
+#### Common Grounding Failure Causes
+
+- **Date Inference:** Function returns a specific date (e.g., "2025-02-19"), agent says "today" or "this week". The grounding checker cannot always infer that a relative date equals a specific date.
+- **Unit Conversion:** Function returns Celsius, agent responds in Fahrenheit without the grounding checker recognizing the conversion.
+- **Embellishment:** Agent adds details not in the function output (e.g., "gentle breeze" when the function only returned temperature data).
+- **Loose Paraphrasing:** Agent restates function output in words that don't closely match the original.
+
+
+#### Diagnosing Grounding Failures
+
+1. Find the `ReasoningStep` with `category: "UNGROUNDED"`
+2. Read the `reason` field — it explains exactly what the grounding checker flagged
+3. Find the `FunctionStep` output for the action that was called
+4. Find the `LLMStep` response — compare it to the function output
+5. Identify where the response diverges from the function output (dates, numbers, names, facts)
+
+**Example:** Function returns:
+```json
+{"date": "2025-02-19", "temperature": "48.5F"}
+```
+
+Agent responds: "Today will be around 50 degrees."
+
+Grounding fails because: "today" requires inference (the checker doesn't know if 2025-02-19 is today), and "around 50" doesn't match the specific value "48.5F".
+
+#### Fix Approach
+
+Update Agent Script instructions to tell the agent to use specific values from action output verbatim rather than paraphrasing or inferring.
+
+```agentscript
+# WRONG — allows paraphrasing and inference
+reasoning:
+    instructions: ->
+        | Tell the user about the weather.
+
+# CORRECT — explicit instructions to use verbatim values
+reasoning:
+    instructions: ->
+        | After getting weather results, respond using the exact date and temperature
+          values returned by the action. Do NOT paraphrase dates (say "2025-02-19",
+          not "today"). Do NOT round temperatures (say the exact value from the results).
+          Quote action output values verbatim whenever possible.
+```
+
+#### Grounding in Simulated Preview Mode
+
+The grounding checker runs in both simulated and live preview modes. However, simulated preview mode generates fake action outputs via LLM, and those outputs can trigger false grounding failures because they don't match real data patterns. If you see grounding failures during simulated preview, switch to live preview mode (`--use-live-actions`) before investing time in diagnosis — the failure may be an artifact of simulation, not a real instruction problem.
+
+---
+

--- a/skills/agent-development/agent-script-skill/references/salesforce-cli-for-agents.md
+++ b/skills/agent-development/agent-script-skill/references/salesforce-cli-for-agents.md
@@ -1,0 +1,290 @@
+# Salesforce CLI for Agents Reference
+
+## Table of Contents
+
+1. Global Rules
+2. Generate
+3. Validate
+4. Deploy
+5. Publish
+6. Activate and Deactivate
+7. Retrieve
+8. Delete
+9. Preview
+10. Test
+11. Open in Browser
+
+---
+
+## 1. Global Rules
+
+Always include `--json` as the FIRST flag after the base command. This ensures machine-readable output and prevents mid-tier LLMs from dropping the flag.
+
+```bash
+# CORRECT — --json first
+sf agent validate authoring-bundle --json --api-name Agent_Name
+
+# WRONG — --json at the end or missing
+sf agent validate authoring-bundle --api-name Agent_Name --json
+sf agent validate authoring-bundle --api-name Agent_Name
+```
+
+Multiple metadata types in `--metadata` are space-separated arguments, NOT comma-separated. Wildcard patterns must be quoted.
+
+```bash
+# CORRECT
+sf project deploy start --json --metadata ApexClass Flow
+sf project retrieve start --json --metadata "AiAuthoringBundle:Agent_Name_*"
+
+# WRONG
+sf project deploy start --json --metadata ApexClass,Flow
+sf project retrieve start --json --metadata AiAuthoringBundle:Agent_Name_*
+```
+
+---
+
+## 2. Generate
+
+Create a new AiAuthoringBundle directory with boilerplate `.agent` and `.bundle-meta.xml` files.
+
+```bash
+sf agent generate authoring-bundle --json --no-spec --name "Agent Label" --api-name Agent_API_Name
+```
+
+- `--name`: Human-readable label (quoted if it contains spaces).
+- `--api-name`: Developer name. Must be a valid Salesforce API name (letters, numbers, underscores). This becomes the directory name under `aiAuthoringBundles/`.
+- `--no-spec`: Skip interactive agent spec generation. Always include this flag — the interactive spec generator cannot be used programmatically.
+
+The generated directory is placed at `<default_package_directory>/main/default/aiAuthoringBundles/<api-name>/`. Read `sfdx-project.json` to find the default package directory path.
+
+---
+
+## 3. Validate
+
+Check Agent Script for syntax errors, structural issues, and missing declarations. Always validate before deploying.
+
+```bash
+sf agent validate authoring-bundle --json --api-name Agent_API_Name
+```
+
+- `--api-name`: The AiAuthoringBundle directory name (same as `config.developer_name` in the `.agent` file).
+- Validates against local files only. Does not contact the org.
+
+---
+
+## 4. Deploy
+
+### Deploy Apex, Flow, or other backing logic (one type at a time)
+
+```bash
+sf project deploy start --json --metadata ApexClass:ClassName
+```
+
+Deploy backing logic BEFORE deploying the AiAuthoringBundle. The bundle's action targets reference these components, and the platform validates they exist during bundle deploy.
+
+### Deploy the AiAuthoringBundle
+
+```bash
+sf project deploy start --json --metadata AiAuthoringBundle:Agent_API_Name
+```
+
+This deploys ONLY the AiAuthoringBundle. A bare `sf project deploy start` (no `--metadata`) deploys ALL changed metadata in the project, which can inadvertently deploy agent metadata during routine development. Always scope deploys explicitly.
+
+### Safe routine deploy (non-agent metadata)
+
+```bash
+sf project deploy start --json --metadata ApexClass Flow
+```
+
+Explicitly list the metadata types to deploy. This avoids accidentally deploying AiAuthoringBundle changes.
+
+---
+
+## 5. Publish
+
+Convert a deployed AiAuthoringBundle into a running agent. Publishing creates the runtime entity graph (Bot, BotVersion, GenAiPlannerBundle) from the authoring bundle.
+
+```bash
+sf agent publish authoring-bundle --json --api-name Agent_API_Name
+```
+
+- `--api-name`: The AiAuthoringBundle directory name.
+- The agent must be deployed before it can be published.
+- The `default_agent_user` in the `.agent` file must exist in the target org and have the Einstein Agent license. To find a valid user: `sf data query --json -q "SELECT Username FROM User WHERE Profile.UserLicense.Name = 'Einstein Agent' AND IsActive = true LIMIT 5"`. An invalid user produces a misleading "Internal Error, try again later" message.
+
+---
+
+## 6. Activate and Deactivate
+
+Activation makes a published agent available for conversations and test execution.
+
+```bash
+sf agent activate --json --api-name Bot_API_Name
+```
+
+```bash
+sf agent deactivate --json --api-name Bot_API_Name
+```
+
+- `--api-name` here is the Bot API name (same as the agent's `config.developer_name`).
+- Only published agents can be activated. DRAFT-only agents cannot be activated.
+- Agent tests require an activated agent.
+
+---
+
+## 7. Retrieve
+
+### Retrieve the authoring bundle (editable source)
+
+```bash
+sf project retrieve start --json --metadata AiAuthoringBundle:Agent_API_Name
+```
+
+### Retrieve all version-suffixed snapshots (read-only)
+
+```bash
+sf project retrieve start --json --metadata "AiAuthoringBundle:Agent_API_Name_*"
+```
+
+Wildcard must be quoted. Version-suffixed bundles (e.g., `Agent_Name_v1`) are immutable snapshots of published versions. They are read-only reference copies.
+
+### Retrieve the runtime entity graph
+
+```bash
+sf project retrieve start --json --metadata Agent:Agent_API_Name
+```
+
+The `Agent:` pseudo-type retrieves the runtime entities (Bot, BotVersion, GenAiPlannerBundle) created by publish. This does NOT include AiAuthoringBundle — use `AiAuthoringBundle:` for that.
+
+---
+
+## 8. Delete
+
+```bash
+sf project delete source --json --metadata AiAuthoringBundle:Agent_API_Name
+```
+
+- Deletes the AiAuthoringBundle from the org AND removes local source files.
+- Published agents cannot be fully deleted via CLI. The platform returns dependency errors. Use Salesforce Setup UI for published agent deletion.
+
+---
+
+## 9. Preview
+
+Preview runs the agent in a simulated or live environment for testing behavior before publishing.
+
+### Start a preview session
+
+```bash
+sf agent preview start --json --authoring-bundle Agent_API_Name
+```
+
+Returns a `sessionId` for subsequent send/end commands.
+
+### Send a message
+
+```bash
+sf agent preview send --json --authoring-bundle Agent_API_Name --session-id SESSION_ID -u "User message here"
+```
+
+- `--session-id`: From the `start` response.
+- `-u`: The user utterance (quoted).
+
+### End a preview session
+
+```bash
+sf agent preview end --json --authoring-bundle Agent_API_Name --session-id SESSION_ID
+```
+
+### Live preview (with real action execution)
+
+```bash
+sf agent preview start --json --authoring-bundle Agent_API_Name --use-live-actions
+```
+
+Add `--use-live-actions` to execute real backing logic instead of simulated responses. Live preview executes real Apex, Flows, and Prompt Templates in the org.
+
+### Preview published agents (post-publish workflow)
+
+**IMPORTANT:** Once your agent is published and activated, use `--api-name` instead of `--authoring-bundle`:
+
+```bash
+sf agent preview start --json --api-name Bot_API_Name
+sf agent preview send --json --api-name Bot_API_Name --session-id SESSION_ID -u "User message"
+sf agent preview end --json --api-name Bot_API_Name --session-id SESSION_ID
+```
+
+The `--api-name` flag uses the runtime API and provides more accurate results than the compiled authoring bundle. Published agents always execute real actions — do NOT pass `--use-live-actions` with `--api-name`.
+
+### Anti-pattern: bare preview command
+
+```bash
+# WRONG — interactive REPL, hangs in automation
+sf agent preview --authoring-bundle Agent_API_Name
+
+# CORRECT — programmatic start/send/end
+sf agent preview start --json --authoring-bundle Agent_API_Name
+```
+
+The bare `sf agent preview` command is an interactive REPL designed for humans. It cannot be used programmatically because automation cannot send the ESC key to exit.
+
+---
+
+## 10. Test
+
+### Create a test from a spec
+
+```bash
+sf agent test create --json --spec specs/Agent_API_Name-testSpec.yaml --api-name Test_Definition_Name --force-overwrite
+```
+
+- `--spec`: Path to the local YAML test spec file.
+- `--api-name`: The name for the AiEvaluationDefinition in the org.
+- `--force-overwrite`: Prevents interactive mode if the AiEvaluationDefinition already exists. Always include this flag.
+- This command automatically deploys the AiEvaluationDefinition to the org. Use `--preview` to generate locally without deploying.
+
+### Run a test
+
+```bash
+sf agent test run --json --api-name Test_Definition_Name --wait 5
+```
+
+- `--api-name`: The AiEvaluationDefinition name (set by `--api-name` during `test create`). NOT the Bot name.
+- `--wait 5`: Synchronous execution with 5-minute timeout. Without `--wait`, returns a job ID immediately.
+- Tests run against activated published agents only.
+
+### Check test results (async fallback)
+
+```bash
+sf agent test results --json --job-id JOB_ID
+```
+
+Only needed if `--wait` was not used or timed out.
+
+### Generate a test spec from existing metadata
+
+```bash
+sf agent generate test-spec --from-definition path/to/AiEvaluationDefinition-meta.xml --output-file specs/Agent_API_Name-testSpec.yaml
+```
+
+Reverse-engineers a YAML test spec from an existing AiEvaluationDefinition. Do NOT use `sf agent generate test-spec` without `--from-definition` — the bare command is interactive and cannot be used programmatically.
+
+---
+
+## 11. Open in Browser
+
+These commands open Agentforce Studio in the user's default browser. Do NOT use `--json` with these commands — JSON mode outputs the target URL but does not open the browser.
+
+### View all authoring bundles
+
+```bash
+sf org open authoring-bundle
+```
+
+### View a specific published agent
+
+```bash
+sf org open agent --api-name Bot_API_Name
+```
+
+Only works for published agents. DRAFT-only bundles must be opened via `sf org open authoring-bundle`.


### PR DESCRIPTION
@W-21341167@

adds skills directory for agentforce devlopment

when I followed the readme for local testing, with agentforce vibes installed, I don't see the command `Agentforce Vibes: Add Library` in the command prompt 
<img width="890" height="191" alt="Screenshot 2026-03-02 at 10 49 28 AM" src="https://github.com/user-attachments/assets/5a6fb5f1-df75-415a-be23-49b75e1b78fb" />
