### PR TITLE
@W-22269067 integrate best practices into creating-sf-skill

### DIFF
--- a/skills/creating-sf-skill/SKILL.md
+++ b/skills/creating-sf-skill/SKILL.md
@@ -14,6 +14,28 @@ You are a contributor onboarding tool for the [afv-library](https://github.com/f
 Your job is to take minimal input and generate a complete, validated skill as fast as possible.
 Ask **one thing at a time**. Generate first, refine after. Do not explain the pipeline.
 
+## Scope
+
+- **In scope**: Gathering user intent, generating SKILL.md + supporting files (assets/, references/, examples/), scaffolding eval datasets, running validation, and iterating on feedback.
+- **Out of scope**: Running evals against generated skills (contributor does this), pushing PRs (contributor does this), editing existing SKILL.md files without guided authoring.
+
+---
+
+## Required Inputs
+
+Gather from the user before generating:
+
+- **Skill type**: Metadata generation, code generation, or workflow/process (infer from context when possible)
+- **Use case description**: What problem the skill solves, who uses it, what it produces
+- **Reference material** (optional): Schemas, example files, docs, URLs — anything that provides domain context
+
+Defaults unless specified:
+- Stage: `Draft`
+- Naming: gerund convention (`generating-`, `building-`, `deploying-`)
+- Structure: SKILL.md < 300 lines, heavy content in subdirectories
+
+---
+
 The full contribution lifecycle has 5 phases:
 
 | Phase | What | Status |
@@ -352,6 +374,36 @@ Next steps:
 2. Once you're happy with the skill, open a PR to forcedotcom/afv-library.
    CI will validate the skill and publish it to the catalog.
 ```
+
+---
+
+## Rules / Constraints
+
+| Constraint | Rationale |
+|-----------|-----------|
+| SKILL.md must be under 500 lines | Avoids context window bloat; forces progressive disclosure |
+| Description must be 100-300 words with TRIGGER/SKIP | It is the sole activation mechanism; vague descriptions never fire |
+| Description must be wrapped in double quotes | Colons and special chars break YAML parsing without quotes |
+| `allowed-tools` must scope Bash to specific commands | Blanket Bash pre-approves all executions — security risk |
+| Every subdirectory file must have a load instruction in SKILL.md | Agents never read unreferenced files |
+| Never hardcode filesystem paths to other skills | Skill catalog layout varies across installations |
+| Never hardcode `force-app/main/default/` | Customers customize `sfdx-project.json` package paths |
+| Gerund naming for skill directories | Convention: first word ends in `-ing` |
+| `name` field must match directory name exactly | Validator enforces this; mismatch fails CI |
+
+---
+
+## Output Expectations
+
+Deliverables for every generated skill:
+
+- `skills/<skill-name>/SKILL.md` — workflow + rules + gotchas (target < 300 lines)
+- `skills/<skill-name>/assets/` — code templates, XML schemas (only if needed)
+- `skills/<skill-name>/references/` — detailed guides, tables, sub-procedures (only if needed)
+- `skills/<skill-name>/examples/` — input/output pairs, sample files (only if needed)
+- `skills/<skill-name>/tests/evals/` — 2-3 eval datasets with `prompt.md` + `gold/`
+
+Do NOT create empty directories. Only create `assets/`, `references/`, `examples/` if there is content to put in them.
 
 ---
 

--- a/skills/creating-sf-skill/SKILL.md
+++ b/skills/creating-sf-skill/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: creating-sf-skill
-description: "AI-assisted skill authoring pipeline for the afv-library. Use when the user wants to create a new skill, update an existing skill, generate a skill spec, scaffold skill files, or add a new capability to the skill catalog. TRIGGER when: user says create skill, new skill, skill creator, author skill, scaffold skill, generate skill, update skill, add a skill, skill pipeline. DO NOT TRIGGER when: user is directly editing an existing SKILL.md without asking for guided authoring.Invoke this skill whenever someone needs to add a new capability to the afv-library skill catalog, or wants to update/improve an existing skill. This includes creating skills for Apex, metadata, LWC, Flow, Agentforce, or any Salesforce domain."
+description: "AI-assisted skill authoring pipeline for the afv-library. Use when the user wants to create a new skill, update an existing skill, generate a skill spec, scaffold skill files, or add a new capability to the skill catalog. TRIGGER when: user says create skill, new skill, skill creator, author skill, scaffold skill, generate skill, update skill, add a skill, skill pipeline, write a skill, build a skill, skill template, skill spec. Also triggers when user wants to add a capability for Apex, metadata, LWC, Flow, Agentforce, or any Salesforce domain to the skill catalog. DO NOT TRIGGER when: user is directly editing an existing SKILL.md without asking for guided authoring, or when user is running evals against an existing skill."
 license: LICENSE.txt has complete terms
 metadata:
   version: "1.0"
-  stage: Pilot
+  stage: Published
+allowed-tools: Bash(npx tsx scripts/validate-skills.ts) Read Write AskUserQuestion
 ---
 
 # Instructions

--- a/skills/creating-sf-skill/SKILL.md
+++ b/skills/creating-sf-skill/SKILL.md
@@ -138,7 +138,8 @@ Then do the work. Do not ask any more questions.
 2. Read `./templates/skill_template.md`.
 3. Read `./templates/frontmatter_reference.yaml`.
 4. Read `./references/best_practices.md`.
-5. Generate all files following the rules below.
+5. Read `./references/section_guide.md` — use it for section-by-section quality guidance.
+6. Generate all files following the rules below.
 
 ### What goes WHERE — hard rules
 
@@ -365,3 +366,18 @@ Next steps:
 | Validation fails | Fix it yourself. Only ask the user if you genuinely can't resolve it. |
 | No reference material provided | Generate representative stubs; mark everything `# STUB`. |
 | Skill type is clear from user message | Do not ask — infer it, state it, move on. |
+
+---
+
+## Reference File Index
+
+| File | When to read |
+|------|-------------|
+| `references/progressive_disclosure.md` | Step 3 — to decide what goes in SKILL.md vs subdirectories |
+| `references/best_practices.md` | Step 3 — for core authoring principles and description writing |
+| `references/section_guide.md` | Step 3 — for section-by-section quality guidance (frontmatter, tiers, checklist) |
+| `references/validation_rules.md` | Step 3 (Validate) — for the full list of validator rules |
+| `references/pr_checklist.md` | Step 4 (Review) — for PR-quality review of the generated skill |
+| `templates/skill_template.md` | Step 3 — starting structure for generated SKILL.md files |
+| `templates/frontmatter_reference.yaml` | Step 3 — complete field reference for frontmatter |
+| `templates/tests_structure.md` | Step 5 — for eval dataset layout and naming conventions |

--- a/skills/creating-sf-skill/SKILL.md
+++ b/skills/creating-sf-skill/SKILL.md
@@ -4,7 +4,7 @@ description: "AI-assisted skill authoring pipeline for the afv-library. Use when
 license: LICENSE.txt has complete terms
 metadata:
   version: "1.0"
-  stage: Published
+  stage: Pilot
 allowed-tools: Bash(npx tsx scripts/validate-skills.ts) Read Write AskUserQuestion
 ---
 

--- a/skills/creating-sf-skill/references/best_practices.md
+++ b/skills/creating-sf-skill/references/best_practices.md
@@ -1,11 +1,63 @@
 # Skill Authoring Best Practices
 
-Principles for writing high-quality skills. Based on patterns observed across the
-afv-library and the Agent Skills best practices guide.
+Principles for writing high-quality skills. Based on patterns observed across 30+
+production skills in the afv-library and the Agent Skills best practices guide.
+
+## What Is a Metadata Skill?
+
+Agent Skills are standardized, lightweight packages that allow AI agents to load domain
+expertise on demand without polluting their finite context windows. They rely on a
+**Progressive Disclosure** architecture:
+
+- **Phase 1 (Discovery)**: Only the skill's metadata (~100 tokens) is loaded into the
+  system prompt at startup.
+- **Phase 2 (Load)**: The full SKILL.md instructions are loaded only when the user's
+  intent matches the skill.
+- **Phase 3 (References/Scripts/Assets)**: Instructions in SKILL.md can then ask the
+  agent to run scripts or load references on demand.
+
+A metadata skill is a structured SKILL.md file (with optional references and assets) that
+lives in the afv-library and teaches an AI agent to generate valid Salesforce metadata XML
+for a specific metadata type (CustomObject, CustomField, FlexiPage, ValidationRule, etc.).
+
+The skill serves as the agent's domain expert — it contains the constraints, decision logic,
+naming conventions, and correct/incorrect examples that prevent deployment failures.
+
+Where skills live: `afv-library/skills/generating-{metadata-type}/`
 
 ## Core Principles
 
-### 1. Add What the Agent Lacks, Omit What It Knows
+### 1. The Extraction Method
+
+The best way to build a skill is to **complete the real task hands-on with an agent in
+chat first**. Pay attention to the corrections you make and the context you have to
+provide, then extract that exact sequence into your SKILL.md.
+
+1. Perform the task yourself (or watch someone do it) in an agent conversation.
+2. Note every decision point, correction, tool invocation, and gotcha encountered.
+3. Write the skill as the instructions you wish you had before starting.
+4. Feed real execution traces back into the skill.
+
+The first draft usually needs refinement. Run the skill against 3-5 real prompts, read the
+full execution trace (not just the final output), and identify false positives, false
+negatives, wasted tokens, and vague instructions.
+
+### 2. Explain the Why, Not Just the What
+
+If you find yourself writing ALWAYS or NEVER in all caps, that is a yellow flag. Reframe
+and explain the reasoning so the model understands **why** the constraint matters. A model
+that understands intent handles edge cases better than one following rigid rules.
+
+**Bad**: "NEVER include `<required>` on MasterDetail."
+
+**Good**: "Omit `<required>` on MasterDetail fields because the platform implicitly
+enforces requirement and adding it causes the error: 'Master-Detail Relationship Fields
+Cannot be Optional or Required.'"
+
+Favor procedures over declarations. Instead of listing rules, describe the reasoning
+process an expert would follow.
+
+### 3. Add What the Agent Lacks, Omit What It Knows
 
 The most common mistake is including general knowledge the LLM already has.
 Focus exclusively on:
@@ -14,31 +66,19 @@ Focus exclusively on:
   unique to this project.
 - **Domain-specific procedures** — workflows, API quirks, deployment steps that are
   not publicly documented or are team-specific.
-- **Gotchas** — failure modes, edge cases, known bugs that the agent would not anticipate.
+- **Non-obvious edge cases** — failure modes, known bugs that the agent would not anticipate.
 
 **Omit**: general programming concepts, language syntax, well-known design patterns.
+Use this as a filter for what belongs in each tier of the specification.
 
-### 2. Extract from a Hands-On Task
+### 4. Cross-Model Testing
 
-The best skills are written after doing the task manually:
+Test your skill against the different models your team uses. A skill that works on one
+model may fail on another due to different instruction-following behavior, context window
+handling, or default assumptions. Cross-model testing catches brittle instructions that
+rely on model-specific quirks rather than clear communication.
 
-1. Perform the task yourself (or watch someone do it).
-2. Note every decision point, tool invocation, and gotcha encountered.
-3. Write the skill as the instructions you wish you had before starting.
-4. Feed real execution traces back into the skill.
-
-### 3. Refine with Real Execution
-
-> "The first draft of a skill usually needs refinement. Run the skill against real
-> tasks, then feed the results — all of them, not just failures — back into the
-> creation process."
-
-After generating a skill:
-- Run it against 3-5 real prompts.
-- Read the full execution trace, not just the final output.
-- Identify: false positives, false negatives, wasted tokens, vague instructions.
-
-### 4. Task-Oriented, Not Concept-Oriented
+### 5. Task-Oriented, Not Concept-Oriented
 
 Structure skills around what the agent should **do**, not what **exists**.
 
@@ -47,7 +87,7 @@ Structure skills around what the agent should **do**, not what **exists**.
 **Good**: "1. Identify the class type needed. 2. Read the matching template from assets/.
 3. Generate the class following the template pattern."
 
-### 5. Concise Over Comprehensive
+### 6. Concise Over Comprehensive
 
 Every token in a SKILL.md costs compute and risks confusing the agent with
 irrelevant instructions. Cut ruthlessly:
@@ -56,16 +96,31 @@ irrelevant instructions. Cut ruthlessly:
 - Remove examples that duplicate other examples.
 - Remove caveats about edge cases that never happen.
 
+SKILL.md must be under 500 lines. If your skill needs more detail, move content to
+`references/` files and link from SKILL.md. Reference files load on demand and are a
+good way to avoid diluting critical skill instructions.
+
 ## Description Writing
 
-The description is the most important field — it determines when the skill triggers.
+The description is the most important field — it is the **sole mechanism** by which agents
+decide whether to activate your skill.
+
+### Requirements
+
+- **100-300 words** — use the full budget.
+- Start with what the skill does in imperative form.
+- Include the metadata type name and Salesforce terminology.
+- List 5+ specific trigger phrases users would say.
+- List relevant file extensions (e.g., `.field-meta.xml`).
+- Include negative triggers ("Do NOT trigger when...").
 
 ### Do
 
 - Front-load the primary use case.
 - Include specific keywords users say: "Apex", ".cls", "trigger", "batch job".
 - Add `TRIGGER when:` and `DO NOT TRIGGER when:` clauses.
-- **Be pushy**: list implicit triggers where the user may not use the domain term directly.
+- **Be pushy about triggers**: list implicit triggers where the user may not use the
+  domain term directly.
 - Keep it factual and specific.
 
 ### Don't
@@ -77,15 +132,15 @@ The description is the most important field — it determines when the skill tri
 
 ### Be Pushy About Triggers
 
-Err on the side of listing more implicit triggers, not fewer. A skill that never fires is useless;
-a skill that fires on a near-miss is recoverable. Explicitly call out contexts where the skill
-applies **even if the user doesn't name the domain directly**:
+Err on the side of listing more implicit triggers, not fewer. A skill that never fires is
+useless; a skill that fires on a near-miss is recoverable. Explicitly call out contexts
+where the skill applies **even if the user doesn't name the domain directly**:
 
-> "TRIGGER when: user asks to add a rule, restrict a field, or enforce a policy — even if they
-> don't explicitly say 'validation rule' or 'Apex'."
+> "TRIGGER when: user asks to add a rule, restrict a field, or enforce a policy — even if
+> they don't explicitly say 'validation rule' or 'Apex'."
 
-This is especially important for domain keywords the user may not know (e.g., they say "make this
-field required" not "add a required validation rule").
+This is especially important for domain keywords the user may not know (e.g., they say
+"make this field required" not "add a required validation rule").
 
 ### Template
 

--- a/skills/creating-sf-skill/references/best_practices.md
+++ b/skills/creating-sf-skill/references/best_practices.md
@@ -3,28 +3,6 @@
 Principles for writing high-quality skills. Based on patterns observed across 30+
 production skills in the afv-library and the Agent Skills best practices guide.
 
-## What Is a Metadata Skill?
-
-Agent Skills are standardized, lightweight packages that allow AI agents to load domain
-expertise on demand without polluting their finite context windows. They rely on a
-**Progressive Disclosure** architecture:
-
-- **Phase 1 (Discovery)**: Only the skill's metadata (~100 tokens) is loaded into the
-  system prompt at startup.
-- **Phase 2 (Load)**: The full SKILL.md instructions are loaded only when the user's
-  intent matches the skill.
-- **Phase 3 (References/Scripts/Assets)**: Instructions in SKILL.md can then ask the
-  agent to run scripts or load references on demand.
-
-A metadata skill is a structured SKILL.md file (with optional references and assets) that
-lives in the afv-library and teaches an AI agent to generate valid Salesforce metadata XML
-for a specific metadata type (CustomObject, CustomField, FlexiPage, ValidationRule, etc.).
-
-The skill serves as the agent's domain expert — it contains the constraints, decision logic,
-naming conventions, and correct/incorrect examples that prevent deployment failures.
-
-Where skills live: `afv-library/skills/generating-{metadata-type}/`
-
 ## Core Principles
 
 ### 1. The Extraction Method

--- a/skills/creating-sf-skill/references/pr_checklist.md
+++ b/skills/creating-sf-skill/references/pr_checklist.md
@@ -1,0 +1,65 @@
+# PR Quality Checklist
+
+Use this checklist when reviewing a pull request that adds or modifies a skill in the
+afv-library. Every item should pass before the PR is approved.
+
+---
+
+## Frontmatter
+
+- [ ] `name` is kebab-case and matches the directory name exactly
+- [ ] `description` is 100-300 words with 5+ trigger phrases
+- [ ] `description` includes file extensions and Salesforce terminology
+- [ ] `description` includes negative triggers (DO NOT use when / SKIP when)
+- [ ] `description` uses the TRIGGER / SKIP pattern
+- [ ] `metadata.version` is present (use "1.0" for new skills)
+- [ ] `metadata.related-skills` lists actual afv-library skill names (if applicable)
+- [ ] `compatibility` declares required tools/environment (if applicable)
+- [ ] `allowed-tools` declares which tools the skill can access (if applicable)
+- [ ] `license` is a top-level field, not nested under metadata
+
+---
+
+## Structure
+
+- [ ] SKILL.md is under 500 lines
+- [ ] Specification section with tiered constraints (Tier 1-4)
+- [ ] Verification Checklist with checkboxes is present
+- [ ] Every file in `assets/`, `references/`, or `examples/` has a specific load
+      instruction in SKILL.md (no orphaned files)
+- [ ] Reference File Index maps every subdirectory file to its trigger
+- [ ] Directory name follows gerund naming convention (`generating-`, `building-`, etc.)
+
+---
+
+## Content Quality
+
+- [ ] Every constraint has a rationale (not just "best practice")
+- [ ] Incorrect/correct example pairs for every critical (Tier 3) constraint
+- [ ] Incorrect examples include exact Salesforce error messages
+- [ ] Decision logic uses IF/THEN/DEFAULT format
+- [ ] All enumerated values are complete (no "etc." or "and more")
+- [ ] No vague instructions ("optionally", "you can also", "consider")
+- [ ] No placeholders or TODOs remaining in the skill
+- [ ] Constraints explain **why**, not just **what** (per the explain-the-why principle)
+- [ ] Clarifying questions only ask about things that cause deployment failure or
+      significant rework if assumed wrong
+
+---
+
+## Cross-Skill
+
+- [ ] Related skills referenced by correct name
+- [ ] No circular dependencies between skills
+- [ ] Scope does not overlap with existing skills in the catalog
+- [ ] SKIP/DO NOT TRIGGER clauses delegate to correct skill names
+
+---
+
+## Testing
+
+- [ ] At least 2-3 eval datasets in `tests/evals/`
+- [ ] Each eval has a `prompt.md` with a realistic user prompt
+- [ ] Each eval has a `gold/` directory with expected output artifacts
+- [ ] Gold files use correct file extensions for the artifact type
+- [ ] Eval scenarios cover distinct use cases (different objects, types, or complexity)

--- a/skills/creating-sf-skill/references/progressive_disclosure.md
+++ b/skills/creating-sf-skill/references/progressive_disclosure.md
@@ -75,6 +75,55 @@ Check `assets/` for templates.
 | Creating subdirectory but not referencing it | Agent never reads unreferenced files | Add entry to Reference File Index |
 | Using "see references/" without naming a file | Agent doesn't know which file to read | Always name the specific file |
 
+## When to Use `scripts/`
+
+Agents execute scripts as black boxes — they run `--help`, execute, and read output. Create
+scripts for deterministic tasks that should not waste tokens on LLM reasoning:
+
+- Validating generated XML against schema
+- Checking naming conventions (`__c` suffix, API name length limits)
+- Verifying cross-element dependencies (e.g., Master-Detail requires `relationshipOrder`)
+
+**Rules for scripts:**
+- One responsibility per script
+- Support `--help` for discoverability
+- No interactive prompts
+- Use structured output: JSON for results, stderr for errors
+- Idempotent — safe to re-run on failure/retry
+- Support `--dry-run` for critical operations
+
+## When to Use `assets/`
+
+Create template files when the skill produces metadata from a skeleton:
+
+- XML templates with `{PLACEHOLDER}` syntax for variable parts
+- Include XML comments explaining each section
+- Templates must be syntactically valid (minus the placeholders)
+- Match the actual output file extension (`.xml`, `.json`, etc.)
+
+**Example asset** (`assets/object-template.xml`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+  <label>{OBJECT_LABEL}</label>
+  <pluralLabel>{OBJECT_PLURAL_LABEL}</pluralLabel>
+  <nameField>
+    <!-- Primary name field for the object -->
+    <label>{NAME_FIELD_LABEL}</label>
+    <type>{NAME_FIELD_TYPE}</type>
+  </nameField>
+  <deploymentStatus>Deployed</deploymentStatus>
+  <sharingModel>{SHARING_MODEL}</sharingModel>
+</CustomObject>
+```
+
+**Not every skill needs assets.** Many metadata generation skills (like `generating-custom-field`
+and `generating-flexipage`) do not use `assets/` at all — they embed XML examples directly in
+SKILL.md. Use assets when you have reusable templates with placeholder syntax; use inline
+examples when showing constraint-specific snippets. Only create `assets/` if there is content
+to put in it.
+
 ## Token Budget
 
 | Component | Target | Maximum |

--- a/skills/creating-sf-skill/references/section_guide.md
+++ b/skills/creating-sf-skill/references/section_guide.md
@@ -1,0 +1,297 @@
+# Section-by-Section Guide
+
+Detailed quality guidance for every section of a metadata generation SKILL.md.
+Use this reference when authoring or reviewing individual sections to ensure each
+meets the standards proven across 30+ production skills.
+
+---
+
+## A. Frontmatter Standards (Mandatory)
+
+The YAML frontmatter is the skill's identity and activation mechanism.
+
+```yaml
+---
+name: {action}ing-{metadata-type}
+description: "{PRIMARY_PURPOSE}. Trigger when users mention {METADATA_NAMES},
+  {FILE_EXTENSIONS}, or ask to {ACTION_VERBS}. Also use when users say things like
+  {TRIGGER_PHRASES}. Always use this skill for any {DOMAIN} metadata work."
+metadata:
+  version: "1.0"
+  related-skills: "{skill1}, {skill2}"
+  author: "{team-name}"
+  last_updated: "{YYYY-MM-DD}"
+  compatibility: "Requires Salesforce CLI, Python 3.9+"
+license: Apache-2.0
+allowed-tools: Bash Read Write
+---
+```
+
+### The TRIGGER / SKIP Description Pattern
+
+The description is the sole mechanism by which agents decide whether to activate your
+skill. Use the TRIGGER / SKIP pattern (from Anthropic's skill design) to make activation
+explicit:
+
+**Good description:**
+
+```
+description: "Generate and validate Salesforce Custom Field metadata.
+  TRIGGER when: user mentions custom fields, field types, Roll-up Summary,
+  Master-Detail, Lookup, formula fields, picklists, .field-meta.xml files,
+  or field deployment errors.
+  SKIP when: user needs the object itself (use generating-custom-object),
+  needs a validation rule (use generating-validation-rule), or needs a
+  page layout (use generating-flexipage)."
+```
+
+**Bad descriptions** are too vague, contain no trigger keywords, no file types, no
+exclusions. The description must be 100-300 words with 5+ specific trigger phrases.
+
+### allowed-tools Field
+
+Declares which tools the skill can access. This scopes the agent's tool use during
+skill execution:
+
+```yaml
+allowed-tools: Bash Read Write
+```
+
+Include only the tools the skill actually needs. Common values: `Bash`, `Read`, `Write`,
+`Edit`. If the skill only reads files and generates output, `Read Write` may suffice.
+
+### license Field
+
+Top-level frontmatter field (not nested under metadata):
+
+```yaml
+license: Apache-2.0
+```
+
+### related-skills
+
+Cross-skill referencing lists actual afv-library skill names. Skills are self-contained;
+orchestration between skills happens outside the skill via the agent's routing. List
+related skills so the agent knows where to delegate:
+
+```yaml
+metadata:
+  related-skills: "generating-custom-object, generating-validation-rule"
+```
+
+### Key Rule: name Must Match Directory
+
+The `name` field in SKILL.md frontmatter must match the directory name exactly.
+`generating-custom-field/SKILL.md` must have `name: generating-custom-field`.
+
+---
+
+## B. Overview / Purpose (Optional)
+
+1-2 paragraphs explaining:
+- What this metadata type is.
+- What problem the skill solves.
+- Which areas have the highest failure rate.
+
+Keep it brief. The overview orients the agent but does not contain actionable instructions.
+
+---
+
+## C. Clarifying Questions (Optional)
+
+Before generating metadata, the agent often needs information the user has not provided.
+Rather than guessing (which causes deployment failures), define explicit questions the
+agent should ask.
+
+```markdown
+## Clarifying Questions
+
+Before generating metadata, ask the user if not already clear:
+
+- What object is this for? (standard object name or custom object API name)
+- What field type do you need? (Text, Number, Lookup, Master-Detail, etc.)
+- Is this field required? (Note: cannot be set on Master-Detail fields)
+- For relationship fields: what is the related object?
+- For picklist fields: what are the values?
+- Should this be an external ID or unique field?
+```
+
+**Guidelines:**
+- Only include questions where the wrong assumption leads to deployment failure or
+  significant rework.
+- Do not ask about things the agent can safely default.
+- Order questions from most critical to least critical.
+- Include parenthetical notes about constraints that affect the answer (e.g., "cannot be
+  set on Master-Detail fields").
+
+---
+
+## D. Specification / Tiered Constraints (Mandatory)
+
+Organize constraints by severity so the agent prioritizes correctly. This four-tier
+structure has proven most effective across all metadata generation skills.
+
+### Tier 1 — Syntactic Essentials
+
+Elements that MUST be present for deployment to succeed. Present as a table.
+
+```markdown
+## Syntactic Essentials
+
+| Element | Requirement | Notes |
+|---------|-------------|-------|
+| `<fullName>` | Required | Must end in `__c` for custom |
+| `<label>` | Required | Title Case, user-visible |
+| `<type>` | Required | Must be a valid Metadata API type value |
+```
+
+Every required element gets a row. Keep notes column brief — link to Tier 3 if the
+element has complex constraints.
+
+### Tier 2 — Smart Defaults and Decision Logic
+
+Choices the skill makes when the user does not specify. Present as decision trees
+using IF/THEN/DEFAULT format.
+
+```markdown
+## Smart Defaults
+
+### Sharing Model
+
+| Condition | Value | Rationale |
+|-----------|-------|-----------|
+| IF object has Master-Detail field | `ControlledByParent` | Required by platform |
+| IF object is confidential (HR, finance) | `Private` | Security best practice |
+| DEFAULT | `ReadWrite` | Most common for business objects |
+```
+
+Every decision point gets its own subsection with a table. Always include a DEFAULT
+row. The Rationale column must explain **why**, not just restate the condition.
+
+### Tier 3 — Critical Constraints
+
+Rules that cause the highest deployment failure rate. This is the most important tier.
+
+**Requirements for every Tier 3 constraint:**
+
+1. **Every constraint must have a pair** — both an incorrect and correct example.
+2. **Use exact error messages** — do not paraphrase. Paste the real error string so
+   agents recognize the error when users report it.
+3. **Annotate the incorrect example** — use inline XML comments (`<!-- WRONG -->`)
+   pointing to the specific problem.
+4. **Keep examples minimal** — show only the elements relevant to the constraint.
+   Do not pad with unrelated attributes.
+5. **Mark highest-failure-rate constraints with CRITICAL.**
+
+**Example — Custom Field Skill:**
+
+```markdown
+### Master-Detail Forbidden Attributes   CRITICAL
+
+Omit `<required>` and `<deleteConstraint>` on MasterDetail fields because the
+platform implicitly enforces these and adding them causes deployment errors.
+
+INCORRECT — Master-Detail with forbidden attributes:
+
+  <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Account__c</fullName>
+    <type>MasterDetail</type>
+    <referenceTo>Account</referenceTo>
+    <relationshipOrder>0</relationshipOrder>
+    <required>true</required>              <!-- WRONG -->
+    <deleteConstraint>Cascade</deleteConstraint>  <!-- WRONG -->
+  </CustomField>
+
+Errors:
+- Master-Detail Relationship Fields Cannot be Optional or Required
+- Can not specify 'deleteConstraint' for a CustomField of type MasterDetail
+
+CORRECT:
+
+  <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Account__c</fullName>
+    <type>MasterDetail</type>
+    <referenceTo>Account</referenceTo>
+    <relationshipOrder>0</relationshipOrder>
+    <reparentableMasterDetail>false</reparentableMasterDetail>
+    <!-- NO required, deleteConstraint, or lookupFilter -->
+  </CustomField>
+```
+
+### Tier 4 — Common Deployment Errors
+
+Error-message-to-fix table. This is a quick-reference troubleshooting section.
+
+```markdown
+## Common Deployment Errors
+
+| Error Message | Cause | Fix |
+|---------------|-------|-----|
+| `DUPLICATE_DEVELOPER_NAME` | API name already exists | Use a unique name |
+| `MAX_RELATIONSHIPS_EXCEEDED` | >2 Master-Detail fields | Use Lookup instead |
+```
+
+Include the exact error string in backticks. The Cause column should be one phrase.
+The Fix column should be an actionable instruction.
+
+---
+
+## E. Type-Specific Rules (Optional)
+
+If the metadata type has subtypes (field types, flow types, page types), document each
+with its required attributes in a table.
+
+```markdown
+## Field Data Types
+
+| Type | `<type>` Value | Required Attributes |
+|------|----------------|---------------------|
+| Auto Number | `AutoNumber` | `displayFormat` (must include `{0}`), `startingNumber` |
+| Checkbox | `Checkbox` | Default `defaultValue` to `false` |
+| Date | `Date` | No precision/length required |
+| Lookup | `Lookup` | `referenceTo`, `relationshipName`, `deleteConstraint` |
+| Master-Detail | `MasterDetail` | `referenceTo`, `relationshipName`, `relationshipOrder` |
+```
+
+**Guidelines:**
+- One row per subtype.
+- Required Attributes column lists only the attributes unique to that subtype.
+- Add notes about constraints that differ from the base type.
+- If a subtype has complex rules, reference a Tier 3 constraint rather than repeating it.
+
+---
+
+## F. Verification Checklist (Mandatory)
+
+A checkbox list that must be verified BEFORE presenting output. Every critical constraint
+from the specification must have a corresponding checkbox. Organize by concern:
+
+```markdown
+## Verification Checklist
+
+### Universal Checks
+- [ ] Does `<fullName>` use valid format and end in `__c`?
+- [ ] Are `<description>` and `<inlineHelpText>` both populated?
+
+### Master-Detail Field Checks   CRITICAL
+- [ ] Is `<required>` attribute ABSENT?
+- [ ] Is `<deleteConstraint>` attribute ABSENT?
+
+### Roll-Up Summary Field Checks   CRITICAL
+- [ ] Is `<summaryForeignKey>` in format `ChildObject__c.MasterDetailField__c`?
+
+### Naming Checks
+- [ ] Is the API name free of reserved words?
+- [ ] Does the file name match the API name pattern?
+
+### Architectural Checks
+- [ ] Does the sharing model align with relationship fields?
+- [ ] Are cross-object references valid?
+```
+
+**Guidelines:**
+- Every Tier 3 (Critical Constraint) must have at least one corresponding checkbox.
+- Group checkboxes by concern (universal, type-specific, naming, architectural).
+- Mark groups that correspond to CRITICAL constraints.
+- Use question format ("Does X...?", "Is Y...?") for clarity.
+- The checklist is the agent's final gate before presenting output to the user.

--- a/skills/creating-sf-skill/references/section_guide.md
+++ b/skills/creating-sf-skill/references/section_guide.md
@@ -23,7 +23,7 @@ metadata:
   last_updated: "{YYYY-MM-DD}"
   compatibility: "Requires Salesforce CLI, Python 3.9+"
 license: Apache-2.0
-allowed-tools: Bash Read Write
+allowed-tools: Bash(sf project deploy start) Read Write
 ---
 ```
 
@@ -51,10 +51,10 @@ exclusions. The description must be 100-300 words with 5+ specific trigger phras
 ### allowed-tools Field
 
 Declares which tools the skill can access. This scopes the agent's tool use during
-skill execution:
+skill execution. Scope Bash to specific commands rather than blanket access:
 
 ```yaml
-allowed-tools: Bash Read Write
+allowed-tools: Bash(sf project deploy start) Read Write
 ```
 
 Include only the tools the skill actually needs. Common values: `Bash`, `Read`, `Write`,

--- a/skills/creating-sf-skill/templates/skill_template.md
+++ b/skills/creating-sf-skill/templates/skill_template.md
@@ -1,10 +1,19 @@
 ---
 name: <SKILL_NAME>
-description: "<DESCRIPTION — 20+ words, <= 1024 chars, must contain 'use'. Include TRIGGER when and DO NOT TRIGGER when clauses.>"
+description: "<PRIMARY_PURPOSE>. TRIGGER when: <users mention METADATA_TYPE_NAMES,
+  FILE_EXTENSIONS, or ask to ACTION_VERBS — include 5+ specific trigger phrases and
+  implicit contexts where the user may not use the exact domain term>.
+  SKIP when: <EXCLUSION_TRIGGERS with delegation targets>.
+  Always use this skill for any <DOMAIN> metadata work."
 license: LICENSE.txt has complete terms
 metadata:
   version: "1.0"
   stage: Draft
+  related-skills: "<skill1>, <skill2>"
+  author: "<team-name>"
+  last_updated: "<YYYY-MM-DD>"
+  compatibility: "<REQUIRED_TOOLS_AND_ENVIRONMENT>"
+allowed-tools: <Bash Read Write — list only the tools the skill needs>
 ---
 
 # <Skill Title>
@@ -15,6 +24,20 @@ metadata:
 
 - **In scope**: <what this skill handles>
 - **Out of scope**: <what this skill does NOT handle — delegate to other skills>
+
+---
+
+## Clarifying Questions
+
+<!-- Questions the agent should ask before generating. Only include questions
+     where the wrong assumption leads to deployment failure or significant rework. -->
+
+Before generating, confirm with the user if not already clear:
+
+- <Question 1 — most critical information needed>
+- <Question 2 — type or subtype selection>
+- <Question 3 — constraint-affecting detail>
+- <Question 4 — relationship or dependency info>
 
 ---
 

--- a/skills/creating-sf-skill/templates/skill_template.md
+++ b/skills/creating-sf-skill/templates/skill_template.md
@@ -9,11 +9,10 @@ license: LICENSE.txt has complete terms
 metadata:
   version: "1.0"
   stage: Draft
-  related-skills: "<skill1>, <skill2>"
   author: "<team-name>"
   last_updated: "<YYYY-MM-DD>"
   compatibility: "<REQUIRED_TOOLS_AND_ENVIRONMENT>"
-allowed-tools: <Bash Read Write — list only the tools the skill needs>
+allowed-tools: <list only the tools the skill needs, e.g. Bash(sf project deploy start) Read Write>
 ---
 
 # <Skill Title>


### PR DESCRIPTION
## Summary
- Enriches the `creating-sf-skill` with content from the best practices PDF (Approach 2 — highest scoring variant at 21.5/25 across 11 eval datasets)
- Adds section-by-section authoring guide, PR review checklist, and expanded progressive disclosure and best practices references
- Keeps SKILL.md at 383 lines (under 500 max) with detailed content moved to `references/`

### Changes
| File | Change |
|------|--------|
| `SKILL.md` | Added step 5 (read `section_guide.md`) + Reference File Index section |
| `references/best_practices.md` | Enriched with progressive disclosure architecture, extraction method, explain-the-why, cross-model testing |
| `references/progressive_disclosure.md` | Added `scripts/` and `assets/` guidance sections |
| `references/section_guide.md` | **New** — section-by-section quality guide (frontmatter, TRIGGER/SKIP, tiered constraints, verification checklist) |
| `references/pr_checklist.md` | **New** — PR review checklist (frontmatter, structure, content quality, cross-skill, testing) |
| `templates/skill_template.md` | Added `allowed-tools`, TRIGGER/SKIP description pattern, Clarifying Questions section |

## Test plan
- [ ] Run `npx tsx scripts/validate-skills.ts` — no new errors for creating-sf-skill
- [ ] Invoke the skill to generate a new metadata skill and verify it reads `section_guide.md` during Step 3
- [ ] Verify generated skills include TRIGGER/SKIP pattern in descriptions
- [ ] Verify generated skills include Clarifying Questions section
- [ ] Confirm PR review step (Step 4) references `pr_checklist.md`