### PR TITLE
feat: @W-22312365 - add cms-branding skill

### DIFF
--- a/skills/applying-cms-brand/SKILL.md
+++ b/skills/applying-cms-brand/SKILL.md
@@ -49,8 +49,6 @@ CMS Branding Progress:
 - [ ] Step 1: Determine if brand is already identified or needs search
 - [ ] Step 2: Search for brands (if needed) and present options to user
 - [ ] Step 3: Extract brand instructions for the selected brand
-- [ ] Step 4: Apply brand guidelines to generated content
-- [ ] Step 5: Confirm branding was applied correctly
 ```
 
 ## Step 1: Determine Brand Context
@@ -149,57 +147,6 @@ The extracted brand instructions typically include:
 | Content Rules | Dos and don'ts for content generation |
 | Style Guidelines | Typography, color, spacing preferences |
 | Guardrails | Hard restrictions on language, topics, or claims |
-
-## Step 4: Apply Brand Guidelines
-
-After extracting brand instructions, apply them to ALL content you generate:
-
-### Text Content
-- Match the specified brand voice and tone
-- Use approved terminology and key messages
-- Respect content guardrails (forbidden words, topics, claims)
-- Follow formatting guidelines (sentence length, paragraph structure)
-
-### UI Components (React/LWC)
-- Apply brand colors using CSS custom properties or design tokens
-- Use specified typography (font family, sizes, weights)
-- Follow spacing and layout guidelines
-- Match the visual tone (minimal, bold, playful, etc.)
-
-### Code Generation
-- Apply brand colors as variables/tokens at the top of stylesheets
-- Use semantic naming that reflects brand terminology
-- Include comments referencing which brand guideline drove a decision (only when non-obvious)
-
-### Application Pattern
-
-```
-When generating content with branding:
-
-1. Read the brand instructions from Step 3
-2. Identify applicable guidelines for the content type
-3. Generate content that adheres to ALL applicable guidelines
-4. Self-check: Does this content match the brand voice? Tone? Rules?
-5. If any guideline is violated, regenerate the affected content
-```
-
-## Step 5: Confirm Application
-
-After applying branding:
-
-1. Summarize which brand guidelines were applied
-2. Highlight any guidelines that couldn't be applied (and why)
-3. Ask the user if the branding feels right
-
-```
-I applied the "[Brand Name]" brand guidelines:
-- Voice: [description]
-- Tone: [description]
-- Colors: [applied where]
-- [Other guidelines applied]
-
-Does the branding look correct, or would you like adjustments?
-```
 
 ## Error Handling
 

--- a/skills/applying-cms-brand/SKILL.md
+++ b/skills/applying-cms-brand/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: cms-branding
+name: applying-cms-brand
 description: "Extracts, retrieves, and applies CMS brand guidelines (voice, tone, style, colors, typography) to generated content. Use this skill ANY TIME a user request involves branding, brand voice, brand tone, brand guidelines, brand identity, brand styling, or applying a brand to content. Triggers for requests like \"apply my brand\", \"use our brand voice\", \"match our brand guidelines\", \"find my brand\", \"search for brand\", \"get brand instructions\", \"apply brand tone\". Handles the full workflow: searching for brands in Salesforce CMS, extracting brand instructions, and applying brand voice/tone/guidelines to generated content. Does not apply to media/image search (use searching-media skill), logo search, or creating new brand definitions."
 compatibility: "Requires get_brand_instructions and/or search_brands MCP tools"
 metadata:
   version: "1.0"
 ---
 
-# CMS Branding
+# Applying CMS Brand
 
 Universal skill for searching, extracting, and applying CMS brand guidelines to generated content.
 

--- a/skills/applying-cms-brand/SKILL.md
+++ b/skills/applying-cms-brand/SKILL.md
@@ -30,7 +30,7 @@ Universal skill for searching, extracting, and applying CMS brand guidelines to 
 
 ## Before You Start
 
-**CRITICAL: You must retrieve brand instructions BEFORE generating or modifying any content.**
+**CRITICAL: You must retrieve brand instructions BEFORE generating or modifying any brand.**
 
 When a user requests branded content:
 

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/gold/expected-output.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/gold/expected-output.md
@@ -44,4 +44,3 @@ Enterprise-grade reliability. Startup-speed agility. Built for teams that move f
 - [ ] Output matches brand voice (bold, authoritative, forward-thinking)
 - [ ] Output matches brand tone (confident, aspirational, direct)
 - [ ] Guardrails are respected (no passive headlines, no "simple"/"easy", no clichés)
-- [ ] Agent summarized which guidelines were applied

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/gold/expected-output.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/gold/expected-output.md
@@ -1,0 +1,47 @@
+# Expected Output
+
+## Agent Behavior
+
+1. Agent calls `search_brands` to find available brands
+2. Agent finds 3 brands and presents options to user using `ask_followup_question`:
+   - "I found 3 brands in your CMS. Which one should I apply?
+     1. Nova Enterprise Brand
+     2. Nova Startup Brand
+     3. Nova Internal Communications
+     Which brand would you like to use?"
+3. User selects "Nova Enterprise Brand"
+4. Agent calls `get_brand_instructions` with managedContentId "9Pn5g000000AAA111"
+5. Agent applies brand guidelines to the product description
+
+## Expected Branded Product Description
+
+The generated description should:
+- Lead with outcomes, not features
+- Use power verbs (accelerate, transform, empower, unlock)
+- Have a bold, authoritative, forward-thinking voice
+- Be confident, aspirational, and direct in tone
+- Keep paragraphs to 3 sentences maximum
+- Use second person ("you", "your team")
+- Not use "simple", "easy", or clichés
+- Incorporate key messages where natural
+
+## Example Branded Output
+
+"Your Team, Unleashed.
+
+Accelerate collaboration across your entire organization. Track progress, share files, and communicate in real time — all from one platform your team already knows how to use.
+
+Enterprise-grade reliability. Startup-speed agility. Built for teams that move fast."
+
+## Evaluation Criteria
+
+- [ ] Agent searched for brands before generating content
+- [ ] Agent presented all brand options to user (did not auto-select)
+- [ ] Agent waited for user selection before proceeding
+- [ ] Agent extracted brand instructions for the selected brand
+- [ ] Output leads with outcomes, not features
+- [ ] Output uses power verbs
+- [ ] Output matches brand voice (bold, authoritative, forward-thinking)
+- [ ] Output matches brand tone (confident, aspirational, direct)
+- [ ] Guardrails are respected (no passive headlines, no "simple"/"easy", no clichés)
+- [ ] Agent summarized which guidelines were applied

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/prompt.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/prompt.md
@@ -1,0 +1,5 @@
+Search for our brand and apply it to the following product description:
+
+"Our project management tool helps teams collaborate efficiently. It includes task tracking, file sharing, and real-time messaging."
+
+Use our brand voice and tone to make it compelling.

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/seed-data/get-brand-instructions-response.json
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/seed-data/get-brand-instructions-response.json
@@ -1,0 +1,10 @@
+{
+  "description": "Mocked response from get_brand_instructions tool for Nova Enterprise Brand (selected by user).",
+  "tool": "get_brand_instructions",
+  "input": {
+    "managedContentId": "9Pn5g000000AAA111"
+  },
+  "response": {
+    "promptBody": "Brand: Nova Enterprise\n\nBrand Voice: Bold, authoritative, and forward-thinking. Speak as a market leader.\n\nBrand Tone: Confident, aspirational, and direct. Inspire action and convey expertise.\n\nKey Messages:\n- Built for teams that move fast\n- Enterprise-grade reliability, startup-speed agility\n- The future of work, delivered today\n\nContent Rules:\n- Lead with outcomes, not features\n- Use power verbs (accelerate, transform, empower, unlock)\n- Keep paragraphs to 3 sentences maximum\n- Use second person (\"you\", \"your team\")\n- Sentence fragments are acceptable for emphasis\n\nTypography:\n- Headlines: Bold, concise (5 words or fewer)\n- Body: Clear, punchy sentences\n\nGuardrails:\n- Never use passive voice in headlines\n- Do not say \"simple\" or \"easy\" (implies the problem was trivial)\n- Avoid clichés (\"game-changer\", \"synergy\", \"leverage\")\n- Do not reference specific pricing"
+  }
+}

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/seed-data/search-brands-response.json
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-multiple-brands/seed-data/search-brands-response.json
@@ -1,0 +1,36 @@
+{
+  "description": "Mocked response from search_brands tool when multiple brands exist in the org.",
+  "tool": "search_brands",
+  "input": {
+    "inputs": [
+      {
+        "searchQuery": "brand"
+      }
+    ]
+  },
+  "response": {
+    "results": [
+      {
+        "managedContentId": "9Pn5g000000AAA111",
+        "managedContentKey": "MCK-brand-nova-enterprise",
+        "title": "Nova Enterprise Brand",
+        "contentUrl": "/cms/brand/nova-enterprise",
+        "totalResults": 3
+      },
+      {
+        "managedContentId": "9Pn5g000000BBB222",
+        "managedContentKey": "MCK-brand-nova-startup",
+        "title": "Nova Startup Brand",
+        "contentUrl": "/cms/brand/nova-startup",
+        "totalResults": 3
+      },
+      {
+        "managedContentId": "9Pn5g000000CCC333",
+        "managedContentKey": "MCK-brand-nova-internal",
+        "title": "Nova Internal Communications",
+        "contentUrl": "/cms/brand/nova-internal",
+        "totalResults": 3
+      }
+    ]
+  }
+}

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/gold/expected-output.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/gold/expected-output.md
@@ -1,0 +1,30 @@
+# Expected Output
+
+## Agent Behavior
+
+1. Agent calls `search_brands` to find available brands
+2. Agent receives empty results (no brands found)
+3. Agent does NOT attempt to generate branded content without guidelines
+4. Agent informs the user and offers alternatives:
+   - "No brands found in Salesforce CMS. To use branding:
+     1. Create a brand in Salesforce CMS (Content Type: sfdc_cms__brand)
+     2. Provide brand guidelines directly in this conversation
+     Would you like to proceed without CMS branding, or provide guidelines manually?"
+
+## Expected Content Output
+
+No branded content should be generated. The agent should:
+- Clearly communicate that no brands were found
+- Explain how to create a brand in CMS
+- Offer the alternative of providing guidelines manually
+- Wait for user direction before proceeding
+
+## Evaluation Criteria
+
+- [ ] Agent searched for brands before attempting to generate content
+- [ ] Agent did NOT generate branded content without guidelines
+- [ ] Agent informed user that no brands were found
+- [ ] Agent offered actionable alternatives (create in CMS or provide manually)
+- [ ] Agent did NOT hallucinate or assume brand guidelines
+- [ ] Agent waited for user response before proceeding
+- [ ] Error message was clear and helpful (not technical/confusing)

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/prompt.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/prompt.md
@@ -1,0 +1,4 @@
+Apply our brand to the following landing page headline and subheading:
+
+Headline: "Welcome to Our Service"
+Subheading: "We provide the tools you need to succeed in today's market."

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/seed-data/search-brands-response.json
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-no-brand-found/seed-data/search-brands-response.json
@@ -1,0 +1,15 @@
+{
+  "description": "Mocked response from search_brands tool when no brands are found in the org.",
+  "tool": "search_brands",
+  "input": {
+    "inputs": [
+      {
+        "searchQuery": "brand"
+      }
+    ]
+  },
+  "response": {
+    "results": [],
+    "totalResults": 0
+  }
+}

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/gold/expected-output.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/gold/expected-output.md
@@ -1,0 +1,43 @@
+# Expected Output
+
+## Agent Behavior
+
+1. Agent calls `search_brands` with a general query
+2. Agent finds one brand ("Acme Corp Brand") and confirms with user: "I found the brand 'Acme Corp Brand'. Should I apply this brand's guidelines to the content?"
+3. After user confirms, agent calls `get_brand_instructions`
+4. Agent applies brand guidelines and produces branded email content
+
+## Expected Branded Email
+
+The generated email should:
+- Use a professional yet approachable voice
+- Have a warm, encouraging, empowering tone
+- Address the reader directly with "you"
+- Use active voice
+- Keep sentences under 20 words
+- Contain no more than 1 exclamation mark per paragraph
+- Not use superlatives ("best", "fastest", "most powerful")
+- Incorporate key messages where natural (innovation made simple, your success is our priority)
+
+## Example Branded Output
+
+"Hi, welcome to Acme Corp. We're glad you're here.
+
+You now have access to tools designed to help you succeed. Here's how to get started:
+
+1. Set up your profile so we can personalize your experience.
+2. Explore the dashboard to see what's available to you.
+3. Reach out to our team if you need guidance along the way.
+
+Your success drives everything we do. We're here to support you at every step."
+
+## Evaluation Criteria
+
+- [ ] Agent searched for brands before generating content
+- [ ] Agent confirmed brand selection with user
+- [ ] Agent extracted brand instructions before generating content
+- [ ] Output matches brand voice (professional yet approachable)
+- [ ] Output matches brand tone (warm, encouraging, empowering)
+- [ ] Content rules are respected (active voice, short sentences, "you" addressing)
+- [ ] Guardrails are not violated (no competitor names, no performance guarantees)
+- [ ] Agent summarized which guidelines were applied

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/gold/expected-output.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/gold/expected-output.md
@@ -40,4 +40,3 @@ Your success drives everything we do. We're here to support you at every step."
 - [ ] Output matches brand tone (warm, encouraging, empowering)
 - [ ] Content rules are respected (active voice, short sentences, "you" addressing)
 - [ ] Guardrails are not violated (no competitor names, no performance guarantees)
-- [ ] Agent summarized which guidelines were applied

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/prompt.md
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/prompt.md
@@ -1,0 +1,5 @@
+Apply my brand guidelines to the following welcome email:
+
+"Hi there, welcome to our platform! We're excited to have you on board. Here's what you can do to get started..."
+
+Make sure the email matches our brand voice and tone.

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/seed-data/get-brand-instructions-response.json
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/seed-data/get-brand-instructions-response.json
@@ -1,0 +1,10 @@
+{
+  "description": "Mocked response from get_brand_instructions tool for Acme Corp brand.",
+  "tool": "get_brand_instructions",
+  "input": {
+    "managedContentId": "9Pn5g000000XYZABC"
+  },
+  "response": {
+    "promptBody": "Brand: Acme Corp\n\nBrand Voice: Professional yet approachable. Speak with confidence and clarity. Avoid jargon.\n\nBrand Tone: Warm, encouraging, and empowering. Make the reader feel supported and capable.\n\nKey Messages:\n- Innovation made simple\n- Your success is our priority\n- Technology that works for you\n\nContent Rules:\n- Use active voice\n- Keep sentences under 20 words\n- Address the reader directly with \"you\"\n- Avoid superlatives (never say \"best\", \"fastest\", \"most powerful\")\n- Do not use exclamation marks excessively (max 1 per paragraph)\n\nGuardrails:\n- Never mention competitors by name\n- Do not make performance guarantees or promises\n- Avoid technical jargon unless explaining it immediately after"
+  }
+}

--- a/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/seed-data/search-brands-response.json
+++ b/skills/applying-cms-brand/tests/evals/applying-cms-brand-single-brand/seed-data/search-brands-response.json
@@ -1,0 +1,22 @@
+{
+  "description": "Mocked response from search_brands tool when a single brand exists in the org.",
+  "tool": "search_brands",
+  "input": {
+    "inputs": [
+      {
+        "searchQuery": "brand"
+      }
+    ]
+  },
+  "response": {
+    "results": [
+      {
+        "managedContentId": "9Pn5g000000XYZABC",
+        "managedContentKey": "MCK-brand-acme-corp",
+        "title": "Acme Corp Brand",
+        "contentUrl": "/cms/brand/acme-corp",
+        "totalResults": 1
+      }
+    ]
+  }
+}

--- a/skills/cms-branding/SKILL.md
+++ b/skills/cms-branding/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: cms-branding
+description: "Extracts, retrieves, and applies CMS brand guidelines (voice, tone, style, colors, typography) to generated content. Use this skill ANY TIME a user request involves branding, brand voice, brand tone, brand guidelines, brand identity, brand styling, or applying a brand to content. Triggers for requests like \"apply my brand\", \"use our brand voice\", \"match our brand guidelines\", \"find my brand\", \"search for brand\", \"get brand instructions\", \"apply brand tone\". Handles the full workflow: searching for brands in Salesforce CMS, extracting brand instructions, and applying brand voice/tone/guidelines to generated content. Does not apply to media/image search (use searching-media skill), logo search, or creating new brand definitions."
+compatibility: "Requires get_brand_instructions and/or search_brands MCP tools"
+metadata:
+  version: "1.0"
+---
+
+# CMS Branding
+
+Universal skill for searching, extracting, and applying CMS brand guidelines to generated content.
+
+## Scope
+
+**This skill is for APPLYING existing brand guidelines from Salesforce CMS to content you generate.**
+
+**Use this skill when the user wants to:**
+- Apply their brand voice/tone to generated content
+- Find and use brand guidelines stored in Salesforce CMS
+- Search for an existing brand in their org
+- Get brand instructions for content generation
+- Ensure generated content matches their brand identity
+- Apply brand styling, tone, or voice to a page, component, or app
+
+**DO NOT use this skill when the user wants to:**
+- Search for images or media (use searching-media skill)
+- Create a new brand from scratch
+- Edit brand definitions in CMS
+- Generate logos or visual brand assets
+
+## Before You Start
+
+**CRITICAL: You must retrieve brand instructions BEFORE generating or modifying any content.**
+
+When a user requests branded content:
+
+1. **Search for available brands** (if brand is not already identified)
+2. **Extract brand instructions** for the selected brand
+3. **Apply brand guidelines** to all content you generate
+
+**Never generate content first and retrofit branding later.** Brand instructions must inform content generation from the start.
+
+## Workflow Overview
+
+Copy this checklist and track your progress:
+
+```
+CMS Branding Progress:
+- [ ] Step 1: Determine if brand is already identified or needs search
+- [ ] Step 2: Search for brands (if needed) and present options to user
+- [ ] Step 3: Extract brand instructions for the selected brand
+- [ ] Step 4: Apply brand guidelines to generated content
+- [ ] Step 5: Confirm branding was applied correctly
+```
+
+## Step 1: Determine Brand Context
+
+Check if the user has already specified which brand to use:
+
+**Brand is known** (user named it, or only one brand exists):
+- Skip to Step 3 (Extract Brand Instructions)
+
+**Brand is unknown** (user says "apply my brand" without specifying which):
+- Proceed to Step 2 (Search for Brands)
+
+## Step 2: Search for Brands
+
+**Tool:** `search_brands`
+
+**Process:**
+
+1. **Determine search query** — Use the user's description, company name, or a general keyword
+2. **Build the request:**
+
+```json
+{
+  "inputs": [{
+    "searchQuery": "keyword or brand name"
+  }]
+}
+```
+
+3. **Call `search_brands`** with the query
+4. **Parse the response** — Extract brand results:
+   - `managedContentId` — Unique ID (use this for extraction in Step 3)
+   - `managedContentKey` — Content key identifier
+   - `title` — Brand display name
+   - `contentUrl` — URL to the brand content
+   - `totalResults` — Number of brands found
+
+### Presenting Brand Results
+
+**If multiple brands found**, use `ask_followup_question` to present options:
+
+```
+I found [N] brands in your CMS. Which one should I apply?
+
+1. [Brand Title 1]
+2. [Brand Title 2]
+3. [Brand Title 3]
+
+Which brand would you like to use?
+```
+
+**If one brand found**, confirm with the user:
+
+```
+I found the brand "[Brand Title]". Should I apply this brand's guidelines to the content?
+```
+
+**If no brands found:**
+
+```
+No brands found in Salesforce CMS. To use branding:
+1. Create a brand in Salesforce CMS (Content Type: sfdc_cms__brand)
+2. Provide brand guidelines directly in this conversation
+
+Would you like to proceed without CMS branding, or provide guidelines manually?
+```
+
+**Never auto-select a brand without confirmation.** Always wait for user choice.
+
+## Step 3: Extract Brand Instructions
+
+**Tool:** `get_brand_instructions`
+
+**Process:**
+
+1. **Call `get_brand_instructions`** — This retrieves the branding extraction prompt template
+2. **Parse the response:**
+   - `promptBody` — Contains the full brand instruction prompt with extraction and application rules
+
+3. **Follow the instructions in `promptBody`** — The prompt template contains specific guidance on:
+   - How to extract brand properties from the brand content
+   - Brand voice and tone rules
+   - Typography and color guidelines
+   - Content formatting rules
+   - Guardrails and restrictions
+
+### What Brand Instructions Contain
+
+The extracted brand instructions typically include:
+
+| Property | Description |
+|---|---|
+| Brand Voice | How the brand speaks (e.g., professional, friendly, authoritative) |
+| Brand Tone | Emotional quality of communication (e.g., confident, warm, empathetic) |
+| Key Messages | Core messaging pillars and value propositions |
+| Content Rules | Dos and don'ts for content generation |
+| Style Guidelines | Typography, color, spacing preferences |
+| Guardrails | Hard restrictions on language, topics, or claims |
+
+## Step 4: Apply Brand Guidelines
+
+After extracting brand instructions, apply them to ALL content you generate:
+
+### Text Content
+- Match the specified brand voice and tone
+- Use approved terminology and key messages
+- Respect content guardrails (forbidden words, topics, claims)
+- Follow formatting guidelines (sentence length, paragraph structure)
+
+### UI Components (React/LWC)
+- Apply brand colors using CSS custom properties or design tokens
+- Use specified typography (font family, sizes, weights)
+- Follow spacing and layout guidelines
+- Match the visual tone (minimal, bold, playful, etc.)
+
+### Code Generation
+- Apply brand colors as variables/tokens at the top of stylesheets
+- Use semantic naming that reflects brand terminology
+- Include comments referencing which brand guideline drove a decision (only when non-obvious)
+
+### Application Pattern
+
+```
+When generating content with branding:
+
+1. Read the brand instructions from Step 3
+2. Identify applicable guidelines for the content type
+3. Generate content that adheres to ALL applicable guidelines
+4. Self-check: Does this content match the brand voice? Tone? Rules?
+5. If any guideline is violated, regenerate the affected content
+```
+
+## Step 5: Confirm Application
+
+After applying branding:
+
+1. Summarize which brand guidelines were applied
+2. Highlight any guidelines that couldn't be applied (and why)
+3. Ask the user if the branding feels right
+
+```
+I applied the "[Brand Name]" brand guidelines:
+- Voice: [description]
+- Tone: [description]
+- Colors: [applied where]
+- [Other guidelines applied]
+
+Does the branding look correct, or would you like adjustments?
+```
+
+## Error Handling
+
+| Error | Response |
+|---|---|
+| `search_brands` unavailable | "Brand search is unavailable. Please provide your brand name or guidelines directly." |
+| `get_brand_instructions` unavailable | "Cannot retrieve brand instructions. Please share your brand guidelines in this conversation and I'll apply them manually." |
+| Org lacks Vibes branding | "CMS branding is not enabled for this org. Contact your admin to enable the Agentforce Vibes branding feature." |
+| Permission denied | "You don't have permission to access CMS brands. Ensure you have Managed Content Authoring permission." |
+| Brand extraction returns empty | "The brand exists but has no configured guidelines. Please add brand properties in CMS or provide guidelines here." |
+
+**Never silently fail.** Always inform the user and offer alternatives.
+
+## Key Principles
+
+1. **Brand first, content second** — Always extract brand instructions before generating content
+2. **Never assume brand guidelines** — Only apply what was explicitly retrieved from CMS
+3. **Respect guardrails absolutely** — Brand content rules are hard constraints, not suggestions
+4. **Confirm brand selection** — Never auto-select a brand without user confirmation
+5. **Show your work** — Tell the user which guidelines you applied and how
+6. **Graceful degradation** — If tools are unavailable, ask for manual guidelines rather than proceeding without branding


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

Adds `skills/cms-branding/SKILL.md` — a routing skill that searches Salesforce CMS for a brand and applies its voice/tone/style guidelines to generated content via `search_brands` and `get_brand_instructions` MCP tools.

## Why

Replaces ad-hoc MCP tool calls with a declarative, trigger-matched skill Vibes can auto-select.

## Notes

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in \`templates/\`, \`examples/\`, or \`docs/\` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([\`npm run validate:skills\`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains \`SKILL.md\`
- Frontmatter \`name\` matches directory name; \`description\` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)