### PR TITLE
Update skills for custom objects and fields

### DIFF
--- a/skills/salesforce-custom-field/SKILL.md
+++ b/skills/salesforce-custom-field/SKILL.md
@@ -42,6 +42,10 @@ Every generated field must include these tags:
 | `<description>` | Mandatory | State the business "why" behind the field |
 | `<inlineHelpText>` | Mandatory | Provide actionable guidance for the end-user. Must add value beyond the label (e.g., "Enter the value in USD including tax" instead of just "The amount") |
 
+### XML Comments — NEVER Before Root Element
+
+**NEVER place XML comments (`<!-- ... -->`) before the root `<CustomField>` element in metadata XML files.** Comments between the XML declaration and `<CustomField>` cause a `ConversionError` during deployment. Comments inside the root element are safe.
+
 ### External ID Configuration
 
 **Trigger:** If the user mentions "integration," "importing data," "external system ID," or "unique key from [System Name]," set `<externalId>true</externalId>`.
@@ -440,6 +444,7 @@ Formula fields that reference other fields will fail deployment if the reference
 
 | Error Message | Cause | Fix |
 |---------------|-------|-----|
+| `ConversionError: Invalid XML tags or unable to find matching parent xml file for CustomField` | XML comments placed before the root `<CustomField>` element | Remove XML comments (`<!-- ... -->`) that appear before `<CustomField>` in the `.field-meta.xml` file |
 | `Field [FieldName] does not exist. Check spelling.` | Referenced field does not exist or has not been deployed yet | Verify the referenced field exists and is deployed before this field |
 | `DUPLICATE_DEVELOPER_NAME` | Field fullName already exists on the object | Use a unique business-driven name |
 | `MAX_RELATIONSHIPS_EXCEEDED` | More than 2 Master-Detail or 15 Lookup fields on the object | Use Lookup for 3rd+ Master-Detail; review Lookup count |
@@ -455,6 +460,7 @@ Before generating CustomField XML, verify:
 - [ ] Does `<fullName>` use valid format and end in `__c`?
 - [ ] Are `<description>` and `<inlineHelpText>` both populated and meaningful?
 - [ ] Is `<label>` in Title Case?
+- [ ] Are there no XML comments (`<!-- ... -->`) before the root `<CustomField>` element? (Comments before the root element break SDR's parser)
 
 ### Master-Detail Field Checks ⭐ CRITICAL
 - [ ] Is `<required>` attribute ABSENT? (Master-Detail is always required)

--- a/skills/salesforce-custom-object/SKILL.md
+++ b/skills/salesforce-custom-object/SKILL.md
@@ -16,7 +16,9 @@ Use this skill when you need to:
 
 ## 1. Overview and Purpose
 
-This document defines the mandatory constraints for generating CustomObject metadata XML (`.object` file). The agent must verify these constraints before outputting XML to prevent Metadata API deployment errors.
+This document defines the mandatory constraints for generating CustomObject metadata XML (`.object-meta.xml` file). The agent must verify these constraints before outputting XML to prevent Metadata API deployment errors.
+
+**File extension:** `.object-meta.xml`
 
 ---
 
@@ -24,7 +26,7 @@ This document defines the mandatory constraints for generating CustomObject meta
 
 The following constraints must be true for the XML body to deploy successfully.
 
-**Note:** The API Name (fullName) is NOT a tag; it is the filename (e.g., `Vehicle__c.object`).
+**Note:** The API Name (fullName) is NOT a tag; it is the filename (e.g., `Vehicle__c.object-meta.xml`).
 
 ### Required Elements
 
@@ -145,7 +147,7 @@ Do not create more than **2 Master-Detail relationships** for a single object. I
 
 ### XML Root Element
 
-Do NOT include the `<fullName>` tag at the root of the `.object` XML file. The API name is derived from the filename.
+Do NOT include the `<fullName>` tag at the root of the `.object-meta.xml` file. The API name is derived from the filename.
 
 **❌ INCORRECT:**
 ```xml
@@ -159,7 +161,7 @@ Do NOT include the `<fullName>` tag at the root of the `.object` XML file. The A
 ```xml
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
   <label>Vehicle</label>
-  <!-- fullName comes from filename: Vehicle__c.object -->
+  <!-- fullName comes from filename: Vehicle__c.object-meta.xml -->
 </CustomObject>
 ```
 


### PR DESCRIPTION
1. Updated all file extension references from .object to .object-meta.xml
2. Added a new "XML Comments — NEVER Before Root Element" section warning that placing XML comments (<!-- ... -->) before the <CustomField> root element causes a ConversionError during deployment.