### PR TITLE
feat: expand required-field FLS detection in generating-permission-set

### DIFF
--- a/skills/generating-permission-set/SKILL.md
+++ b/skills/generating-permission-set/SKILL.md
@@ -68,6 +68,15 @@ Define field permissions for sensitive or custom fields:
     <required>true</required>
 </fields>
 ```
+
+**A field counts as required (and must be omitted from `<fieldPermissions>`) when ANY of these are true:**
+- Field metadata contains `<required>true</required>`
+- Field is a **Master-Detail** relationship (`<type>MasterDetail</type>`) — implicitly required on the child object
+- Field is a **system required** standard field (e.g. `Name` on most objects, `OwnerId`, `CreatedById`)
+- Field is a **Lookup** with `<required>true</required>` set
+
+**Detection:** read the field's `*.field-meta.xml` before emitting a `<fieldPermissions>` entry. If you cannot read it, do not emit the entry — flag the field for manual review.
+
 - Use format `ObjectName.FieldName` for field references
 - Set both readable and editable to true when the user needs edit access; editable implies readable
 - If all fields should be visible, can alternatively enable the "viewAllFields" object permission
@@ -175,13 +184,17 @@ Important:
 Before deploying, verify:
 - [ ] fullName, label, description set
 - [ ] Permissions follow least privilege
-- [ ] No required fields in `<fieldPermissions>`
+- [ ] No required fields in `<fieldPermissions>` — for each entry, verified the field's `*.field-meta.xml` does NOT have `<required>true</required>` and is NOT a Master-Detail
 - [ ] No duplicate permissions
 - [ ] no lengthy comments
 
 ## What Causes Deployment Failure
 
-- **Field permissions on required fields:** Any required field in `<fieldPermissions>` fails deployment. Required fields cannot have FLS; omit them entirely. Always confirm from object/field metadata that a field exists and is not required—never assume.
+- **Field permissions on required fields:** Any required field in `<fieldPermissions>` fails deployment with an error like:
+
+  > `You can't edit field-level security for a required field, universally required field, or master-detail relationship field. Remove [Object.Field__c] from the permission set.`
+
+  Required fields cannot have explicit FLS — the platform grants it automatically. Omit them entirely. Always confirm from the field's `*.field-meta.xml` that the field is not required (see Step 3 "What counts as required") before adding it; never assume.
 - **Incorrect API names:** Using the wrong name or missing suffixes (e.g. missing `__c` for custom objects, fields, tabs) cause failure.
 
 ## Deployment


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

- Added a **"What counts as required"** subsection to Step 3 of `skills/generating-permission-set/SKILL.md`, covering Master-Detail relationships, system-required standard fields (`Name`, `OwnerId`, `CreatedById`), and required Lookups — beyond the existing `<required>true</required>` check.
- Added a **detection note**: read the field's `*.field-meta.xml` before emitting a `<fieldPermissions>` entry; if the file can't be read, flag for manual review rather than guessing.
- **Quoted the actual Salesforce deployment error** in "What Causes Deployment Failure" so agents retrying a failed deploy can pattern-match the error to the rule.
- Tightened the **Validation Checklist** item on required fields to require verifying the field's metadata file rather than asserting "no required fields" by assumption.

## Why

The skill already forbids `<fieldPermissions>` entries on required fields, but the guidance reads as a single check against `<required>true</required>` in field metadata. In practice, three other patterns produce the same deployment failure and are under-covered:

1. **Master-Detail** fields are implicitly required on the child object — mentioned in one passing line, no detection guidance.
2. **System-required standard fields** (e.g. `Name`, `OwnerId`) and **required Lookups** also fail FLS deployment.
3. The platform error message is unambiguous (`You can't edit field-level security for a required field, universally required field, or master-detail relationship field...`) but isn't quoted in the skill, so an agent retrying a failed deploy can't match the error back to the rule.

Real-world trigger: a custom datetime field was flipped to `<required>true</required>` to back an LWC requirement; the existing permission set's `<fieldPermissions>` entry silently broke the next deploy with the error above. The updated guidance directs the agent to read the field metadata before emitting an entry, which catches this and similar cases.

## Notes

- Single-file change: `skills/generating-permission-set/SKILL.md` (+15 / -2). No frontmatter changes.
- `npm run validate:skills` passes locally (57/57). The three pre-existing line-count warnings on unrelated skills (`developing-agentforce`, `generating-flexipage`, `using-ui-bundle-salesforce-data`) are unchanged.
- Happy to soften the language if maintainers prefer "flag and ask" over "omit the entry" when metadata can't be read.

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body