### PR TITLE
W-21685788: skill selection rule

### DIFF
--- a/rules/a4v-expert-global-rule.md
+++ b/rules/a4v-expert-global-rule.md
@@ -17,6 +17,17 @@ Enforce: **skill load -> API context -> file generation** for all Salesforce met
 - Search available skills and load the best-matching app-level skill first when the request asks for a Lightning app, end-to-end solution, or a business app spanning multiple metadata types.
 - Search available skills and load the best-matching per-type metadata skill first when the request targets individual metadata components.
 
+## Task Planning and Skill Re-evaluation
+
+Before starting metadata generation, create a short plan with clearly separated, atomic tasks.
+
+- Each task must include `task=<name> selected_skill=<exact-skill-name|none>`.
+- Determine the most appropriate skill before each task.
+- Prefer specialized skills over general skills when both are available.
+- Re-evaluate the selected skill after each task completes.
+- Switch skills when a different skill is better suited.
+- Do not reuse the same skill across unrelated tasks unless it is still the best match.
+
 ## Initial Gate
 
 Never create files or generate metadata before completing skill selection.
@@ -83,6 +94,7 @@ For each metadata type in scope, whether identified by an app-level skill or req
 | Never skip the API context attempt for any type | No schema for those types | Attempt API context for EVERY type |
 | Never write using API context alone without a loaded skill | Missing platform constraints | Stop and ask for guidance when no skill exists |
 | Never write without recorded `mcp_tools` or `mcp=unavailable` | No evidence of MCP gate completion | Record MCP tool usage before any write |
+| Never keep one skill for unrelated tasks | Poor task-skill fit | Re-evaluate and switch skills at each task boundary |
 | Never ask more than 1 clarifying question | Token waste | Max 1 question |
 | Never skip any gate in the loop (skill load, API context, pre-write, checkpoint) | Wrong artifacts | Follow all mandatory gates in the loop (a-e) |
 | Never write with a missing checkpoint | Aware violation | Stop and complete missing step |

--- a/rules/skill-selection-rule.md
+++ b/rules/skill-selection-rule.md
@@ -1,0 +1,19 @@
+# SKILL SELECTION RULE
+
+## Task-First Planning
+- Create a plan with clearly separated tasks.
+- Each task must be small and atomic.
+- For each task, explicitly state the skill to use (for example: typescript, api, testing, performance).
+- Execute each task with the most appropriate skill.
+
+## Execution Rules
+- Re-evaluate the skill before every task.
+- Switch skills when needed.
+- Do not reuse the same skill across unrelated tasks.
+
+## Selection Behavior
+- Before each task, determine the most appropriate skill.
+- Do not stay locked into a single skill for the entire plan.
+- Switch skills when a different skill is better suited.
+- Prefer specialized skills over general ones.
+- Re-evaluate skill choice after completing each task.


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

The added rule, makes the agent pick the best skill for each task step, instead of using one skill for everything. it improves plan quality, skill-task fit, and output accuracy by forcing per-task skill re-evaluation and skill switching when appropriate.

## Why

It solves the common failure mode where execution quality drops because the agent:

- stays locked into an initial skill,
- applies a generic skill to specialized work,
- or reuses the same skill across unrelated tasks.

When testing AFV, there's only one skill selected for the whole process. depending on the selected skill, the task at hand went well or bad. Example: if using salesforce data as skill, then the app creation went bad, if using app creation, then the data part was bad.

## Notes

I added the new rule (the one im testing with); i also tried to add it for a4v-global-rule; i will test the flow with the a4v-global-rules modification.

@W-21685788@
---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
