### PR TITLE
chore: @W-22268829@ rename afv-library to sf-skills across all references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,21 +12,21 @@ To contribute, create your own copy:
 2.  Click the **Fork** button in the top-right corner.
 3.  Select your GitHub account as the destination.
 4.  GitHub will create your personal fork at:
-    `https://github.com/<your-username>/afv-library`.
+    `https://github.com/<your-username>/sf-skills`.
 
 ## 2. Clone Your Fork
 
 Clone your personal fork:
 
 ``` sh
-git clone https://github.com/<your-username>/afv-library.git
-cd afv-library
+git clone https://github.com/<your-username>/sf-skills.git
+cd sf-skills
 ```
 
 Add the original repository as the upstream remote:
 
 ``` sh
-git remote add upstream https://github.com/forcedotcom/afv-library.git
+git remote add upstream https://github.com/forcedotcom/sf-skills.git
 ```
 
 ## 3. Create a Branch
@@ -61,7 +61,7 @@ GitHub will display a **Compare & pull request** button.
 Once your branch is pushed to your fork, you can open a Pull Request
 (PR) to propose merging your changes into this repository.
 
-Unsure that your PR title is prefixed with  `feat:` or `fix:` as those will result in an update to the change log 
+Ensure that your PR title is prefixed with  `feat:` or `fix:` as those will result in an update to the change log 
 and inclusion in SF tooling. 
 
 ### 6.1 Start the Pull Request
@@ -76,7 +76,7 @@ Click it.
 **Option B --- Manually**
 
 1.  Go to your fork on GitHub:\
-    `https://github.com/<your-username>/afv-library`
+    `https://github.com/<your-username>/sf-skills`
 2.  Switch to your feature branch.
 3.  Click the **Pull requests** tab.
 4.  Click **New pull request**.
@@ -88,15 +88,15 @@ Click it.
 
 Make sure GitHub is targeting the correct repositories and branches:
 
--   **Base repository:** `forcedotcom/afv-library`
+-   **Base repository:** `forcedotcom/sf-skills`
 -   **Base branch:** `main`
--   **Head repository:** `<your-username>/afv-library`
+-   **Head repository:** `<your-username>/sf-skills`
 -   **Head branch:** your feature branch (`my-feature-name`)
 
 Correct configuration:
 
-    base: forcedotcom/afv-library → main
-    compare: <your-username>/afv-library → my-feature-name
+    base: forcedotcom/sf-skills → main
+    compare: <your-username>/sf-skills → my-feature-name
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The skills are contributed by Salesforce and the broader community. It’s optim
 ## 🗂️ Structure
 
 ```
-afv-library/
+sf-skills/
 ├── skills/               # Directory-based executable workflows
 │   ├── generating-apex/
 │   ├── generating-custom-object/
@@ -26,7 +26,7 @@ afv-library/
 | **Tool** | **Usage** |
 |----------|-------------|
 | **Agentforce Vibes** | Skills are auto-installed and auto-updated |
-| **OpenCode, Claude Code, Codex, Cursor, [more](https://agentskills.io/)** | `npx skills add forcedotcom/afv-library` |
+| **OpenCode, Claude Code, Codex, Cursor, [more](https://agentskills.io/)** | `npx skills add forcedotcom/sf-skills` |
 
 ## 📦 Samples
 

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -399,7 +399,7 @@ function main(): void {
   }
 
   const hasIssues = allErrors.length > 0 || allWarnings.length > 0
-  const footer = "Spec: https://agentskills.io/specification · Authoring guide: https://github.com/forcedotcom/afv-library#readme"
+  const footer = "Spec: https://agentskills.io/specification · Authoring guide: https://github.com/forcedotcom/sf-skills#readme"
 
   if (allWarnings.length > 0) {
     console.warn(`\n${allWarnings.length} warning(s):\n`)

--- a/skills/generating-permission-set/SKILL.md
+++ b/skills/generating-permission-set/SKILL.md
@@ -3,7 +3,7 @@ name: generating-permission-set
 description: "Generates correct, deployable Salesforce permission set metadata (PermissionSet XML) with object, field, user, and app permissions. Use this skill when creating or editing permission set metadata, object permissions, field-level security (FLS), tab visibility, or deploying permission sets."
 compatibility: Salesforce Metadata API v60.0+
 metadata:
-  author: afv-library
+  author: sf-skills
   version: "1.0"
 ---
 


### PR DESCRIPTION
@W-22268829@

Update all in-repo references from afv-library to sf-skills in README, CONTRIBUTING, scripts, and skill files to reflect the upcoming GitHub repo rename from forcedotcom/afv-library to forcedotcom/sf-skills.

**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

<!-- Briefly describe what skill(s) were added, updated, or removed. -->

## Why

<!-- What gap does this fill, or what problem does it solve? -->

## Notes

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [ ] Clear goal statement
- [ ] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
