### PR TITLE
fix: make sync-react-samples manual-only

### DIFF
--- a/.github/workflows/sync-react-samples.yml
+++ b/.github/workflows/sync-react-samples.yml
@@ -13,9 +13,6 @@ name: Sync React samples from npm
 
 on:
   workflow_dispatch:
-  schedule:
-    # Nightly at 02:00 UTC
-    - cron: "0 2 * * *"
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- Remove the nightly cron schedule from the sync-react-samples workflow so it only runs when manually triggered via `workflow_dispatch`

## Test plan
- [ ] Verify the workflow no longer appears in scheduled runs
- [ ] Trigger it manually via the Actions tab and confirm it still works