### PR TITLE
feat: Add skill to guide agent to use ADK tools in DX MCP @W-22047442

### DIFF
--- a/skills/generating-lwc/SKILL.md
+++ b/skills/generating-lwc/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: generating-lwc
+description: "Enforce use of Salesforce LWC MCP tools before generating any Lightning Web Component code, examples, or tests. Use when creating, modifying, reviewing, optimizing, migrating, or generating LWC code or tests, including accessibility, wire adapters, LDS/UI API, GraphQL in LWC, SLDS usage, and mobile device capabilities."
+---
+
+# Skill: lwc-development
+Intent
+- Enforce HARD REQUIREMENT to use Salesforce LWC MCP tools before emitting any LWC code, examples, or tests.
+Trigger Conditions
+- Any request that asks to create, modify, review, optimize, migrate, or generate Lightning Web Components (LWC) code or tests.
+- Mentions or implications of LWC files: .js, .html, .css, .xml (.js-meta.xml), wire adapters, LDS/UI API, GraphQL in LWC, SLDS usage in LWC.
+- Mobile LWC device capabilities: Barcode Scanner, Contacts, Biometrics, NFC, Location, Geofencing, Document Scanner, AR Space Capture, App Review.
+Hard Requirements
+Before any LWC code is produced, the agent MUST call one or more of these MCP tools based on scope:
+   - General LWC guidance:
+     - guide_lwc_development (mode=analysis for discovery; mode=fix if user provided code to be corrected)
+     - guide_lwc_best_practices (when the goal is guidance, patterns, or conventions)
+     - guide_lws_security (when security/LWS concerns are involved)
+     - guide_design_general (when SLDS/UX questions exist)
+   - LDS / UI API:
+     - explore_lds_uiapi (to retrieve adapter API or UI API types)
+     - guide_lds_development (general LDS guidance)
+     - guide_lds_referential_integrity (referential integrity guidance)
+     - guide_lds_data_consistency (data consistency patterns)
+   - GraphQL via LDS:
+     - guide_lds_graphql (MUST be called; only use its sub-tools through this orchestrator)
+       - Sub-tools are NOT to be called directly: create_lds_graphql_read_query, create_lds_graphql_mutation_query, fetch_lds_graphql_schema, test_lds_graphql_query
+   - Mobile features (call the specific tool BEFORE producing code):
+     - create_mobile_lwc_barcode_scanner
+     - create_mobile_lwc_contacts
+     - create_mobile_lwc_biometrics
+     - create_mobile_lwc_document_scanner
+     - create_mobile_lwc_location
+     - create_mobile_lwc_geofencing
+     - create_mobile_lwc_nfc
+     - create_mobile_lwc_ar_space_capture
+     - create_mobile_lwc_app_review
+   - Testing and quality:
+     - orchestrate_lwc_component_testing (for end-to-end Jest test generation/validation)
+     - review_lwc_jest_tests (feedback-only)
+     - run_lwc_accessibility_jest_tests (Sa11y guidance and commands)
+     - validate_and_optimize (UI component quality assessment runbook)
+Operational Flow
+- Step 1: Classify scope:
+  - Mobile capability? Map to the specific mobile MCP tool(s).
+  - Data via LDS/UI API? Plan explore_lds_uiapi and/or guide_lds_development.
+  - GraphQL? Plan guide_lds_graphql (and follow only its orchestrated sub-tools).
+  - Otherwise: guide_lwc_development (mode=analysis by default).
+- Step 2: Invoke mapped tools in precedence until all applicable areas are covered:
+  1) General LWC (guide_lwc_development / best practices / security / design)
+  2) LDS/UI API (explore_lds_uiapi and/or guide_lds_development; add referential_integrity/data_consistency as needed)
+  3) GraphQL (guide_lds_graphql; use sub-tools only through its workflow)
+  4) Mobile feature tool(s)
+  5) Testing/quality tools, if user requested tests or quality validation
+- Step 3: If tests requested, use orchestrate_lwc_component_testing or review_lwc_jest_tests as appropriate, and include accessibility (run_lwc_accessibility_jest_tests) guidance if applicable.
+Guardrails
+- Prefer guide_lwc_development mode=analysis when the user request is ambiguous; switch to mode=fix when correcting provided code.

--- a/skills/generating-lwc/SKILL.md
+++ b/skills/generating-lwc/SKILL.md
@@ -17,6 +17,8 @@ Before any LWC code is produced, the agent MUST call one or more of these MCP to
      - guide_lwc_best_practices (when the goal is guidance, patterns, or conventions)
      - guide_lws_security (when security/LWS concerns are involved)
      - guide_design_general (when SLDS/UX questions exist)
+   - Accessibility Guidance
+     - guide_copmonent_accessibility (to audit/fix components for accessibility compliance)
    - LDS / UI API:
      - explore_lds_uiapi (to retrieve adapter API or UI API types)
      - guide_lds_development (general LDS guidance)

--- a/skills/generating-lwc/SKILL.md
+++ b/skills/generating-lwc/SKILL.md
@@ -38,7 +38,6 @@ Before any LWC code is produced, the agent MUST call one or more of these MCP to
    - Testing and quality:
      - orchestrate_lwc_component_testing (for end-to-end Jest test generation/validation)
      - review_lwc_jest_tests (feedback-only)
-     - run_lwc_accessibility_jest_tests (Sa11y guidance and commands)
      - validate_and_optimize (UI component quality assessment runbook)
 Operational Flow
 - Step 1: Classify scope:


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

@W-22047442@

## What changed

Added a skill to guide the agent to invoke the MCP tools for LWC development available in the DX MCP

## Why

The team noticed that since AFV has adopted skills, the MCP tools to guide LWC code generation were no longer being called.

## Notes

Our goal is to migrate our MCP tool offerings into skills in the near future. This skill is to route the agent to the right tool in the interim.

Testing that lead us to this:

### Out of the box config (DX MCP enabled, other normal MCPs enabled, all default skills enabled)
Prompt: `Write me a todo app in LWC. keep it simple.`
Result: does **NOT** use MCP tool

Prompt: `Write me a todo app in LWC. keep it simple. Use the tools available for writing LWC code.`
Result: does **NOT** use MCP tool

Prompt: `Write me a todo app in LWC. keep it simple. you MUST use the MCP tools available for writing LWC code.`
Result: DOES use MCP tool

_So right now the user must explicitly request that MCP tools are used._

### After installing the skill in this PR:

Prompt: `Write me a todo app in LWC. keep it simple.`
Result: **DOES** use MCP tool


---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
