### PR TITLE
W-21660521 feat: Agentforce Vibes - Unable to assign agent access in permission set

### DIFF
--- a/skills/generating-permission-set/SKILL.md
+++ b/skills/generating-permission-set/SKILL.md
@@ -154,6 +154,21 @@ Specify license requirements and record type visibility:
     <default>true</default>
 </recordTypeVisibilities>
 ```
+## Step 8: Set Agent Access (Optional)
+                                              
+Enable access to Agentforce Employee Agents for users assigned to this permission set:
+
+<agentAccesses>
+    <agentName>Sales_Assistant_Agent</agentName>
+    <enabled>true</enabled>
+</agentAccesses>
+
+Field requirements:
+- agentName (Required): The developer name of the employee agent
+- enabled (Required): Set to true to grant access, false to deny
+
+Important:
+- Agent names must match existing Agentforce Employee Agent developer names
 
 ## Validation Checklist
 


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)
W-21660521

## What changed

<!-- Briefly describe what skill(s) were added, updated, or removed. -->
Added instructions to generating-permission-set to generate permission sets with agent accesses

## Why

<!-- What gap does this fill, or what problem does it solve? -->
This allows us to generate permission sets that grant access to agents

## Notes
When testing, I ran into issues creating and deploying a Agentforce Employee Agent using Vibes, so I manually created an agent in the app named Station Commander.
I used this utterance: "Assign Station Commander agent access in the permission set"
Do not tell Vibes to assign agent access to a user, that is not possible via metadata

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [ ] Clear goal statement
- [ ] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
