### PR TITLE
chore: add skip validate to sample sync action

### DIFF
--- a/.github/workflows/sync-react-samples.yml
+++ b/.github/workflows/sync-react-samples.yml
@@ -134,6 +134,7 @@ jobs:
             echo ""
             echo "${BODY}"
             echo "Same flow as running locally: \`npm install\` then the sync scripts."
+            echo "Below line is used in automated scripts to avoid internal SF validation on this PR"
             echo "[skip-validate-pr]"
             echo "EOFBODY"
           } >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What changed

Update the github action that syncs the sample projects to not require PR validation.  Since these are automated form updates in NPM WI will not be associated. 

## Why
Prevent fails of validation on automated PRs
[skip-validate-pr]
