### PR TITLE
chore: ignore sample template packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@salesforce/ui-bundle-template-app-react-sample-b2e"
+      - dependency-name: "@salesforce/ui-bundle-template-app-react-sample-b2x"
+      - dependency-name: "@salesforce/webapp-template-app-react-sample-b2e-experimental"
+      - dependency-name: "@salesforce/webapp-template-app-react-sample-b2x-experimental"


### PR DESCRIPTION
## Summary
- Adds `ignore` rules to `.github/dependabot.yml` for four sample template packages that should not receive automated dependency updates:
  - `@salesforce/ui-bundle-template-app-react-sample-b2e`
  - `@salesforce/ui-bundle-template-app-react-sample-b2x`
  - `@salesforce/webapp-template-app-react-sample-b2e-experimental`
  - `@salesforce/webapp-template-app-react-sample-b2x-experimental`

## Test plan
- [ ] Verify dependabot no longer opens PRs for the ignored packages