### PR TITLE
feat: sync-validate-skill-main-branch-changes-from-internal-to-public @W-22488862@

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validate-skills:
-    runs-on: salesforce-internal-Ubuntu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validate-skills:
-    runs-on: ubuntu-latest
+    runs-on: salesforce-internal-Ubuntu
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -190,6 +190,52 @@ Wrap values that contain \`: \` (colon + space), such as long descriptions with 
     },
   },
   {
+    description: 'Frontmatter "description" value must be wrapped in double quotes',
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const descLine = rawFrontmatter.split(/\r?\n/).find((l) => l.startsWith("description:"))
+      if (!descLine) return { errors: [] }
+      const rawValue = descLine.slice(descLine.indexOf(":") + 1).trim()
+      if (!rawValue.startsWith('"') || !rawValue.endsWith('"')) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: description value must be wrapped in double quotes — got: ${rawValue.slice(0, 60)}${rawValue.length > 60 ? "…" : ""}`,
+          ],
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
+    description:
+      'Special characters in description must be escaped (\\\\ and \\")',
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const descLine = rawFrontmatter.split(/\r?\n/).find((l) => l.startsWith("description:"))
+      if (!descLine) return { errors: [] }
+      const rawValue = descLine.slice(descLine.indexOf(":") + 1).trim()
+      if (!rawValue.startsWith('"') || !rawValue.endsWith('"')) return { errors: [] }
+      const inner = rawValue.slice(1, -1)
+      const issues: string[] = []
+      // Strip valid escape sequences (\\, \") then check for remaining backslashes or unescaped quotes
+      const stripped = inner.replace(/\\\\|\\"/g, "")
+      if (stripped.includes('"')) {
+        issues.push('unescaped " (use \\")')
+      }
+      if (stripped.includes("\\")) {
+        issues.push("unescaped \\ (use \\\\)")
+      }
+      if (issues.length > 0) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: description contains ${issues.join(", ")}`,
+          ],
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
     description: "SKILL.md must have a non-empty body (instructions after the frontmatter block)",
     run({ dirName, body }) {
       if (!body.trim()) {
@@ -237,6 +283,126 @@ Wrap values that contain \`: \` (colon + space), such as long descriptions with 
     },
   },
   {
+    description: "Metadata field must be a key-value map (not scalar or array)",
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const meta = parseMetadataBlock(rawFrontmatter)
+      if (meta === null) return { errors: [] }
+      if (meta === "scalar") {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: "metadata" must be a key-value map, not an inline scalar — use indented sub-keys (e.g. metadata:\\n  version: "1.0")`,
+          ],
+        }
+      }
+      if (meta === "list") {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: "metadata" must be a key-value map, not a YAML list — use indented key-value pairs instead of "- " list items`,
+          ],
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
+    description: 'Frontmatter must include a metadata block with a "version" field',
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const meta = parseMetadataBlock(rawFrontmatter)
+
+      // Fail if no metadata block exists
+      if (meta === null) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: frontmatter must include a "metadata:" block with a "version" field (e.g. metadata:\\n  version: "1.0")`,
+          ],
+        }
+      }
+
+      // Fail if metadata is a scalar (inline value)
+      if (typeof meta === "string") {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: metadata must be a key-value block, not an inline scalar — use indented sub-keys (e.g. metadata:\\n  version: "1.0")`,
+          ],
+        }
+      }
+
+      // Fail if version is missing inside metadata
+      if (!meta.version) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: metadata is missing required "version" field (e.g. version: "1.0")`,
+          ],
+        }
+      }
+
+      return { errors: [] }
+    },
+  },
+  {
+    description: 'Version must follow x.y format (e.g. "1.0", "2.5")',
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const meta = parseMetadataBlock(rawFrontmatter)
+      if (meta === null || typeof meta === "string") return { errors: [] }
+      if (!meta.version) return { errors: [] }
+      const versionPattern = /^\d+\.\d+$/
+      if (!versionPattern.test(meta.version)) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: version must follow x.y format (e.g. "1.0", "2.5") — got: "${meta.version}"`,
+          ],
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
+    description: "Compatibility field (if present) must be at most 500 characters",
+    run({ dirName, frontmatter }) {
+      if (!frontmatter) return { errors: [] }
+      if (!("compatibility" in frontmatter)) return { errors: [] }
+      const len = frontmatter.compatibility?.length ?? 0
+      if (len > 500) {
+        return {
+          errors: [`skills/${dirName}/SKILL.md: compatibility is ${len} characters (maximum 500)`],
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
+    description: "Allowed-tools field (if present) must be a string (not array or object)",
+    run({ dirName, rawFrontmatter }) {
+      if (rawFrontmatter === null) return { errors: [] }
+      const line = rawFrontmatter.split(/\r?\n/).find((l) => l.startsWith("allowed-tools:"))
+      if (!line) return { errors: [] }
+      const rawValue = line.slice(line.indexOf(":") + 1).trim()
+      if (rawValue.startsWith("[") || rawValue.startsWith("{")) {
+        return {
+          errors: [
+            `skills/${dirName}/SKILL.md: "allowed-tools" must be a plain string (space-separated tool names), not a YAML array or object — got: ${rawValue.slice(0, 60)}`,
+          ],
+        }
+      }
+      const nextLineIdx = rawFrontmatter.split(/\r?\n/).indexOf(line) + 1
+      const lines = rawFrontmatter.split(/\r?\n/)
+      if (nextLineIdx < lines.length) {
+        const nextLine = lines[nextLineIdx]
+        if (nextLine.match(/^\s+- /)) {
+          return {
+            errors: [
+              `skills/${dirName}/SKILL.md: "allowed-tools" must be a plain string, not a YAML list — use space-separated tool names (e.g. "Bash Read Write")`,
+            ],
+          }
+        }
+      }
+      return { errors: [] }
+    },
+  },
+  {
     description: "Skill body should be under 500 lines for context efficiency",
     run({ dirName, body }) {
       const lines = body.split("\n").length
@@ -250,6 +416,35 @@ Wrap values that contain \`: \` (colon + space), such as long descriptions with 
     },
   },
 ]
+
+/**
+ * Extracts nested key-value pairs from the `metadata:` block in raw frontmatter.
+ * Returns `null` if no metadata block, `"scalar"` if metadata has an inline value,
+ * `"list"` if it contains YAML list items, or a `Record` of sub-keys.
+ */
+function parseMetadataBlock(rawFrontmatter: string): Record<string, string> | "scalar" | "list" | null {
+  const lines = rawFrontmatter.split(/\r?\n/)
+  const metaIdx = lines.findIndex((l) => /^metadata\s*:/.test(l))
+  if (metaIdx === -1) return null
+
+  const metaLine = lines[metaIdx]
+  const inlineValue = metaLine.slice(metaLine.indexOf(":") + 1).trim()
+  if (inlineValue && !inlineValue.startsWith("#")) return "scalar"
+
+  const result: Record<string, string> = {}
+  for (let i = metaIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line.startsWith(" ") && !line.startsWith("\t")) break
+    const trimmed = line.trim()
+    if (trimmed.startsWith("- ")) return "list"
+    const colonIdx = trimmed.indexOf(":")
+    if (colonIdx === -1) continue
+    const key = trimmed.slice(0, colonIdx).trim()
+    const raw = trimmed.slice(colonIdx + 1).trim()
+    result[key] = raw.replace(/^(['"])([\s\S]*)\1$/, "$2")
+  }
+  return result
+}
 
 /**
  * Returns the deduplicated list of top-level skill directory names that have

--- a/skills/building-ui-bundle-frontend/SKILL.md
+++ b/skills/building-ui-bundle-frontend/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: building-ui-bundle-frontend
 description: "MUST activate before editing ANY file under uiBundles/*/src/ for visual or UI changes to an EXISTING app — pages, components, sections, layout, styling, colors, fonts, navigation, animations, or any look-and-feel change. Use this skill when modifying pages, components, layout, styling, or navigation in an existing UI bundle app. Activate when the project contains appLayout.tsx, routes.tsx, src/pages/, src/components/, or global.css. This skill contains critical project-specific conventions (appLayout.tsx shell, shadcn/ui components, Tailwind CSS, Salesforce base-path routing, module restrictions) that override general knowledge. Without this skill, generated code will use wrong imports, break routing, or ignore project structure. Do NOT use when creating a new app from scratch (use building-ui-bundle-app instead)."
+metadata:
+  version: "1.0"
 ---
 
 # UI Bundle UI

--- a/skills/deploying-ui-bundle/SKILL.md
+++ b/skills/deploying-ui-bundle/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deploying-ui-bundle
 description: "MUST activate when the project contains a uiBundles/*/src/ directory or sfdx-project.json and the task involves deploying, pushing to an org, or post-deploy setup. Use this skill when deploying a UI bundle app to a Salesforce org. Covers the full deployment sequence: org authentication, pre-deploy build, metadata deployment, permission set assignment, data import, GraphQL schema fetch, and codegen. Activate when files like *.uibundle-meta.xml or sfdx-project.json exist and the user mentions deploying, pushing, org setup, or post-deploy tasks."
+metadata:
+  version: "1.0"
 ---
 
 # Deploying a UI Bundle

--- a/skills/developing-agentforce/SKILL.md
+++ b/skills/developing-agentforce/SKILL.md
@@ -4,7 +4,7 @@ description: "Build, modify, debug, and deploy agents with Agentforce Agent Scri
 license: Apache-2.0
 compatibility: "Requires Agentforce license, API v66.0+, Einstein Agent User"
 metadata:
-  version: "0.5.1"
+  version: "1.0"
   last_updated: "2026-04-08"
 ---
 

--- a/skills/generating-apex-test/SKILL.md
+++ b/skills/generating-apex-test/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-apex-test
-description: Generate and validate Apex test classes with TestDataFactory patterns, bulk testing (251+ records), mocking strategies, assertion best practices, and disciplined test-fix loops. Use this skill when creating new Apex test classes, improving test coverage, debugging and fixing failing Apex tests, running test execution and coverage analysis, or implementing testing patterns for triggers, services, controllers, batch jobs, queueables, and integrations. Triggers on *Test.cls, *_Test.cls files, sf apex run test workflows, coverage reports, test-fix loops. Do NOT trigger for production Apex code (use generating-apex) or Jest/LWC tests.
+description: "Generate and validate Apex test classes with TestDataFactory patterns, bulk testing (251+ records), mocking strategies, assertion best practices, and disciplined test-fix loops. Use this skill when creating new Apex test classes, improving test coverage, debugging and fixing failing Apex tests, running test execution and coverage analysis, or implementing testing patterns for triggers, services, controllers, batch jobs, queueables, and integrations. Triggers on *Test.cls, *_Test.cls files, sf apex run test workflows, coverage reports, test-fix loops. Do NOT trigger for production Apex code (use generating-apex) or Jest/LWC tests."
+metadata:
+  version: "1.0"
 ---
 
 # Generating Apex Tests

--- a/skills/generating-apex/SKILL.md
+++ b/skills/generating-apex/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-apex
-description: Primary Apex authoring skill for class generation, refactoring, and review. ALWAYS ACTIVATE when the user mentions Apex, .cls, triggers, or asks to create/refactor a class (service, selector, domain, batch, queueable, schedulable, invocable, DTO, utility, interface, abstract, exception, REST resource). Use this skill for requests involving SObject CRUD, mapping collections, fetching related records, scheduled jobs, batch jobs, trigger design, @AuraEnabled controllers, @RestResource endpoints, custom REST APIs, or code review of existing Apex.
+description: "Primary Apex authoring skill for class generation, refactoring, and review. ALWAYS ACTIVATE when the user mentions Apex, .cls, triggers, or asks to create/refactor a class (service, selector, domain, batch, queueable, schedulable, invocable, DTO, utility, interface, abstract, exception, REST resource). Use this skill for requests involving SObject CRUD, mapping collections, fetching related records, scheduled jobs, batch jobs, trigger design, @AuraEnabled controllers, @RestResource endpoints, custom REST APIs, or code review of existing Apex."
+metadata:
+  version: "1.0"
 ---
 
 # Generating Apex

--- a/skills/generating-custom-application/SKILL.md
+++ b/skills/generating-custom-application/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-custom-application
 description: "Use this skill when users need to create or configure Salesforce Custom Applications. Trigger when users mention custom apps, application metadata, app navigation, or organizing tabs into applications. Use when users want to create app containers for tabs and pages. Always use this skill for custom application work."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-custom-field/SKILL.md
+++ b/skills/generating-custom-field/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-custom-field
 description: "Use this skill when users need to create, generate, or validate Salesforce Custom Field metadata. Trigger when users mention custom fields, field types, Roll-up Summary fields, Master-Detail relationships, Lookup relationships, formula fields, picklists, or field metadata. Also use when users encounter field deployment errors, especially around Roll-up Summary format, Master-Detail constraints, or formula issues. Always use this skill for any custom field metadata work, field generation, or field troubleshooting."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-custom-lightning-type/SKILL.md
+++ b/skills/generating-custom-lightning-type/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-custom-lightning-type
 description: "Use this skill when users need to create Custom Lightning Types (CLTs) for Einstein Agent actions or structured input/output schemas. Trigger when users mention CLT, Custom Lightning Types, JSON schemas for agents, type definitions, lightning__objectType, or editor/renderer configurations. This is complex - always use this skill for CLT work."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-custom-object/SKILL.md
+++ b/skills/generating-custom-object/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-custom-object
 description: "Use this skill when users need to create, generate, or validate Salesforce Custom Object metadata. Trigger when users mention custom objects, creating objects, object metadata, .object files, sharing models, name fields, or validation rules on objects. Also use when users say things like \"create a custom object\", \"generate object metadata\", \"set up an object for...\", or when they're troubleshooting object deployment errors especially around sharing models and Master-Detail relationships. Always use this skill for any custom object metadata work."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-custom-tab/SKILL.md
+++ b/skills/generating-custom-tab/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-custom-tab
 description: "Use this skill when users need to create or configure Salesforce Custom Tabs. Trigger when users mention tabs, navigation tabs, object tabs, web tabs, Visualforce tabs, Lightning component tabs, app page tabs, or tab configuration. Also use when users want to add navigation to custom objects, create tabs for external content, or set up Lightning page tabs. Always use this skill for any custom tab work."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-flexipage/SKILL.md
+++ b/skills/generating-flexipage/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-flexipage
 description: "Use this skill when users need to create, generate, modify, or validate Salesforce Lightning pages (FlexiPages). Trigger when users mention RecordPage, AppPage, HomePage, Lightning pages, page layouts, adding components to pages, or page customization. Also use when users say things like 'create a Lightning page', 'add a component to a page', 'customize the record page', 'generate a FlexiPage', or when they're working with FlexiPage XML files and need help with components, regions, or deployment errors. Always use this skill for any FlexiPage-related work, even if they just mention 'page' in the context of Salesforce."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-flow/SKILL.md
+++ b/skills/generating-flow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-flow
 description: "Generate Salesforce Flows using the MCP tool execute_metadata_action. Use when the user asks to create, build, or generate a flow — including Screen, Autolaunched, Record-Triggered (before/after-save), Scheduled. Also trigger for flow-like requests such as \"when a record is created\", \"trigger daily at\", \"send an email when\", \"update the field when\", \"automate\", \"workflow\", or \"flow XML/metadata\". This is the only skill for Salesforce Flow generation."
+metadata:
+  version: "1.0"
 ---
 
 ## Goal

--- a/skills/generating-lightning-app/SKILL.md
+++ b/skills/generating-lightning-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generating-lightning-app
-description: Build complete Salesforce Lightning Experience applications from natural language descriptions. Use this skill when a user requests a "complete app", "Lightning app", "business solution", "management system", or describes a scenario requiring multiple interconnected Salesforce components (objects, fields, pages, tabs, security). Orchestrates all required metadata types in proper dependency order to produce a deployable application.
+description: "Build complete Salesforce Lightning Experience applications from natural language descriptions. Use this skill when a user requests a \"complete app\", \"Lightning app\", \"business solution\", \"management system\", or describes a scenario requiring multiple interconnected Salesforce components (objects, fields, pages, tabs, security). Orchestrates all required metadata types in proper dependency order to produce a deployable application."
 metadata:
   version: "1.0"
   related-skills: generating-custom-object, generating-custom-field, generating-custom-tab, generating-flexipage, generating-custom-application, generating-flow, generating-validation-rule, generating-list-view, generating-permission-set

--- a/skills/generating-list-view/SKILL.md
+++ b/skills/generating-list-view/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-list-view
 description: "Use this skill when users need to create, generate, or validate Salesforce List View metadata. Trigger when users mention list views, filtered record lists, creating views, setting up record columns, filtering records by criteria, or ask about list view visibility. Also use when users say things like \"I need a view that shows...\", \"filter records by...\", \"create a list view for...\", or when they're working with ListView XML files and need validation or troubleshooting."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/generating-ui-bundle-features/SKILL.md
+++ b/skills/generating-ui-bundle-features/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-ui-bundle-features
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and the user wants to add authentication or search to their app. Use this skill when adding authentication or search to a UI bundle app. Only covers two features: authentication (login, logout, protected routes, session management) and search (global search across pages and content). Always use this skill for these two features instead of building from scratch."
+metadata:
+  version: "1.0"
 ---
 
 # UI Bundle Features

--- a/skills/generating-ui-bundle-metadata/SKILL.md
+++ b/skills/generating-ui-bundle-metadata/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-ui-bundle-metadata
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and scaffolding a new UI bundle or app, or when editing ui-bundle.json, .uibundle-meta.xml, or CSP trusted site files. Use this skill when scaffolding with sf template generate ui-bundle, configuring ui-bundle.json (routing, headers, outputDir), or registering CSP Trusted Sites. Activate when the task involves files matching *.uibundle-meta.xml, ui-bundle.json, or cspTrustedSites/*.cspTrustedSite-meta.xml."
+metadata:
+  version: "1.0"
 ---
 
 # UI Bundle Metadata

--- a/skills/generating-ui-bundle-site/SKILL.md
+++ b/skills/generating-ui-bundle-site/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-ui-bundle-site
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and the task involves creating or configuring site infrastructure. Use this skill when creating or configuring a Salesforce Digital Experience Site for hosting a UI bundle. Activate when files matching digitalExperiences/, networks/, customSite/, or DigitalExperienceBundle exist and need modification, or when the user wants to publish, host, or configure guest access for their app."
+metadata:
+  version: "1.0"
 ---
 
 # Digital Experience Site for React UI Bundles

--- a/skills/generating-validation-rule/SKILL.md
+++ b/skills/generating-validation-rule/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-validation-rule
 description: "Use this skill when users need to create, modify, or validate Salesforce Validation Rules. Trigger when users mention validation rules, field validation, data quality rules, formula validation, error messages, or validation logic. Also use when users encounter validation errors, need to update formulas, or want to enforce business rules at the data layer. Always use this skill for any validation rule work."
+metadata:
+  version: "1.0"
 ---
 
 ## When to Use This Skill

--- a/skills/implementing-ui-bundle-agentforce-conversation-client/SKILL.md
+++ b/skills/implementing-ui-bundle-agentforce-conversation-client/SKILL.md
@@ -3,7 +3,7 @@ name: implementing-ui-bundle-agentforce-conversation-client
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and the task involves adding or modifying a chat widget, chatbot, or conversational AI. Use this skill when the user asks to add, embed, integrate, configure, style, or remove an agent, chatbot, chat widget, conversation client, or AI assistant. Covers styling (colors, fonts, spacing, borders), layout (inline vs floating, width, height, dimensions), and props (agentId, agentLabel, headerEnabled, showHeaderIcon, showAvatar, styleTokens). Activate when files under uiBundles/*/src/ import AgentforceConversationClient or when adding any chat or agent functionality to a page. Never create a custom agent, chatbot, or chat widget component."
 metadata:
   author: ACC Components
-  version: 1.0.1
+  version: "1.0"
   package: "@salesforce/ui-bundle-template-feature-react-agentforce-conversation-client"
   sdk-package: "@salesforce/agentforce-conversation-client"
   last-updated: 2025-04-01

--- a/skills/implementing-ui-bundle-file-upload/SKILL.md
+++ b/skills/implementing-ui-bundle-file-upload/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: implementing-ui-bundle-file-upload
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and the task involves uploading, attaching, or dropping files. Use this skill when adding file upload functionality to a UI bundle app. Provides progress tracking and Salesforce ContentVersion integration. This feature provides programmatic APIs ONLY — build custom UI using the upload() API. ALWAYS use this instead of building file upload from scratch with FormData or XHR."
+metadata:
+  version: "1.0"
 ---
 
 # File Upload API (workflow)

--- a/skills/observing-agentforce/SKILL.md
+++ b/skills/observing-agentforce/SKILL.md
@@ -4,7 +4,7 @@ description: "Analyze production Agentforce agent behavior using session traces 
 allowed-tools: Bash Read Write Edit Glob Grep
 license: Apache-2.0
 metadata:
-  version: "0.5.1"
+  version: "1.0"
   last_updated: "2026-04-08"
   argument-hint: "<org-alias> [--agent-file <path>] [--session-id <id>] [--days <n>]"
   compatibility: claude-code

--- a/skills/switching-org/SKILL.md
+++ b/skills/switching-org/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: switching-org
-description: Switches the active Salesforce org (default target-org) using the Salesforce CLI. Use whenever someone wants to change which org CLI commands run against — whether they say "switch org", "change default org", "set my org to", "use alias", "point to", or describe wanting to work against a specific org, scratch org, sandbox, or production.
+description: "Switches the active Salesforce org (default target-org) using the Salesforce CLI. Use whenever someone wants to change which org CLI commands run against — whether they say \"switch org\", \"change default org\", \"set my org to\", \"use alias\", \"point to\", or describe wanting to work against a specific org, scratch org, sandbox, or production."
 compatibility: Salesforce CLI (sf) v2+
 metadata:
   version: "1.0"

--- a/skills/testing-agentforce/SKILL.md
+++ b/skills/testing-agentforce/SKILL.md
@@ -4,7 +4,7 @@ description: "Write, run, and analyze structured test suites for Agentforce agen
 allowed-tools: Bash Read Write Edit Glob Grep
 license: Apache-2.0
 metadata:
-  version: "0.5.1"
+  version: "1.0"
   last_updated: "2026-04-08"
   argument-hint: "<org-alias> --authoring-bundle <AgentName> [--utterances <file>] | run <org> --target <flow://Name>"
   compatibility: claude-code

--- a/skills/uplifting-components-to-slds2/SKILL.md
+++ b/skills/uplifting-components-to-slds2/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: uplifting-components-to-slds2
-description: Migrate Lightning Web Components from SLDS 1 to SLDS 2 by running the SLDS linter and fixing violations. Use this skill whenever users mention SLDS 2, SLDS uplift, linter violations, LWC token migration, class overrides, hardcoded CSS values that need SLDS hook replacement, or styling hook selection. Covers all styling hook categories — color, spacing, sizing, typography, borders, radius, and shadows. Also use when users mention no-hardcoded-values, no-slds-class-overrides, lwc-to-slds-hooks, no-deprecated-tokens-slds1, or ask about SLDS component migration — even if they don't explicitly say "uplift" or "migration".
+description: "Migrate Lightning Web Components from SLDS 1 to SLDS 2 by running the SLDS linter and fixing violations. Use this skill whenever users mention SLDS 2, SLDS uplift, linter violations, LWC token migration, class overrides, hardcoded CSS values that need SLDS hook replacement, or styling hook selection. Covers all styling hook categories — color, spacing, sizing, typography, borders, radius, and shadows. Also use when users mention no-hardcoded-values, no-slds-class-overrides, lwc-to-slds-hooks, no-deprecated-tokens-slds1, or ask about SLDS component migration — even if they don't explicitly say \"uplift\" or \"migration\"."
+metadata:
+  version: "1.0"
 ---
 
 # Goal

--- a/skills/using-ui-bundle-salesforce-data/SKILL.md
+++ b/skills/using-ui-bundle-salesforce-data/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: using-ui-bundle-salesforce-data
 description: "MUST activate when the project contains a uiBundles/*/src/ directory and the task involves ANY Salesforce record operation — reading, creating, updating, or deleting. Use this skill when building forms that submit to Salesforce, pages that display Salesforce records, or any code that touches Salesforce objects or custom objects. Activate when files under uiBundles/*/src/ import from @salesforce/sdk-data, or when *.graphql files or codegen.yml exist. This skill owns all Salesforce data access patterns in UI bundles. Does not apply to authentication/OAuth setup, schema changes, Bulk/Tooling/Metadata API, or declarative automation."
+metadata:
+  version: "1.0"
 ---
 
 # Salesforce Data Access


### PR DESCRIPTION
@W-22488862@

Summary
Brings scripts/validate-skills.ts changes from sf-skills-internal main into sf-skills main.

New checks added:

Description value must be wrapped in double quotes
Special characters in description must be escaped (\\ and \")
Frontmatter must include a metadata: block with a version field
Metadata field must be a key-value map (not scalar or array)
Version must follow x.y format
Compatibility field (if present) must be ≤ 500 characters
Allowed-tools field (if present) must be a plain string
Also adds the parseMetadataBlock helper function.

Updates .github/workflows/validate-skills.yml runner from ubuntu-latest to salesforce-internal-Ubuntu.

Fixes 25 SKILL.md files to pass the new validation checks: added metadata/version blocks, quoted descriptions, fixed version format to x.y.

Test plan
 Run npm run validate:skills against existing skills to confirm no regressions
 Verify new checks catch malformed skill frontmatter as expected