### PR TITLE
fix: replace deprecated sf ui-bundle generate CLI command @W-21338965@

### DIFF
--- a/skills/building-ui-bundle-app/SKILL.md
+++ b/skills/building-ui-bundle-app/SKILL.md
@@ -43,7 +43,7 @@ Build a complete, deployable Salesforce React UI bundle application from a natur
 ### Phase 1: Scaffolding (Foundation)
 
 ```
-UI Bundle scaffold (sf ui-bundle generate)
+UI Bundle scaffold (sf template generate ui-bundle)
     v
 Install dependencies (npm install)
     v
@@ -214,7 +214,7 @@ Execute each phase sequentially. Complete all steps within a phase before moving
 
 **Phase 1 -- Scaffolding**
 - 1. Load skill: Invoke `generating-ui-bundle-metadata`
-- 2. Execute: Run `sf ui-bundle generate`, install dependencies (`npm install`), configure meta XML, ui-bundle.json, and CSP trusted sites
+- 2. Execute: Run `sf template generate ui-bundle`, install dependencies (`npm install`), configure meta XML, ui-bundle.json, and CSP trusted sites
 - 3. Verify: Confirm directory structure and metadata files exist
 - 4. Checkpoint: UI bundle scaffold is ready -- proceed to Phase 2
 

--- a/skills/generating-ui-bundle-metadata/SKILL.md
+++ b/skills/generating-ui-bundle-metadata/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: generating-ui-bundle-metadata
-description: "Scaffold new Salesforce UI bundles and configure their metadata — sf ui-bundle generate, UIBundle bundles (meta XML, ui-bundle.json with routing/headers/outputDir), and CSP Trusted Sites for external domains. Use whenever creating a new UI bundle, setting up UI bundle metadata structure, configuring routing or headers, setting outputDir, adding external domains that need CSP registration, or editing bundle configuration. Triggers on: create UI bundle, create ui-bundle, new app, sf ui-bundle generate, metadata, ui-bundle.json, CSP, trusted site, bundle configuration, meta XML, routing config, external domain, headers config, outputDir."
+description: "Scaffold new Salesforce UI bundles and configure their metadata — sf template generate ui-bundle, UIBundle bundles (meta XML, ui-bundle.json with routing/headers/outputDir), and CSP Trusted Sites for external domains. Use whenever creating a new UI bundle, setting up UI bundle metadata structure, configuring routing or headers, setting outputDir, adding external domains that need CSP registration, or editing bundle configuration. Triggers on: create UI bundle, create ui-bundle, new app, sf template generate ui-bundle, metadata, ui-bundle.json, CSP, trusted site, bundle configuration, meta XML, routing config, external domain, headers config, outputDir."
 ---
 
 # UI Bundle Metadata
 
 ## Scaffolding a New UI Bundle
 
-Use `sf ui-bundle generate` to create new apps — not create-react-app, Vite, or other generic scaffolds.
+Use `sf template generate ui-bundle` to create new apps — not create-react-app, Vite, or other generic scaffolds.
 
 **UI bundle name (`-n`):** Alphanumerical only — no spaces, hyphens, underscores, or special characters. Example: `CoffeeBoutique` (not `Coffee Boutique`).
 


### PR DESCRIPTION
## Summary
- Replaces all references to the deprecated `sf ui-bundle generate` command with `sf template generate ui-bundle` across skills
- Updated files: `skills/building-ui-bundle-app/SKILL.md` and `skills/generating-ui-bundle-metadata/SKILL.md`

## Test plan
- [x] Verify no remaining references to `sf ui-bundle generate` exist in the repo (`grep -r "sf ui-bundle" skills/`)
<img width="679" height="225" alt="image" src="https://github.com/user-attachments/assets/b2132b6b-8166-4288-b02a-2a6d5d873d7f" />

- [x] Confirm the new command `sf template generate ui-bundle` is correct per current SF CLI docs
Confirmed with KJ in slack 
@W-21338965@