### PR TITLE
chore: ensure we get the latest samples

### DIFF
--- a/.github/workflows/sync-react-samples.yml
+++ b/.github/workflows/sync-react-samples.yml
@@ -38,6 +38,10 @@ jobs:
         id: npm-version-b2e
         run: |
           LATEST=$(npm view @salesforce/webapp-template-app-react-sample-b2e-experimental version)
+          if [ -z "$LATEST" ]; then
+            echo "ERROR: npm view returned empty version for B2E package" >&2
+            exit 1
+          fi
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Read current synced B2E version
@@ -56,6 +60,10 @@ jobs:
         id: npm-version-b2x
         run: |
           LATEST=$(npm view @salesforce/webapp-template-app-react-sample-b2x-experimental version)
+          if [ -z "$LATEST" ]; then
+            echo "ERROR: npm view returned empty version for 2x package" >&2
+            exit 1
+          fi
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Read current synced B2X version
@@ -101,11 +109,11 @@ jobs:
 
       - name: Install latest B2E package
         if: steps.skip.outputs.skip != 'true' && steps.skip.outputs.b2e_changed == 'true'
-        run: npm install @salesforce/webapp-template-app-react-sample-b2e-experimental@${{ steps.npm-version-b2e.outputs.latest }}
+        run: npm install @salesforce/webapp-template-app-react-sample-b2e-experimental@latest
 
       - name: Install latest B2X package
         if: steps.skip.outputs.skip != 'true' && steps.skip.outputs.b2x_changed == 'true'
-        run: npm install @salesforce/webapp-template-app-react-sample-b2x-experimental@${{ steps.npm-version-b2x.outputs.latest }}
+        run: npm install @salesforce/webapp-template-app-react-sample-b2x-experimental@latest
 
       - name: Sync B2E sample
         if: steps.skip.outputs.skip != 'true'


### PR DESCRIPTION
## What changed

Updated github action for syncing react samples projects. 
 
## Why

Discovered that updates from the sample project was not getting copied on automatic PRs.   Was due to package-lock and npm not adhering to laster package.json.

## Notes

GHA only change for samples. 
Here's an example where the PR wasn't updating the sample content https://github.com/forcedotcom/afv-library/pull/59/changes
[skip-validate-pr]
