### PR TITLE
fix: update details for PR title 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ GitHub will display a **Compare & pull request** button.
 Once your branch is pushed to your fork, you can open a Pull Request
 (PR) to propose merging your changes into this repository.
 
+Unsure that your PR title is prefixed with  `feat:` or `fix:` as those will result in an update to the change log 
+and inclusion in SF tooling. 
+
 ### 6.1 Start the Pull Request
 
 **Option A --- From the GitHub banner (easiest)**\


### PR DESCRIPTION
## What changed

- Update contributing doc to include info for correct PR titles. 

## Why

Ensure inclusion in changelog and release of skills. 


[skip-validate-pr]