### PR TITLE
@W-22279874 : Refactor CLT Skills using Progressive Disclosure

### DIFF
--- a/skills/generating-custom-lightning-type/SKILL.md
+++ b/skills/generating-custom-lightning-type/SKILL.md
@@ -56,39 +56,8 @@ Custom Lightning Types (CLTs) are JSON Schema-based type definitions used by the
 - **Object type validation**: the CLT root is validated to ensure `lightning:type` is exactly `lightning__objectType`.
 
 ## Primitive Types & Constraints
-- `lightning__textType`
-  - Max length 255
-- `lightning__multilineTextType`
-  - Max length 2000
-- `lightning__richTextType`
-  - Max length 100000
-- `lightning__urlType`
-  - Max length 2000
-  - Optional `lightning:allowedUrlSchemes` enum values: `https`, `http`, `relative`, `mailto`, `tel`
-- `lightning__dateType`
-  - Data pattern: YYYY-MM-DD
-- `lightning__timeType`
-  - Data pattern: HH:MM:SS.sssZ
-- `lightning__dateTimeType`
-  - Data shape is an object with required `dateTime` and optional `timeZone`
-- `lightning__numberType`
-  - Decimal numbers; optional `maximum`, `minimum`, `multipleOf`
-- `lightning__integerType`
-  - Whole numbers only; optional `maximum`, `minimum`
-- `lightning__booleanType`
-  - true/false
 
-## Allowed Property-Level Keywords
-When strict validation is enabled (`unevaluatedProperties: false`), keep each property minimal and prefer only keywords known to be allowed:
-- `title`, `description`, `einstein:description`
-- `type` (when used, ensure it matches the chosen `lightning:type`)
-- `lightning:type`
-- `maximum`, `minimum`, `multipleOf` (numeric)
-- `maxLength`, `minLength` (string)
-- `const`, `enum`
-- `lightning:textIndexed`, `lightning:supportsPersonalization`, `lightning:localizable`
-- `lightning:uiOptions`, `lightning:allowedUrlSchemes`
-- `lightning:tags` (metaschema restricts values; currently `flow` is the only known allowed tag)
+When you need the full list of supported primitive types, their constraints, and allowed property-level keywords, read `assets/primitive-types-and-constraints.md`.
 
 ## Generation Workflow
 1. **Confirm the CLT approach**
@@ -164,11 +133,6 @@ When strict validation is enabled (`unevaluatedProperties: false`), keep each pr
          </targets>
      </LightningComponentBundle>
      ```
-7. **Deploy and validate**
-   - Run a final schema sanity check before deploy: valid `lightning:type` names, required fields present, and no disallowed keywords.
-   - Deploy the bundle using your org's standard metadata deployment flow (e.g. Salesforce CLI or IDE). The MCP client or tooling in use should provide or integrate with the appropriate deploy/retrieve commands for Lightning Type bundles.
-   - Validate incrementally: if deployment fails, remove disallowed keywords first (especially `examples`, `items`, nested `lightning:type`).
-
 ## Common Deployment Errors
 | Error / Symptom | Likely Cause | Fix |
 |---|---|---|

--- a/skills/generating-custom-lightning-type/assets/primitive-types-and-constraints.md
+++ b/skills/generating-custom-lightning-type/assets/primitive-types-and-constraints.md
@@ -1,0 +1,41 @@
+# Primitive Types & Constraints
+
+Reference for all supported Lightning primitive types and their allowed constraints.
+
+## Supported Types
+
+- `lightning__textType`
+  - Max length 255
+- `lightning__multilineTextType`
+  - Max length 2000
+- `lightning__richTextType`
+  - Max length 100000
+- `lightning__urlType`
+  - Max length 2000
+  - Optional `lightning:allowedUrlSchemes` enum values: `https`, `http`, `relative`, `mailto`, `tel`
+- `lightning__dateType`
+  - Data pattern: YYYY-MM-DD
+- `lightning__timeType`
+  - Data pattern: HH:MM:SS.sssZ
+- `lightning__dateTimeType`
+  - Data shape is an object with required `dateTime` and optional `timeZone`
+- `lightning__numberType`
+  - Decimal numbers; optional `maximum`, `minimum`, `multipleOf`
+- `lightning__integerType`
+  - Whole numbers only; optional `maximum`, `minimum`
+- `lightning__booleanType`
+  - true/false
+
+## Allowed Property-Level Keywords
+
+When strict validation is enabled (`unevaluatedProperties: false`), keep each property minimal and prefer only keywords known to be allowed:
+
+- `title`, `description`, `einstein:description`
+- `type` (when used, ensure it matches the chosen `lightning:type`)
+- `lightning:type`
+- `maximum`, `minimum`, `multipleOf` (numeric)
+- `maxLength`, `minLength` (string)
+- `const`, `enum`
+- `lightning:textIndexed`, `lightning:supportsPersonalization`, `lightning:localizable`
+- `lightning:uiOptions`, `lightning:allowedUrlSchemes`
+- `lightning:tags` (metaschema restricts values; currently `flow` is the only known allowed tag)


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

<!-- Briefly describe what skill(s) were added, updated, or removed. -->

- Moved Primitive Types & Constraints and Allowed Property-Level Keywords from inline SKILL.md into assets/primitive-types-and-constraints.md
- Replaced both inline sections in SKILL.md with a single reference line (progressive disclosure)
- Removed Step 7 (Deploy and validate) from the Generation Workflow

## Why

<!-- What gap does this fill, or what problem does it solve? -->
Follow-up to [PR #190](https://github.com/forcedotcom/afv-library/pull/190) review feedback (W-22279874):

- Progressive disclosure — primitive type tables are reference material consulted on demand, not core workflow. Inlining them forced every CLT task to load the full table upfront. Moving to assets/ matches the pattern already used in generating-apex/.
- Step 7 was out of scope — deployment requires org credentials and CLI tooling, which sit outside skill boundaries. Skills generate artifacts; the user owns deploy.

## Notes

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

- Verified locally by swapping the updated skill into the Vibes install path and generating a CLT — schema produced correctly, no deploy instructions emitted, asset loaded only when constraint questions were asked

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
