### PR TITLE
chore: add dependabot config for root npm dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to monitor root npm dependencies on a weekly schedule
- Excludes `/samples` directories from dependency updates by only configuring the root directory

## Test plan
- [ ] Verify dependabot.yml is valid by checking GitHub's dependabot settings page after merge
- [ ] Confirm no dependabot PRs are opened for `/samples` dependencies