### PR TITLE
fix: derive router basename from base href at runtime @W-21338965@

### DIFF
--- a/skills/building-ui-bundle-frontend/SKILL.md
+++ b/skills/building-ui-bundle-frontend/SKILL.md
@@ -43,6 +43,15 @@ Before finishing, confirm: Did I update `appLayout.tsx` with real nav items and 
 
 Use a single router package. With `createBrowserRouter` / `RouterProvider`, all imports must come from `react-router` (not `react-router-dom`).
 
+If the app uses a client-side router (React Router, Remix Router, Vue Router, etc.), always derive basename / basepath / base from the document's `<base href>` tag at runtime. Never hardcode the basename:
+
+```js
+const basename = document.querySelector('base')
+  ? new URL(document.querySelector('base').href).pathname.replace(/\/$/, '')
+  : '/';
+const router = createBrowserRouter(routes, { basename });
+```
+
 ### Component Library and Styling
 
 - **shadcn/ui** for components: `import { Button } from '@/components/ui/button';`


### PR DESCRIPTION
## Summary
- Adds guidance to the `building-ui-bundle-frontend` skill to always derive the client-side router `basename` from the document's `<base href>` tag at runtime instead of hardcoding it
- Includes a code snippet showing the recommended pattern for `createBrowserRouter`

## Test plan
- [x] Verify the SKILL.md renders correctly in markdown
- [x] Confirm the code snippet is syntactically correct

@W-21338965@