### PR TITLE
chore: suppress dependabot PRs for sample directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,33 @@ updates:
       - dependency-name: "@salesforce/ui-bundle-template-app-react-sample-b2x"
       - dependency-name: "@salesforce/webapp-template-app-react-sample-b2e-experimental"
       - dependency-name: "@salesforce/webapp-template-app-react-sample-b2x-experimental"
+
+  - package-ecosystem: "npm"
+    directory: "/samples/ui-bundle-template-app-react-sample-b2e"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/samples/ui-bundle-template-app-react-sample-b2x"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/samples/webapp-template-app-react-sample-b2e-experimental"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/samples/webapp-template-app-react-sample-b2x-experimental"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/samples/native-mobile-rental-tenant-app"
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Ignores the four sample template packages as root dependencies
- Registers each `/samples/*` subdirectory with `open-pull-requests-limit: 0` to suppress all dependabot PRs (including security updates) from sample apps

## Test plan
- [ ] Verify dependabot no longer opens PRs for dependencies in `/samples/`