### PR TITLE
updating routing skill to account for base name

### DIFF
--- a/skills/generating-webapp-ui/SKILL.md
+++ b/skills/generating-webapp-ui/SKILL.md
@@ -43,6 +43,16 @@ Before finishing, confirm: Did I update `appLayout.tsx` with real nav items and 
 
 Use a single router package. With `createBrowserRouter` / `RouterProvider`, all imports must come from `react-router` (not `react-router-dom`).
 
+If the app uses a client-side router (React Router, Remix Router, Vue Router, etc.), always derive basename / basepath / base from the document's <base href> tag at runtime. Never hardcode the basename:
+
+​```js
+const basename = document.querySelector('base')
+  ? new URL(document.querySelector('base').href).pathname.replace(/\/$/, '')
+  : '/';
+
+const router = createBrowserRouter(routes, { basename });
+​```
+
 ### Component Library and Styling
 
 - **shadcn/ui** for components: `import { Button } from '@/components/ui/button';`


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

Updated the `generating-webapp-ui` skill's routing instructions to:
- Add a `basename` derivation pattern that reads from the document's `<base href>` tag at runtime

## Why

A vibe-coded app shipped with `@remix-run/router` despite the skill discouraging it, the previous instruction was too vague to reliably prevent it. Caught in production. The basename gap was a separate latent issue: nothing in the skill enforced that routers respect `<base href>`, leaving apps broken when deployed to a subpath.

## Notes

The basename snippet is prescriptive on purpose (exact API call, trailing-slash strip) so the model doesn't generate a subtly broken variant.

No follow-up PRs needed. Both fixes are self-contained in the routing section of `SKILL.md`.

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)