### PR TITLE
ci: simplify pull request validation triggers in skills workflow @W-21534193@

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,13 +2,6 @@ name: Validate Skills
 
 on:
   pull_request:
-    paths:
-      - 'skills/**'
-      - 'scripts/validate-skills.ts'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.nvmrc'
-      - '.github/workflows/validate-skills.yml'
 
 jobs:
   validate-skills:


### PR DESCRIPTION
## What changed
Removed path filters from the Validate Skills workflow so it runs on every PR instead of only when specific files change.
@W-21534193@


## Why
A path-filtered workflow can't be a required status check — GitHub blocks merges when a required check never runs (e.g. a README-only PR). Always running the workflow lets it be enforced as a branch protection rule.

## Notes
The existing if/else logic in the validate step already handles the non-skills case: when no skills/ files are in the diff it runs full corpus validation, which exits 0 in seconds.

