### PR TITLE
fix: trigger ui-bundle skill for React app prompts @W-21916680@

### DIFF
--- a/skills/building-ui-bundle-app/SKILL.md
+++ b/skills/building-ui-bundle-app/SKILL.md
@@ -3,7 +3,7 @@ name: building-ui-bundle-app
 description: "MUST activate when the user wants to build, create, or generate a React application, React app, web application, single-page application (SPA), or frontend application — even if no project files exist yet. MUST also activate when the project contains a uiBundles/*/src/ directory or sfdx-project.json and the prompt says create, build, construct, or generate a new app, site, or page from scratch — even if the prompt also describes visual styling. MUST also activate when the task spans more than one ui-bundle skill. Use this skill when building a complete app end-to-end. This is the orchestrator that coordinates scaffolding, features, data access, frontend UI, integrations, and deployment in the correct dependency order. Without it, phases execute out of order and the app breaks. Do NOT use for Lightning Experience apps with custom objects (use generating-lightning-app). Do NOT use for single-concern edits to an existing page (use building-ui-bundle-frontend)."
 metadata:
   version: "1.0"
-  related-skills: generating-ui-bundle-metadata, generating-ui-bundle-features, using-ui-bundle-salesforce-data, building-ui-bundle-frontend, implementing-ui-bundle-agentforce-conversation-client, implementing-ui-bundle-file-upload, deploying-ui-bundle, generating-experience-react-site
+  related-skills: generating-ui-bundle-metadata, generating-ui-bundle-features, using-ui-bundle-salesforce-data, building-ui-bundle-frontend, implementing-ui-bundle-agentforce-conversation-client, implementing-ui-bundle-file-upload, deploying-ui-bundle, generating-ui-bundle-site
 ---
 
 # Building a UI Bundle App


### PR DESCRIPTION
## Summary
- Adds React-specific trigger language ("React application", "React app", "web application", "SPA", "frontend application") to the `building-ui-bundle-app` skill description
- Ensures the ui-bundle orchestrator activates for greenfield prompts like "I want to build a react application" even without existing project files

## Test plan
- [x] Verify prompts like "I want to build a react application" trigger `building-ui-bundle-app`
- [x] Verify existing triggers (project with `uiBundles/*/src/`) still work
- [x] Verify single-concern edits still route to `building-ui-bundle-frontend`
- [x] Run `npx tsx scripts/validate-skills.ts` — all 29 skills pass

@W-21916680@