### PR TITLE
@W-21648052 Include new Context API MCP server

### DIFF
--- a/rules/a4v-expert-global-rule.md
+++ b/rules/a4v-expert-global-rule.md
@@ -1,69 +1,42 @@
 # Rule: Salesforce Metadata Generation
 
-## Objective
-Enforce: **skill load → API context → file generation** for all Salesforce metadata.
-
 ## Constraints
 
-1. **Never write** without both: metadata type skill loaded AND `get_metadata_api_context` called for that type
-2. **One type at a time** - complete full cycle before next type
-3. **One type per API call** - no batching
-4. **Child types need own context** - if adding any child metadata inside a parent metadata's file, load skill and call `get_metadata_api_context` for each child type (e.g. CustomField inside CustomObject) separately; don't rely on the parent's schema for creating child metadata
+1. **Never write** without both: metadata type skill loaded AND context tools from `salesforce-api-context` MCP server called for that type.
+2. **One type at a time** - finish one type before starting the next
+3. **One type per API call** - do not batch types when calling MCP tools
+4. **Child types need their own context** - if adding any child metadata inside a parent metadata's file, treat the child metadata seperately; don't rely on the parent's schema for creating child metadata
 5. **Max one clarifying question** before starting
 
 ## Workflow
 
-### 1. Detect Intent
-- **Solution skill** (end-to-end capability like lex/react app) → Solution Path
-- **Direct metadata** (specific fields/objects/pages) → Direct Path
-
-### 2. Solution Path
-1. Load solution skill, extract metadata type sequence
-2. For each type, execute loop (a-e below)
-3. Proceed to Step 3
-
-### 2. Direct Path
-1. Identify all needed types
-2. For each type in dependency order, execute loop (a-e below)
-3. Proceed to Step 3
-
-### Loop (a-e) - Execute for Each Type
+### Step 1: Metadata Loop - Execute for Each Type
+For each type, execute loop below
 
 **a. Load Skill**
-- Load metadata type skill once (not per record)
-- If no skill exists, continue with API context only
+- Load the metadata type skill once (not per record)
 
-**b. Call API Context**
-- `get_metadata_api_context("TypeName")` - single type only
-- Wait for response
+**b. Get entity context**
+- Use these tools from `salesforce-api-context` MCP server for entity context. 
+    - `get_metadata_type_sections`
+    - `get_metadata_type_context`
+    - `get_metadata_type_fields`
+    - `get_metadata_type_fields_properties`
+    - `search_metadata_types`
 
-**c. Pre-Write Gate**
-- Before EVERY write: confirm API context called for this type
-- If no → stop and call now
 
-**d. Generate Files**
-- Use skill constraints + API context
-- Generate all records for this type now
-
-**e. Checkpoint**
-- Skill loaded? API context called? All files written?
-- Only proceed to next type when all true
-
-### 3. Deploy Verification
+### Step 2. Verify deployment
 ```bash
 sf project deploy start --dry-run -d "force-app/main/default" --target-org <alias> --test-level NoTestRun --wait 10 --json
 ```
 On failure: attempt to fix the errors and re-run, retrying up to a maximum of 3 times until it succeeds.
 
+
 ## Anti-Patterns
 
 | Don't | Why | Do |
 |-------|-----|-----|
-| Write without API context | Missing schema validation | Call API context before first write |
 | Reload skill per record | Wastes tokens | Load once per type |
-| Skip API context for later types | No schema for those types | Call for EVERY type |
 | Skip metadata skills | Missing platform constraints | Load skill for every type |
 | Ask 3+ questions | Token waste | Max 1 question |
-| Skip solution skill gates | Wrong artifacts | Follow all mandatory gates |
-| Write despite missing checkpoint | Aware violation | Stop and complete missing step |
-| Batch types in API call | Violates constraint #3 | One type per call |
+| Batch types in calls to MCP tools | Violates constraint | One type per call |


### PR DESCRIPTION
Updated the global rules file for Experts. Added support for the new API Context MCP server. Also removed some extraneous instructions. 
@W-21648052@

## What changed

Replaced instructions for old API Context server with those for the new one in the global Experts rule file. 
No changes in skills. 

## Why

The old server/tools are deprecated and replaced by the new server & tools. 

## Notes


---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [ ] Clear goal statement
- [ ] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
