### PR TITLE
fix: correct .gitignore to track sample lib/ folders @W-21361802@

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,10 +128,8 @@ venv.bak/
 
 # React sample templates: track internal `src/lib` utility modules
 # These rules override the global `lib/` ignore in the Python section above.
-!samples/webapp-template-app-react-sample-b2x-experimental/force-app/main/default/webapplications/appreactsampleb2x/src/lib/
-!samples/webapp-template-app-react-sample-b2x-experimental/force-app/main/default/webapplications/appreactsampleb2x/src/lib/**
-!samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/appreactsampleb2e/src/lib/
-!samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/appreactsampleb2e/src/lib/**
+!samples/**/lib/
+!samples/**/lib/**
 
 # IDEs and Editors
 .vscode/

--- a/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/constants.ts
+++ b/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/constants.ts
@@ -1,0 +1,60 @@
+/**
+ * Application-wide constants.
+ */
+
+import type { PaginationConfig } from "../features/object-search/hooks/useObjectSearchParams";
+
+export const PAGE_SIZE_LIST = 12;
+export const DASHBOARD_MAINTENANCE_LIMIT = 5;
+
+export const PROPERTY_FILTER_EXCLUDED_FIELD_PATHS = new Set([
+	"CreatedDate",
+	"Hero_Image__c",
+	"Year_Built__c",
+	"Available_Date__c",
+]);
+
+export const MAINTENANCE_WORKER_FILTER_EXCLUDED_FIELD_PATHS = new Set<string>([]);
+export const MAINTENANCE_FILTER_EXCLUDED_FIELD_PATHS = new Set(["Scheduled__c"]);
+export const APPLICATION_FILTER_EXCLUDED_FIELD_PATHS = new Set<string>([]);
+
+export const MAINTENANCE_WORKER_OBJECT_API_NAME = "Maintenance_Worker__c" as const;
+
+export const FALLBACK_LABEL_PROPERTIES_PLURAL = "Properties";
+export const FALLBACK_LABEL_MAINTENANCE_PLURAL = "Maintenance Requests";
+export const FALLBACK_LABEL_MAINTENANCE_WORKERS_PLURAL = "Maintenance Workers";
+export const FALLBACK_LABEL_APPLICATIONS_PLURAL = "Applications";
+
+export const PROPERTY_OBJECT_API_NAME = "Property__c" as const;
+export const MAINTENANCE_OBJECT_API_NAME = "Maintenance_Request__c" as const;
+export const APPLICATION_OBJECT_API_NAME = "Application__c" as const;
+
+export const SEARCHABLE_OBJECTS = [
+	{
+		objectApiName: "Property__c" as const,
+		path: "/properties",
+		fallbackLabelPlural: FALLBACK_LABEL_PROPERTIES_PLURAL,
+	},
+	{
+		objectApiName: "Maintenance_Request__c" as const,
+		path: "/maintenance/requests",
+		fallbackLabelPlural: FALLBACK_LABEL_MAINTENANCE_PLURAL,
+	},
+	{
+		objectApiName: MAINTENANCE_WORKER_OBJECT_API_NAME,
+		path: "/maintenance/workers",
+		fallbackLabelPlural: FALLBACK_LABEL_MAINTENANCE_WORKERS_PLURAL,
+	},
+	{
+		objectApiName: "Application__c" as const,
+		path: "/applications",
+		fallbackLabelPlural: FALLBACK_LABEL_APPLICATIONS_PLURAL,
+	},
+] as const;
+
+export type SearchableObjectConfig = (typeof SEARCHABLE_OBJECTS)[number];
+
+export const PAGINATION_CONFIG: PaginationConfig = {
+	defaultPageSize: 6,
+	validPageSizes: [6, 12, 24, 48],
+};

--- a/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/routeConfig.ts
+++ b/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/routeConfig.ts
@@ -1,0 +1,35 @@
+/**
+ * Central route configuration for list pages and navigation.
+ * Use these paths for links and search redirects to avoid duplication.
+ */
+export const PATHS = {
+	HOME: "/",
+	PROPERTIES: "/properties",
+	MAINTENANCE_REQUESTS: "/maintenance/requests",
+	MAINTENANCE_WORKERS: "/maintenance/workers",
+	APPLICATIONS: "/applications",
+} as const;
+
+export interface ListPageRoute {
+	path: string;
+	label: string;
+	searchParamKey?: string;
+}
+
+/** List pages that appear in the Home search object dropdown and in nav */
+export const LIST_PAGE_ROUTES: Record<string, ListPageRoute> = {
+	properties: { path: PATHS.PROPERTIES, label: "Properties", searchParamKey: "q" },
+	maintenance_requests: {
+		path: PATHS.MAINTENANCE_REQUESTS,
+		label: "Maintenance Requests",
+		searchParamKey: "q",
+	},
+	maintenance_workers: {
+		path: PATHS.MAINTENANCE_WORKERS,
+		label: "Maintenance Workers",
+		searchParamKey: "q",
+	},
+	applications: { path: PATHS.APPLICATIONS, label: "Applications", searchParamKey: "q" },
+} as const;
+
+export type ListPageKey = keyof typeof LIST_PAGE_ROUTES;

--- a/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/utils.ts
+++ b/samples/webapp-template-app-react-sample-b2e-experimental/force-app/main/default/webapplications/propertymanagementapp/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/samples/webapp-template-app-react-sample-b2x-experimental/force-app/main/default/webapplications/propertyrentalapp/src/lib/utils.ts
+++ b/samples/webapp-template-app-react-sample-b2x-experimental/force-app/main/default/webapplications/propertyrentalapp/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- The `.gitignore` had negation rules for `lib/` using incorrect webapp folder names (`appreactsampleb2e`/`appreactsampleb2x`), so the sample `lib/` directories were silently git-ignored despite being copied by the sync scripts.
- Replaced the hardcoded paths with a simpler `!samples/**/lib/` glob pattern that is resilient to future webapp name changes.
- Adds the previously-ignored `lib/` utility files for both B2E and B2X samples.

## Test plan
- [x] Verified `git status` shows the `lib/` folders as tracked after the fix
- [x] Verified `git check-ignore` confirms the negation rules match correctly
- [x] Confirm the sync scripts (`npm run sync-react-b2e-sample` / `sync-react-b2x-sample`) still produce a clean working tree after re-running

@W-21361802@