### PR TITLE
feat: Add switching-org skill @W-21436488@

### DIFF
--- a/skills/switching-org/SKILL.md
+++ b/skills/switching-org/SKILL.md
@@ -6,10 +6,6 @@ metadata:
   version: "1.0"
 ---
 
-# switching-org
-
-Switches the active Salesforce org (default target-org) using the Salesforce CLI (sf). Supports either a username or an alias.
-
 ## Steps
 
 1. Identify the org: the user provides a username or alias (`orgIdentifier`). If not provided, run `sf org list` to show authenticated orgs and ask the user which one to use.
@@ -21,15 +17,12 @@ Switches the active Salesforce org (default target-org) using the Salesforce CLI
    - If this fails, report the error and suggest running `sf org login web` if the org may not be authorized.
 3. Verify:
    - `sf config get target-org --json`
-   - If successful, confirm to the user, e.g.: `Switched org (local): my-scratch-org` or `Switched org (global): user@example.com`
+   - Note: the JSON output does not include a scope/location field — it cannot confirm whether the value is local or global. Confirm the value only, e.g.: `target-org is now set to: <value>`
    - If it fails, report the error and advise running `sf config get target-org`.
-
-## Official Documentation
-
-- Salesforce CLI config (unified) reference (sf):
-  https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_config_commands_unified.htm#cli_reference_config_set_unified
 
 ## Notes
 
 - Unified CLI uses keys like `target-org` and `target-dev-hub`. Legacy sfdx keys (`defaultusername`, `defaultdevhubusername`) are deprecated in this context.
 - The sf CLI does not have `--local` or `--scope` flags for config set. Local scope is the default behavior.
+- If the org does not change after setting the config, check whether `SF_TARGET_ORG` is set — environment variables override config values.
+- Salesforce CLI config (unified) reference: https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_config_commands_unified.htm#cli_reference_config_set_unified


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

@W-21436488@

## What changed

Adds a `switching-org` skill (`skills/switching-org/SKILL.md`) that uses the SF CLI to switch the default org (`sf config set`).

## Why

Users reported that when prompted to switch orgs, the agent tries to use the sf cli but uses incorrect commands. This skill provides a guided, CLI-only workflow that uses `sf config set target-org` and then confirms the switch via `sf config get target-org`.

Users can and should switch orgs using the org picker that pops up when the username is clicked in the status bar - this PR is intended to help respond to this explicit request from Users for the agent to take action to make the switch.

## Notes

- Defaults to local (project) scope; global scope only when the user explicitly requests it.
- No sub-directories — the skill is self-contained in `SKILL.md`.
- Tested manually against both Pro and Core models.

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ✅