### PR TITLE
@W-21818163 T/experience sites platform/w 21818163/leave app space blank if web app does not exist

### DIFF
--- a/skills/generating-ui-bundle-site/docs/configure-metadata-digital-experience.md
+++ b/skills/generating-ui-bundle-site/docs/configure-metadata-digital-experience.md
@@ -3,7 +3,7 @@
 ## Purpose
 These configuration files create **net-new, default** DigitalExperience content records (`sfdc_cms__site` type) for a Digital Experience React Site. They are not intended to edit or modify existing DigitalExperience content. Use these templates only when provisioning a brand-new React site.
 
-The `appContainer: true` field in `content.json` is what makes this a React site rather than a standard LWR site. The `appSpace` field should **be left empty if the WebApplication metadata record does not already exist**. When the WebApplication exists, populate the `appSpace` value following the format `{namespace}__{developerName}` to match the deployed `WebApplication` metadata record.
+The `appContainer: true` field in `content.json` is what makes this a React site rather than a standard LWR site. The `appSpace` field should **be left empty if the UIBundle metadata record does not already exist**. When the UIBundle exists, populate the `appSpace` value following the format `{namespace}__{developerName}` to match the deployed `UIBundle` metadata record.
 
 ## File Location
 The DigitalExperience directory contains only `_meta.json` and `content.json`. Do not create any directories other than `sfdc_cms__site` inside the bundle.
@@ -37,4 +37,4 @@ digitalExperiences/site/{siteName}1/sfdc_cms__site/{siteName}1/content.json
 }
 ```
 
-**Note:** Leave `appSpace` empty (`""`) if the WebApplication does not exist. If the WebApplication metadata record is already deployed, populate it with `"{appNamespace}__{appDevName}"`.
+**Note:** Leave `appSpace` empty (`""`) if the UIBundle does not exist. If the UIBundle metadata record is already deployed, populate it with `"{appNamespace}__{appDevName}"`.


### PR DESCRIPTION
@W-21818163@

**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

<!-- Briefly describe what skill(s) were added, updated, or removed. -->

## Why

<!-- What gap does this fill, or what problem does it solve? -->

## Notes

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [ ] Clear goal statement
- [ ] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
