### PR TITLE
@W-22704206 Add investigating-agentforce-architecture skill

### DIFF
--- a/skills/investigating-agentforce-architecture/README.md
+++ b/skills/investigating-agentforce-architecture/README.md
@@ -1,0 +1,163 @@
+# investigating-agentforce-architecture
+
+Declared architecture snapshot for a single Agentforce agent: planner + topics + actions + flows + Apex + prompts + NGA plugins. Reads design-time metadata only (`BotDefinition` + `GenAi*` Tooling objects + Metadata API retrieve) — no runtime audit data.
+
+Input: an `agent_api_name` (the `BotDefinition.DeveloperName`) and an org alias. Optional `agent_version_api_name` to pin a version; otherwise the active `BotVersion` resolves.
+
+Output: two files under `~/.claude/data/investigating-agentforce-architecture/<org_id15>/<agent>__<version>/` — a normalized `<agent>_<ver>_metadata_tree.json` and a human-readable `<agent>_<ver>_architecture.md`.
+
+---
+
+## Runtime budget
+
+**30–45s typical, ≤60s hard cap** on the reference fixtures.
+
+A naive sequential implementation (Metadata API retrieves only) would take 90–220s. Speedup: **3–5×**.
+
+Scaling note: large bots with many flows scale approximately linearly in flow count. Each Flow metadata retrieve is an individual SOQL round-trip; a 20-flow bot takes proportionally longer than a 5-flow bot. The 7 planner-side Tooling SOQL fan-outs are constant-cost (single fan-out regardless of bot size); the flow/apex body fetch wave scales with ref count.
+
+---
+
+## Prerequisites
+
+| Tool | Why |
+|---|---|
+| `sf` CLI (authenticated against the target org) | Shells `sf org display --target-org <alias> --json` for access token, and `sf sobject describe` for the 7-day channel probe |
+| Python 3.10+ | `pathlib`, dataclasses, `\|` union types, `concurrent.futures` |
+
+---
+
+## First invocation — auto-grants permissions
+
+On first use, `tools/grant_allowlist.py` merges ~30 scoped permission rules into `~/.claude/settings.json`'s `permissions.allow` array (append-only, idempotent) and seeds the data + cache dirs with `.gitignore` entries. Each rule is per-script scoped — no `python3:*` blanket. Re-running the script is safe; existing rules are preserved.
+
+---
+
+## Usage
+
+Invoked conversationally via Claude Code. Example prompts:
+
+| User says | Skill does |
+|---|---|
+| `document the architecture of MyAgent in my-org-alias` | Resolve active version, fetch tree, render architecture.md + Mermaid |
+| `draw the invocation graph for MySalesAgent v5 in my-org-alias-3` | Same, pinned to v5 |
+| `what tools does MyAgent2 have in my-org-alias-2` | Fetch tree, surface the plugin/function inventory from the rendered architecture.md |
+| `re-fetch the architecture of MyAgent — I think metadata changed` | Pass `--force` to bypass the cache |
+
+See `SKILL.md` for the full flag table and sample prompts.
+
+---
+
+## Directory layout
+
+```
+investigating-agentforce-architecture/
+├── SKILL.md                       Skill contract (inputs, outputs, pipeline, invariants)
+├── README.md                      This file
+├── assets/
+│   ├── soql/*.soql                Tooling + Data SOQL templates
+│   ├── cli/*.yaml                 sf CLI recipes (subprocess invocation specs)
+│   └── mermaid/*.mmd              Mermaid templates for the invocation graph
+├── references/
+│   ├── soql_fields.md             Per-sObject field reference (13 sObjects)
+│   ├── architecture_sections.md   Section-by-section structure of the rendered architecture.md
+│   └── contract.json              metadata_tree.json schema contract
+├── scripts/
+│   ├── _shared/                   Path helpers + fs_guard validators + sql escapers
+│   ├── main.py                    Orchestrator entry point
+│   ├── config.py                  Shared paths, cache TTLs, validated path builders
+│   ├── soql_loader.py             Template loader with fs_guard-validated substitution
+│   ├── sf_cli.py                  sf CLI subprocess wrapper (yaml.safe_load + stderr redaction)
+│   ├── rest_client.py             urllib wrapper (Authorization-stripping redirect handler)
+│   ├── resolve_bot.py             BotDefinition + BotVersion + planner name lookup
+│   ├── retrieve_planner.py        Metadata retrieve for GenAiPlannerBundle + NGA plugins
+│   ├── parallel_retrieve.py       7-channel parallel Tooling SOQL fan-out
+│   ├── parse_bundle.py            XML → normalized node shapes
+│   ├── parse_wave.py              BFS expansion of flow/apex/prompt refs
+│   ├── probe_channels.py          7-day-TTL channel describe probe
+│   ├── cache_check.py             Asset-hash-aware cache freshness
+│   ├── finalize.py                Merge waves → metadata_tree.json
+│   ├── render_architecture.py     architecture.md + Mermaid graph
+│   ├── resolve_invocation_target.py  ID-prefix router for NGA InvocationTargets
+│   └── tests/                     Unit + integration tests (unittest)
+└── tools/
+    ├── emit_env.py                Env-var emit helper (Phase 0.5)
+    ├── emit_result.py             Final RESULT block renderer
+    ├── grant_allowlist.py         First-run permission granter
+    ├── sanitize.py                Stdin → safe-string filter
+    └── write_emit_ctx.py          Per-phase ctx writer
+```
+
+---
+
+## Architecture
+
+### Channel strategy — SOQL-first
+
+```
+7 parallel Tooling SOQL channels (keyed on planner id):
+    - plugins_by_planner
+    - planner_bundle_functions (join)
+    - functions_by_plugins
+    - planner_attrs_by_parent_ids
+    - plugin_functions_by_plugin_ids (join)
+    - plugin_instructions_by_plugin_ids
+    - planner_definition_by_agent_chain (entry query, chain-LIKE lookup)
+
++ Data API SOQL for Flow / Apex bodies (batched by id list)
++ Metadata retrieve ONLY for:
+    - GenAiPromptTemplate (prompt bodies)
+    - NGA external plugins (when planner is ConcurrentMultiAgentOrchestration etc.)
+```
+
+Most of the 3–5× speedup over a naive Metadata-API-only implementation comes from collapsing a sequential zip-retrieve chain into a single Tooling SOQL fan-out.
+
+### Planner normalization — classic ReAct vs NGA
+
+One tree shape, two planner families:
+
+| `PlannerType` examples | Family | InvocationTarget style |
+|---|---|---|
+| `ReactAiPlannerV1`, `SequentialPlannerIntentClassifier` | Classic ReAct | DeveloperName strings |
+| `ConcurrentMultiAgentOrchestration`, `AnthropicCompatibleV1` | NGA | Sometimes 15/18-char Ids (ID-prefix routed) |
+
+`resolve_invocation_target.py` routes NGA InvocationTargets by Salesforce ID prefix (`01p` → ApexClass, `301` → Flow, etc.). Unknown prefixes become `_unresolved[]` entries with `reason="unknown-id-prefix:<prefix>"` — never silently dropped.
+
+### Cache layers
+
+1. **Tree cache** — `metadata_tree.json` is reused unless `--force`. Cache key includes asset-hashes of every SOQL / YAML / Mermaid template shipped with the skill, so changing a template busts the cache automatically.
+2. **Channel probe cache** — 7-day TTL on `sf sobject describe` results for the 13 sObjects the skill touches. `--reprobe` forces a refresh (needed after Salesforce quarterly releases that rename / remove fields). Mandatory-field gate: a probe that sees any mandatory field missing (per `probe_channels.MANDATORY_FIELDS`) flips `status: PROBE_FAILED` so the caller surfaces a clean error.
+
+---
+
+## Key behaviors
+
+### Idempotence
+
+Re-running the same `(org, agent, version)` overwrites prior artifacts in place. Safe to run repeatedly during development.
+
+### Partial-results surfacing
+
+No silent drops. Any unresolved ref — unknown ID prefix, failed SOQL, missing describe field — lands in `_unresolved[]` with a `reason=...` string. Top-level `STATUS` is `OK` on a clean run, `PARTIAL_OK` when any channel degrades.
+
+### BFS depth cap
+
+Hard cap at depth 5. Real-world agents bottom out well before that; deeper chains emit `_cycle_back_to:<path>` annotations rather than looping.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Permission prompts on every run after install | Sentinel missing. Re-run `python3 tools/grant_allowlist.py` |
+| `sf org display failed` | Re-authenticate: `sf org login web --alias <alias>` |
+| `INVALID_FIELD` from a SOQL asset | Salesforce renamed / removed the field in a quarterly release. Run with `--reprobe` to refresh the 7-day channel cache and pick up the new schema |
+| `STATUS=PROBE_FAILED` on first run | Channel probe saw a mandatory field missing. Check `channels.json` under the probe cache dir for which sObject / field — may require org-side feature enablement |
+| Tree for classic ReAct agent shows `_unresolved` entries for NGA plugins | Expected — the NGA external-plugin retrieve is skipped when the planner shape is classic. Those entries can be ignored |
+
+---
+
+## Author
+
+Raghul Jayagopal (RJ), Salesforce ANZ FDE.

--- a/skills/investigating-agentforce-architecture/SKILL.md
+++ b/skills/investigating-agentforce-architecture/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: investigating-agentforce-architecture
+description: "Declared architecture snapshot for one Agentforce agent — planner + topics + actions + flows + Apex + prompt templates + NGA plugins. Pulls the design-time metadata tree (not runtime audit rows) via 7 parallel Tooling SOQL channels + targeted Metadata retrieve, normalizes it across classic ReAct and NGA planner shapes, renders a human-readable architecture document + a Mermaid invocation graph. TRIGGER when user asks to describe, diagram, inventory, audit, or document the architecture / action tree / topic structure / tool inventory of a specific agent — by agent API name in a specific org. Accepts optional agent_version_api_name to pin a version; otherwise resolves the active BotVersion. DO NOT TRIGGER for runtime session traces, conversation transcripts, generation timings, or gateway audit chains — this skill reads design-time metadata only."
+license: Apache-2.0
+compatibility: "Requires Agentforce license, sf CLI authenticated to target org, Python 3.10+"
+metadata:
+  version: "1.0"
+  last_updated: "2026-05-28"
+  author: "Raghul Jayagopal (RJ), Salesforce ANZ FDE"
+---
+
+# investigating-agentforce-architecture — declared architecture snapshot
+
+Design-time metadata tree for one Agentforce agent: planner → topics → actions → flows → Apex → prompts → NGA plugins. Reads declared metadata only — `BotDefinition`, `GenAiPlanner*`, `GenAiPlugin*`, `GenAiFunction*`, `Flow`, `ApexClass`, `GenAiPromptTemplate`. Does **not** read runtime audit rows.
+
+**Runtime budget: 30–45s typical, ≤60s hard cap** on reference fixtures. Sequential baseline would be 90–220s; parallel Tooling SOQL fan-out delivers a 3–5× speedup. Large bots with many flows scale approximately linearly — each flow metadata retrieve is one round-trip.
+
+Runs **inline** — no subagent. Every phase is deterministic file processing.
+
+## When to use
+
+Trigger this skill when the user:
+- Asks to **describe / diagram / inventory / audit / document** a specific agent's architecture — by agent API name, optionally pinned to a version.
+- Wants the declared **topic / action / flow / Apex / prompt / NGA plugin** tree, not the runtime audit trail.
+- Says things like: "document the architecture of `<agent>` in `<org>`", "draw the invocation graph for `<agent>`", "what tools does `<agent>` have", "which flows does `<agent>` call", "diff the action tree of `<agent v3>` vs `<agent v5>`".
+
+**DO NOT trigger** when the question is about what *ran* on a specific session — steps, generations, timings, gateway calls, conversation transcripts, feedback. Those questions need runtime STDM + GenAI DMOs (Data Cloud) and are out of scope here.
+
+## If the user hasn't given enough to proceed
+
+When invoked with no `agent_api_name` AND no org alias, print the following block **verbatim** — do not paraphrase, do not pre-run any script. Trigger condition: `$ARGUMENTS` is empty OR names no agent (no `--agent` flag and no known agent API name in the prose) OR names no org (no `--org` flag and no known alias).
+
+> Which agent should I document, and in which org?
+>
+> I need:
+> - **Agent API name** — the `DeveloperName` of the `BotDefinition` (e.g. `MyAgent`, `MySalesAgent`). Not the label.
+> - **Org alias** — for `sf` CLI auth (the alias you configured with `sf org login`)
+>
+> Optional:
+> - **Version** — an `agent_version_api_name` like `v5`. If omitted, I'll resolve the active `BotVersion`.
+> - **`--force`** — ignore cached tree; re-fetch everything.
+> - **`--reprobe`** — re-run the 7-day channel-probe cache (only needed after a Salesforce release).
+>
+> I'll run the metadata pipeline inline. Artifacts land under `~/.claude/data/investigating-agentforce-architecture/<org_id15>/<agent_api_name>__<agent_version>/`.
+
+## Pipeline invocation
+
+When the user has supplied `--org <alias>` + `--agent <api_name>` (plus any optional flags), run this block. One `python3` invocation drives the full pipeline. `main.py` writes `.emit_ctx.json`; `emit_result.py` reads it and prints the final `=== RESULT ===` block last to stdout.
+
+```bash
+set -euo pipefail
+
+# zsh arrays are 1-indexed by default; bash arrays are 0-indexed.
+# This block uses 0-indexed semantics throughout (_args[$i] starting at i=0),
+# so under zsh + `set -u` the very first read of `_args[0]` would trip
+# `parameter not set`. KSH_ARRAYS makes zsh treat arrays as 0-indexed,
+# matching the bash shebang's expectation. No-op under bash.
+[ -n "${ZSH_VERSION:-}" ] && setopt KSH_ARRAYS
+
+SKILL_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/investigating-agentforce-architecture}"
+
+# Argument parser. Accepts both `--org foo` and `--org=foo`.
+# `$ARGUMENTS` is the raw user input Claude Code substitutes.
+ARG_ORG=""
+ARG_AGENT=""
+ARG_VERSION=""
+ARG_FORCE=""
+ARG_REPROBE=""
+ARG_PARALLELISM=""
+ARG_MAX_MERMAID=""
+
+# shellcheck disable=SC2206
+_args=($ARGUMENTS)
+i=0
+while [ $i -lt ${#_args[@]} ]; do
+ tok="${_args[$i]}"
+ case "$tok" in
+ --org=*) ARG_ORG="${tok#--org=}" ;;
+ --org) i=$((i+1)); ARG_ORG="${_args[$i]:-}" ;;
+ --agent=*) ARG_AGENT="${tok#--agent=}" ;;
+ --agent) i=$((i+1)); ARG_AGENT="${_args[$i]:-}" ;;
+ --version=*) ARG_VERSION="${tok#--version=}" ;;
+ --version) i=$((i+1)); ARG_VERSION="${_args[$i]:-}" ;;
+ --parallelism=*) ARG_PARALLELISM="${tok#--parallelism=}" ;;
+ --parallelism) i=$((i+1)); ARG_PARALLELISM="${_args[$i]:-}" ;;
+ --max-mermaid-nodes=*) ARG_MAX_MERMAID="${tok#--max-mermaid-nodes=}" ;;
+ --max-mermaid-nodes) i=$((i+1)); ARG_MAX_MERMAID="${_args[$i]:-}" ;;
+ --force) ARG_FORCE="1" ;;
+ --reprobe) ARG_REPROBE="1" ;;
+ esac
+ i=$((i+1))
+done
+
+# Usage block if required flags missing. Agent reads stderr,
+# prints verbatim, and stops — does NOT pre-run main.py.
+if [ -z "$ARG_ORG" ] || [ -z "$ARG_AGENT" ]; then
+ cat >&2 <<'USAGE'
+> Which agent should I trace, and in which org?
+>
+> I need:
+> - **Agent API name** — the BotDefinition.DeveloperName (e.g. `MyAgent`)
+> - **Org alias** — for `sf` CLI auth (the alias you configured with `sf org login`)
+>
+> Optional flags:
+> - `--version v5` — pin a specific BotVersion (default: Active+highest)
+> - `--force` — bypass cache
+> - `--reprobe` — force channel-probe refresh
+> - `--parallelism N` — ThreadPoolExecutor size (default 5)
+USAGE
+ exit 2
+fi
+
+# Fresh work dir per invocation. Epoch + random suffix avoids collisions
+# between concurrent runs on the same host. The path prefix must match
+# the `/tmp/investigating-agentforce-architecture-*` allowlist entries in
+# tools/grant_allowlist.py — change them in lockstep.
+WORK_DIR="/tmp/investigating-agentforce-architecture-$(date +%s)-$RANDOM"
+mkdir -p "$WORK_DIR"
+
+# Input validation at the boundary, BEFORE any python3 call.
+# fs_guard exits 1 and prints an INVALID_INPUT RESULT block on failure;
+# `|| exit 1` is mandatory — bare calls silently continue past failures.
+python3 "$SKILL_ROOT/scripts/_shared/fs_guard.py" "$ARG_AGENT" agent_api_name api_name || exit 1
+python3 "$SKILL_ROOT/scripts/_shared/fs_guard.py" "$ARG_ORG" org_alias not_empty || exit 1
+python3 "$SKILL_ROOT/scripts/_shared/fs_guard.py" "$WORK_DIR" WORK_DIR symlink || exit 1
+python3 "$SKILL_ROOT/scripts/_shared/fs_guard.py" "$WORK_DIR" WORK_DIR owned || exit 1
+if [ -n "$ARG_VERSION" ]; then
+ python3 "$SKILL_ROOT/scripts/_shared/fs_guard.py" "$ARG_VERSION" agent_version api_name || exit 1
+fi
+
+# Single python3 call drives all pipeline phases. main.py writes
+# `.emit_ctx.json` into $WORK_DIR — emit_result.py then renders the
+# RESULT block from that ctx. No subprocess-per-phase.
+_main_args=(--org-alias "$ARG_ORG" --agent "$ARG_AGENT" --work-dir "$WORK_DIR")
+[ -n "$ARG_VERSION" ] && _main_args+=(--version "$ARG_VERSION")
+[ -n "$ARG_FORCE" ] && _main_args+=(--force)
+[ -n "$ARG_REPROBE" ] && _main_args+=(--reprobe)
+[ -n "$ARG_PARALLELISM" ] && _main_args+=(--parallelism "$ARG_PARALLELISM")
+[ -n "$ARG_MAX_MERMAID" ] && _main_args+=(--max-mermaid-nodes "$ARG_MAX_MERMAID")
+
+# main.py returns nonzero on terminal failures; we DON'T short-circuit —
+# emit_result still publishes the failure RESULT block. `set -e` is
+# temporarily relaxed around this single call.
+set +e
+python3 "$SKILL_ROOT/scripts/main.py" "${_main_args[@]}"
+_rc=$?
+set -e
+
+# Final RESULT block is emit_result.py's stdout — MUST be the last thing
+# stdout sees. emit_result exits 0 on render success; the bash harness
+# propagates main.py's rc for the agent's exit status.
+WORK_DIR="$WORK_DIR" python3 "$SKILL_ROOT/tools/emit_result.py"
+exit "$_rc"
+```
+
+## Inputs
+
+| Input | Flag | Required | Default |
+|---|---|---|---|
+| `org_alias` | `--org` | yes | — |
+| `agent_api_name` | `--agent` | yes | — |
+| `agent_version_api_name` | `--version` | no | active BotVersion |
+| `force_refresh` | `--force` | no | false (honor cache) |
+| `reprobe` | `--reprobe` | no | false (honor 7-day channel-probe cache) |
+| `parallelism` | `--parallelism` | no | 5 |
+| `max_mermaid_nodes` | `--max-mermaid-nodes` | no | 80 |
+
+## Outputs
+
+All artifacts under `~/.claude/data/investigating-agentforce-architecture/<org_id15>/<agent_api_name>__<agent_version>/`:
+
+```
+<agent>_<ver>_metadata_tree.json   primary artifact — normalized planner/topic/action/flow/apex/prompt/plugin tree
+<agent>_<ver>_architecture.md      human-readable section-by-section rendering (7 sections + Mermaid invocation graph)
+```
+
+## Pipeline — inline, no subagent
+
+```
+resolve_bot.py        → BotDefinition + BotVersion + planner name lookup
+retrieve_planner.py   → Metadata API zip retrieve for GenAiPlannerBundle (+ NGA plugins if present)
+parallel_retrieve.py  → 7 parallel Tooling SOQL channels fan out from planner id:
+                          - plugins_by_planner (GenAiPluginDefinition)
+                          - planner_bundle_functions (GenAiPlannerFunctionDef join)
+                          - functions_by_plugins (GenAiFunctionDefinition)
+                          - planner_attrs_by_parent_ids (GenAiPlannerAttrDefinition)
+                          - plugin_functions_by_plugin_ids (GenAiPluginFunctionDef join)
+                          - plugin_instructions_by_plugin_ids (GenAiPluginInstructionDef)
+                          - planner_definition_by_agent_chain
+parse_bundle.py       → parse retrieved XML into normalized node shapes
+parse_wave.py         → BFS expansion: flow/apex/prompt refs discovered in nodes
+                          → SOQL for Flow/Apex bodies (batched by id list)
+                          → Metadata retrieve ONLY for GenAiPromptTemplate (+ NGA external plugins conditionally)
+finalize.py           → merge waves into metadata_tree.json
+render_architecture.py → <agent>_<ver>_architecture.md + Mermaid invocation graph (capped at --max-mermaid-nodes)
+```
+
+**Channel strategy — SOQL-first.**
+- **Tooling SOQL** for every normalized tree node (planner, plugins, functions, plugin-functions, plugin-instructions, planner-functions, planner-attrs) — 7 parallel channels keyed on planner id.
+- **Data API SOQL** for Flow (by id) and Apex (by id or name) bodies — batched.
+- **Metadata retrieve** only for two cases: (a) `GenAiPromptTemplate` (prompt bodies aren't cleanly exposed via Tooling SOQL), and (b) NGA **external plugins** when the planner is Native Generative Agent shape (skipped for classic ReAct).
+
+This is where the 3–5× speedup comes from. A naive implementation would retrieve everything via Metadata API zips sequentially; parallel Tooling SOQL covers ~80% of the tree in a single fan-out.
+
+## Planner shapes — classic ReAct vs NGA
+
+The skill normalizes two planner families into a single tree shape:
+
+| Shape | `GenAiPlannerDefinition.PlannerType` | InvocationTarget style | NGA plugins? |
+|---|---|---|---|
+| **Classic ReAct** | `ReactAiPlannerV1` / `SequentialPlannerIntentClassifier` / etc. | DeveloperName strings | no |
+| **NGA** | `ConcurrentMultiAgentOrchestration` / `AnthropicCompatibleV1` / etc. | Sometimes 15/18-char Ids (ID-prefix routed) | yes (external plugins via Metadata retrieve) |
+
+The ID-prefix router in `resolve_invocation_target.py` distinguishes the two: NGA InvocationTargets that look like ids (`01p…` = ApexClass, `301…` = Flow, etc.) get resolved via id-scoped SOQL; DeveloperName targets go through name-scoped SOQL. Unknown prefixes surface as `_unresolved[]` with `reason="unknown-id-prefix:<prefix>"` — never silently dropped.
+
+## Caching
+
+- **Tree cache**: `metadata_tree.json` is reused unless `--force` is passed. Cache key includes the asset-hash of every `.soql` / `.yaml` / `.mmd` template bundled with the skill — bump a template, the cache busts automatically.
+- **Channel probe cache**: 7-day TTL on the per-org `sf sobject describe` results that validate every field name the SOQL assets reference. A Salesforce quarterly release that renames / removes a field triggers `status: PROBE_FAILED`; `--reprobe` forces a refresh.
+
+## Permissions (first-run)
+
+`tools/grant_allowlist.py` merges ~30 scoped permission rules into `~/.claude/settings.json` so the pipeline can run unattended. Each script is per-file scoped — no `python3:*` blanket. The script is idempotent: re-running it is safe; existing rules are preserved.
+
+## Prerequisites
+
+| Tool | Required |
+|---|---|
+| `sf` CLI (authenticated against the target org) | yes — `sf org login web --alias <alias>` |
+| Python 3.10+ | yes |
+
+## Reference docs to load when needed
+
+Do NOT load eagerly. Load when the user's question requires it:
+
+- `references/soql_fields.md` — per-sObject field reference for the 13 sObjects this skill touches (2 Data API + 11 Tooling), with `[mandatory]` vs `[optional]` tags. Load when the user asks about a specific field, or when debugging an `INVALID_FIELD` SOQL error.
+- `references/contract.json` — machine-readable schema for `metadata_tree.json`. Load when writing downstream tooling that consumes the tree.
+- `references/architecture_sections.md` — section-by-section structure of the rendered `<agent>_<ver>_architecture.md`.
+
+## Invariants worth knowing upfront
+
+- **Pipeline is deterministic.** Same `(org, agent, version)` + static org metadata → byte-identical `<agent>_<ver>_metadata_tree.json` and `<agent>_<ver>_architecture.md`. Only manifest timestamps drift across re-runs.
+- **Forward-only traversal.** Every discovered ref goes forward from planner → children. No backward lookups.
+- **Partial results are surfaced, not silenced.** Any unresolved reference lands in `_unresolved[]` with `reason=...`. `STATUS=PARTIAL_OK` if any channel failed; `STATUS=OK` only on a clean run.
+- **BFS depth cap is 5.** Deeper chains emit `_cycle_back_to:<path>` annotations rather than looping. Real-world agents bottom out well before that.
+- **Child ordering is alphabetical by `api_name` (case-insensitive).** Topics come before non-topic plannerActions at the root level. Flow-actionCall order is NOT sorted — that's the flow author's execution sequence.

--- a/skills/investigating-agentforce-architecture/assets/cli/describe_sobject.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/describe_sobject.yaml
@@ -1,0 +1,16 @@
+name: describe_sobject
+argv:
+  - sf
+  - sobject
+  - describe
+  - --sobject
+  - "{{SOBJECT}}"
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --json
+timeout_seconds: 300
+required_params: [ORG_ALIAS, SOBJECT]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/cli/describe_tooling_sobject.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/describe_tooling_sobject.yaml
@@ -1,0 +1,17 @@
+name: describe_tooling_sobject
+argv:
+  - sf
+  - sobject
+  - describe
+  - --sobject
+  - "{{SOBJECT}}"
+  - --use-tooling-api
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --json
+timeout_seconds: 300
+required_params: [ORG_ALIAS, SOBJECT]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/cli/list_metadata_genaiprompttemplate.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/list_metadata_genaiprompttemplate.yaml
@@ -1,0 +1,17 @@
+name: list_metadata_genaiprompttemplate
+argv:
+  - sf
+  - org
+  - list
+  - metadata
+  - --metadata-type
+  - GenAiPromptTemplate
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --json
+timeout_seconds: 300
+required_params: [ORG_ALIAS]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/cli/org_display.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/org_display.yaml
@@ -1,0 +1,15 @@
+name: org_display
+argv:
+  - sf
+  - org
+  - display
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --json
+  - --verbose
+timeout_seconds: 300
+required_params: [ORG_ALIAS]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/cli/retrieve_genai_plugin.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/retrieve_genai_plugin.yaml
@@ -1,0 +1,18 @@
+name: retrieve_genai_plugin
+argv:
+  - sf
+  - project
+  - retrieve
+  - start
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --target-metadata-dir
+  - "{{TARGET_DIR}}"
+  - --json
+extra_argv_anchor: --target-metadata-dir
+timeout_seconds: 300
+required_params: [ORG_ALIAS, TARGET_DIR]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/cli/show_access_token.yaml
+++ b/skills/investigating-agentforce-architecture/assets/cli/show_access_token.yaml
@@ -1,0 +1,27 @@
+name: show_access_token
+# Primary access-token retrieval path per forcedotcom/cli#3560 (effective
+# 2026-05-27). The `sf org display --json` field is now redacted to a
+# placeholder string by default; the dedicated `sf org auth show-access-token`
+# command is the long-term replacement.
+#
+# `--no-prompt` skips the interactive confirmation banner so the command
+# behaves identically under `--json`.
+#
+# The legacy fallback (`sf org display` with `SF_TEMP_SHOW_SECRETS=true`)
+# stays wired for sf CLI versions that don't ship show-access-token; that
+# fallback is orchestrated in `main.py::_resolve_creds`, not here.
+argv:
+  - sf
+  - org
+  - auth
+  - show-access-token
+  - --target-org
+  - "{{ORG_ALIAS}}"
+  - --json
+  - --no-prompt
+timeout_seconds: 60
+required_params: [ORG_ALIAS]
+success_check: stdout_json_status_zero
+auth_required_stderr_patterns:
+  - NoOrgAuthenticationError
+  - AuthInfoError

--- a/skills/investigating-agentforce-architecture/assets/mermaid/action_tree.mmd
+++ b/skills/investigating-agentforce-architecture/assets/mermaid/action_tree.mmd
@@ -1,0 +1,20 @@
+%% action_tree.mmd - section 4 declared action tree (flowchart TB)
+%%
+%% Placeholders (substituted by render_architecture.load_mermaid):
+%%   SUBGRAPHS placeholder: one `subgraph <topic_id>[<topic_label>] ... end`
+%%                          block per topic. Non-topic actions (plannerActions)
+%%                          go in a synthetic subgraph keyed `_plannerActions`.
+%%   EDGES placeholder:     tree edges, one per child->parent descent. Cycle-
+%%                          back annotations render as dotted back-edges
+%%                          `A -.->|cycle| B` (see
+%%                          render_architecture._render_action_tree).
+%%
+%% placeholder names are written as bare tokens (no double-curly)
+%% so load_mermaid's single-pass str.replace cannot corrupt this header.
+%%
+%% Node-cap enforcement: if the tree exceeds `max_mermaid_nodes["flowchart"]`,
+%% the renderer emits a summary placeholder instead of this template.
+flowchart TB
+    {{SUBGRAPHS}}
+
+    {{EDGES}}

--- a/skills/investigating-agentforce-architecture/assets/mermaid/data_flow.mmd
+++ b/skills/investigating-agentforce-architecture/assets/mermaid/data_flow.mmd
@@ -1,0 +1,19 @@
+%% data_flow.mmd - section 8 data flow / context propagation (flowchart LR)
+%%
+%% Placeholders (substituted by render_architecture.load_mermaid):
+%%   NODES placeholder: node declarations: `<id>[<label>]`, one per line.
+%%   EDGES placeholder: labeled-where-possible edges:
+%%                      `A -->|<var>: <type>| B`, bare `A --> B` when no
+%%                      parameter threads between the lanes.
+%%
+%% placeholder names are written as bare tokens (no double-curly)
+%% so load_mermaid's single-pass str.replace cannot corrupt this header.
+%%
+%% Source: GenAiPlannerAttrDefinition rows on the planner drive which slots
+%% populate which actions. Renderer (render_architecture._render_data_flow)
+%% builds nodes/edges from the tree's planner-slot metadata; no slots ->
+%% degenerate diagram with just `User --> Planner --> Actions` skeleton.
+flowchart LR
+    {{NODES}}
+
+    {{EDGES}}

--- a/skills/investigating-agentforce-architecture/assets/mermaid/dependency_graph.mmd
+++ b/skills/investigating-agentforce-architecture/assets/mermaid/dependency_graph.mmd
@@ -1,0 +1,19 @@
+%% dependency_graph.mmd - conditional section (graph LR)
+%%
+%% Rendered ONLY when `_unresolved[]` is non-empty OR cycles exist in the
+%% action tree. Otherwise render_architecture skips this template entirely.
+%%
+%% Placeholders (substituted by render_architecture.load_mermaid):
+%%   NODES placeholder: node declarations: `<id>[<label>]`. Unresolved refs
+%%                      use a `:::unresolved` class marker for CSS styling.
+%%   EDGES placeholder: cross-artifact dependency edges harvested from the
+%%                      tree. Cycle-back edges render as `A -.->|cycle| B`.
+%%
+%% placeholder names are written as bare tokens (no double-curly)
+%% so load_mermaid's single-pass str.replace cannot corrupt this header.
+graph LR
+    {{NODES}}
+
+    {{EDGES}}
+
+    classDef unresolved stroke-dasharray: 5 5

--- a/skills/investigating-agentforce-architecture/assets/mermaid/invocation_sequence.mmd
+++ b/skills/investigating-agentforce-architecture/assets/mermaid/invocation_sequence.mmd
@@ -1,0 +1,20 @@
+%% invocation_sequence.mmd - section 3 invocation sequence (sequenceDiagram)
+%%
+%% Placeholders (substituted by render_architecture.load_mermaid):
+%%   PARTICIPANTS placeholder: one `participant <Name>` line per lane,
+%%                             newline-joined; deactivate with
+%%                             `<Dst>-->>-<Src>: <response>`.
+%%   MESSAGES placeholder:     one `<Src>->>+<Dst>: <label>` per message line.
+%%
+%% placeholder names above are written as bare tokens (no double-
+%% curly) so load_mermaid's single-pass str.replace cannot substitute them
+%% here. That keeps %% headers intact in the rendered output - Mermaid
+%% ignores %% lines as comments at render time, and debuggability wins.
+%%
+%% Renderer (render_architecture.py::_render_invocation_sequence) is the sole
+%% consumer. Generation-aware: classic ReAct uses Planner<->TopicClassifier
+%% <->ActionExecutor; NGA orchestrations add one lane per sub-agent.
+sequenceDiagram
+    autonumber
+    {{PARTICIPANTS}}
+    {{MESSAGES}}

--- a/skills/investigating-agentforce-architecture/assets/mermaid/planner_state.mmd
+++ b/skills/investigating-agentforce-architecture/assets/mermaid/planner_state.mmd
@@ -1,0 +1,18 @@
+%% planner_state.mmd - section 7 planner state machine (stateDiagram-v2)
+%%
+%% Placeholders (substituted by render_architecture.load_mermaid):
+%%   STATES placeholder:      state declarations (`state Foo { ... }` or
+%%                            bare `state`).
+%%   TRANSITIONS placeholder: transition list (`A --> B: <label>`).
+%%
+%% placeholder names are written as bare tokens (no double-curly)
+%% so load_mermaid's single-pass str.replace cannot corrupt this header.
+%%
+%% Renderer selects one of a small library of per-generation state machines
+%% (render_architecture._planner_state_for_generation) and fills in the
+%% template. BYOP / SEARCH generations skip this section and emit a prose
+%% placeholder at call site rather than rendering this template.
+stateDiagram-v2
+    {{STATES}}
+
+    {{TRANSITIONS}}

--- a/skills/investigating-agentforce-architecture/assets/soql/apex_class_bodies_by_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/apex_class_bodies_by_ids.soql
@@ -1,0 +1,3 @@
+SELECT Id, Name, Body, SymbolTable, ApiVersion, IsValid
+FROM ApexClass
+WHERE Id IN ({{APEX_IDS_LIST}})

--- a/skills/investigating-agentforce-architecture/assets/soql/apex_class_bodies_by_names.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/apex_class_bodies_by_names.soql
@@ -1,0 +1,3 @@
+SELECT Id, Name, Body, SymbolTable, ApiVersion, IsValid
+FROM ApexClass
+WHERE Name IN ({{NAMES_LIST}})

--- a/skills/investigating-agentforce-architecture/assets/soql/bot_definition_details.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/bot_definition_details.soql
@@ -1,0 +1,3 @@
+SELECT DeveloperName, MasterLabel, Description, AgentType, Type, AgentTemplate, BotSource
+FROM BotDefinition
+WHERE DeveloperName = '{{AGENT_API_NAME}}'

--- a/skills/investigating-agentforce-architecture/assets/soql/bot_version_lookup.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/bot_version_lookup.soql
@@ -1,0 +1,4 @@
+SELECT Id, DeveloperName, Status, BotDefinitionId,
+       BotDefinition.DeveloperName, BotDefinition.MasterLabel
+FROM BotVersion
+WHERE BotDefinition.DeveloperName = '{{AGENT_API_NAME}}'

--- a/skills/investigating-agentforce-architecture/assets/soql/flow_definition_by_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/flow_definition_by_ids.soql
@@ -1,0 +1,3 @@
+SELECT Id, DeveloperName, ActiveVersionId, LatestVersionId
+FROM FlowDefinition
+WHERE Id IN ({{FLOW_DEF_IDS_LIST}})

--- a/skills/investigating-agentforce-architecture/assets/soql/flow_definition_ids_by_names.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/flow_definition_ids_by_names.soql
@@ -1,0 +1,3 @@
+SELECT Id, DeveloperName, NamespacePrefix, ActiveVersionId
+FROM FlowDefinition
+WHERE DeveloperName IN ({{NAMES_LIST}}) AND NamespacePrefix = NULL

--- a/skills/investigating-agentforce-architecture/assets/soql/flow_definition_view_by_durable_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/flow_definition_view_by_durable_ids.soql
@@ -1,0 +1,4 @@
+SELECT DurableId, ApiName, Label, NamespacePrefix, ActiveVersionId,
+       IsActive, ManageableState, ProcessType
+FROM FlowDefinitionView
+WHERE DurableId IN ({{DURABLE_IDS_LIST}})

--- a/skills/investigating-agentforce-architecture/assets/soql/flow_metadata_by_id.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/flow_metadata_by_id.soql
@@ -1,0 +1,3 @@
+SELECT Id, FullName, Metadata
+FROM Flow
+WHERE Id = '{{FLOW_VERSION_ID}}'

--- a/skills/investigating-agentforce-architecture/assets/soql/functions_by_plugins.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/functions_by_plugins.soql
@@ -1,0 +1,5 @@
+SELECT Id, DeveloperName, MasterLabel, Description, InvocationTargetType, InvocationTarget,
+       IsLocal, IsConfirmationRequired, IsIncludeInProgressIndicator, ProgressIndicatorMessage,
+       Source, PluginId, PlannerId, ParentId, LocalDeveloperName
+FROM GenAiFunctionDefinition
+WHERE PluginId IN ({{PLUGIN_IDS}})

--- a/skills/investigating-agentforce-architecture/assets/soql/planner_attrs_by_parent_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/planner_attrs_by_parent_ids.soql
@@ -1,0 +1,3 @@
+SELECT Id, ParentId, DeveloperName, MasterLabel, Description, MappingType, ParameterName
+FROM GenAiPlannerAttrDefinition
+WHERE ParentId IN ({{PARENT_IDS}})

--- a/skills/investigating-agentforce-architecture/assets/soql/planner_bundle_functions.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/planner_bundle_functions.soql
@@ -1,0 +1,3 @@
+SELECT Id, PlannerId, Plugin
+FROM GenAiPlannerFunctionDef
+WHERE PlannerId = '{{PLANNER_ID}}'

--- a/skills/investigating-agentforce-architecture/assets/soql/planner_definition_by_agent_chain.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/planner_definition_by_agent_chain.soql
@@ -1,0 +1,3 @@
+SELECT Id, DeveloperName, MasterLabel, Description, PlannerType, Capabilities, AgentGraph
+FROM GenAiPlannerDefinition
+WHERE DeveloperName LIKE '{{AGENT_NAME}}%\_{{VERSION}}'

--- a/skills/investigating-agentforce-architecture/assets/soql/plugin_functions_by_plugin_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/plugin_functions_by_plugin_ids.soql
@@ -1,0 +1,3 @@
+SELECT Id, PluginId, Function
+FROM GenAiPluginFunctionDef
+WHERE PluginId IN ({{PLUGIN_IDS}})

--- a/skills/investigating-agentforce-architecture/assets/soql/plugin_instructions_by_plugin_ids.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/plugin_instructions_by_plugin_ids.soql
@@ -1,0 +1,3 @@
+SELECT Id, GenAiPluginDefinitionId, DeveloperName, MasterLabel, Description, SortOrder
+FROM GenAiPluginInstructionDef
+WHERE GenAiPluginDefinitionId IN ({{PLUGIN_IDS}})

--- a/skills/investigating-agentforce-architecture/assets/soql/plugins_by_planner.soql
+++ b/skills/investigating-agentforce-architecture/assets/soql/plugins_by_planner.soql
@@ -1,0 +1,4 @@
+SELECT Id, DeveloperName, MasterLabel, Description, PluginType, Scope,
+       IsLocal, CanEscalate, Source, ParentId, LocalDeveloperName
+FROM GenAiPluginDefinition
+WHERE PlannerId = '{{PLANNER_ID}}'

--- a/skills/investigating-agentforce-architecture/references/architecture_sections.md
+++ b/skills/investigating-agentforce-architecture/references/architecture_sections.md
@@ -1,0 +1,296 @@
+# architecture.md section reference
+
+Per-section rendering spec for `scripts/render_architecture.py::render`.
+Ten core sections + one conditional section. Source of truth: the
+`metadata_tree.json` schema produced by `scripts/parse_wave.py` at the
+end of phase 9.
+
+**Source of truth: the live tree** — field shapes evolve as parse_wave
+learns new agent generations. When this doc disagrees with the
+`metadata_tree.json` written by `parse_wave.py` for an actual agent on
+your machine (under `~/.claude/data/investigating-agentforce-architecture/<org>/<agent>__<ver>/`),
+trust the live tree.
+
+The Mermaid templates live at `assets/mermaid/*.mmd` and are the sole
+consumer of the renderer helpers; each `{{PARAM}}` contract is
+documented in the template's own header comment.
+
+---
+
+## Per-diagram node caps
+
+Default caps (override via `render(..., max_mermaid_nodes={...})`):
+
+| Diagram kind | Default cap | Over-cap behaviour |
+|---|---|---|
+| `flowchart` | 200 | summary placeholder + top-5 fan-out + catalog pointer |
+| `stateDiagram` | 40 | summary placeholder (no fan-out — states are not nodes) |
+| `sequenceDiagram` | 60 | summary placeholder + top-5 fan-out |
+| `graph` | 100 | summary placeholder + top-5 fan-out |
+
+Cap is measured in rendered elements (nodes + edges for flowchart/graph,
+messages for sequenceDiagram, states + transitions for stateDiagram).
+Above cap, the renderer emits a `> [diagram truncated: ...]` blockquote
+with the element count, the top-5 nodes by fan-out (when applicable),
+and a pointer to the catalog section that enumerates the same data
+without compression.
+
+---
+
+## 1. Header + agent overview
+
+**Purpose**: identify the agent and its planner in a single kv table.
+
+**Input fields** (`tree.agent.*`):
+
+- `api_name` — agent developer name
+- `version` — `v<N>` label
+- `master_label` — human-readable name
+- `description` — prose summary
+- `agent_type` — `EinsteinAgentKind` / `EinsteinCopilotForSalesforce` / …
+- `type` — `ExternalCopilot` / `InternalCopilot` / …
+- `agent_template`
+- `bot_source`
+- `generation` — `classic` / `nga` / `search` / `byop`
+- `planner_name`
+- `planner_type`
+- `bot_id`
+
+Plus `tree._schema_version`.
+
+**Output shape**: `# <H1>` with api_name + version, followed by a 2-col
+markdown table.
+
+**Empty/degenerate cases**:
+
+- Missing `api_name` / `version` renders `?` in the H1 (not `None`).
+- Any missing field renders `-` in its row — not empty, because GitHub
+ table rendering collapses empty cells and the row loses alignment.
+
+---
+
+## 2. Anatomy summary
+
+**Purpose**: one-paragraph executive summary plus health callouts.
+
+**Input fields**:
+
+- `tree._kind_counts` — preferred source for topic / action / flow /
+ apex / prompt counts.
+- `tree.depth`, `tree.node_count` — size metrics.
+- `tree._partial`, `tree._partial_reason` — health flag + prose reason.
+- `tree._pending_fetches` — `{"FLOW":[...],"APEX":[...],
+ "PROMPT_TEMPLATE":[...],"STANDARD_ACTION":[...]}`. Count determines
+ the "pending fetches: N" line in the callout.
+- `tree._unresolved` — triggers a second warn callout with the count.
+- `tree.agent.planner_name` — missing -> warn callout.
+
+**Output shape**: `## 2. Anatomy summary` + paragraph + zero-to-three
+blockquote callouts. Callouts render as `> **Health: PARTIAL.**` /
+`> **Health: WARN.**` prefixes with bullet sub-lines.
+
+**Empty/degenerate cases**: if `_kind_counts` is absent, the walker
+supplies counts from its own pass over the tree. Zero topics is valid
+(SequentialPlannerIntentClassifier).
+
+---
+
+## 3. Invocation sequence
+
+**Purpose**: show the lanes a single user turn traverses, from utterance
+to response.
+
+**Input fields**:
+
+- `tree.agent.generation` — drives lane selection.
+- `tree.agent.planner_type` — distinguishes ReAct vs Sequential within
+ `classic`.
+- Walker-derived `topics[]` and `actions[]` — message count estimate.
+
+**Output shape**: `sequenceDiagram` via `load_mermaid("invocation_
+sequence", ...)`. Lanes per generation:
+
+| Generation | Lanes |
+|---|---|
+| `classic` + ReAct | User, Planner, TopicClassifier, ActionExecutor |
+| `classic` + SequentialPlannerIntentClassifier | User, Planner, ActionExecutor |
+| `nga` (ConcurrentMultiAgent, VoiceAgent) | User, Planner, Orchestrator, SubAgent, ActionExecutor |
+| `search` / `byop` | same as `classic` ReAct (planner lane labelled generically) |
+
+**Empty/degenerate cases**: 0 topics still renders — the Planner ->
+ActionExecutor round-trip fires without a TopicClassifier hop. Above
+the `sequenceDiagram` cap, the section emits the truncation placeholder
+and skips the mermaid block entirely.
+
+---
+
+## 4. Action tree
+
+**Purpose**: the full declared action tree as a flowchart with per-topic
+subgraphs, plus a deterministic ASCII appendix for diff review.
+
+**Input fields**:
+
+- Walker-derived `topics[]` -> one subgraph per topic.
+- Walker-derived `edges[]` -> `parent_api_name --> child_api_name`.
+- `node._cycle_back_to` -> dotted back-edge `A -.->|cycle_back_to: X| B`.
+- Planner-level actions (top-level `GEN_AI_FUNCTION` with no parent
+ topic) -> synthetic `_plannerActions` subgraph.
+
+**Output shape**: ` ```mermaid ` block with `flowchart TB` + subgraphs
++ edges, followed by a `<details>` with ASCII-tree appendix. When
+above cap, the mermaid block is replaced with the truncation
+placeholder; the ASCII appendix still renders.
+
+**Empty/degenerate cases**:
+
+- No topics, no planner actions -> `%% no topics` + `%% no edges`
+ mermaid comments; diagram still parses.
+- Cycle annotations render in both the mermaid (dotted edge) and the
+ ASCII appendix (`[cycle]` marker on the node line).
+
+---
+
+## 5. Topic anatomy
+
+**Purpose**: per-topic detail dump. One H3 per topic with a bullet list
+of actions.
+
+**Input fields**:
+
+- Walker-derived `topics[]` with `api_name`, `label`, `actions`.
+- `topic.raw.master_label` (preferred) or api_name for the label.
+
+**Output shape**: `## 5. Topic anatomy` + one `### \`<api_name>\``
+block per topic + kv list (`- Label:`, `- Action count:`, `- Actions:`
+with sub-bullets).
+
+**Empty/degenerate cases**: 0 topics -> `_No topics defined (planner
+exposes actions directly)._` italic fallback. This is the expected
+case for `SequentialPlannerIntentClassifier`.
+
+---
+
+## 6. Action catalog
+
+**Purpose**: flat markdown table of every declared action.
+
+**Input fields**:
+
+- Walker-derived `actions[]` with `api_name`, `topic`, `raw.unwraps_to`.
+
+**Output shape**: 3-col table (`Action | Topic | Unwraps to`). Unwraps
+column renders as `KIND \`api_name\`` when `unwraps_to` is present, `-`
+otherwise. Planner-level actions show `(plannerAction)` in the topic
+column.
+
+**Empty/degenerate cases**: no actions -> `_No actions declared._`
+italic fallback.
+
+---
+
+## 7. Planner state machine
+
+**Purpose**: illustrate the planner's control-flow shape.
+
+**Input fields**:
+
+- `tree.agent.generation` — primary branch.
+- `tree.agent.planner_type` — sub-branch within `classic`.
+
+**Output shape**: `stateDiagram-v2` via `load_mermaid("planner_state",
+...)`. Per-generation templates:
+
+| Generation | States | Transitions |
+|---|---|---|
+| `classic` + ReAct | Thought / Action / Observation / Respond | Thought -> Action -> Observation -> Thought, Observation -> Respond |
+| `classic` + Sequential | Classify / Execute / Respond | linear |
+| `nga` | Planning / Orchestration (par/and) / Respond | Planning -> Orchestration -> Respond |
+| `search` / `byop` | (skipped — prose placeholder) | (skipped) |
+
+**Empty/degenerate cases**: `search` / `byop` generations render a
+one-line italic placeholder noting that the planner is Apex-backed and
+pointing at section 9. No mermaid block is emitted.
+
+---
+
+## 8. Data flow / context propagation
+
+**Purpose**: show which slot values propagate from user utterance
+through the planner into each action.
+
+**Input fields**:
+
+- Walker-derived `topics[]` and `actions[]`.
+- `action.raw.planner_attr.variable_name` + `planner_attr.data_type` —
+ labels the edge `A -->|var: Type| B`. When absent, the edge is bare.
+
+**Output shape**: `flowchart LR` via `load_mermaid("data_flow", ...)`.
+Skeleton: `User` -> `Planner` -> each `Topic` -> each `Action` under
+that topic.
+
+**Empty/degenerate cases**: no planner_attr metadata -> every edge is
+bare. 0 topics -> only `User --> Planner` renders (no action-level
+edges). Above cap -> truncation placeholder.
+
+---
+
+## 9. Flow / Apex / Prompt catalogs
+
+**Purpose**: per-artifact detail section for every backing flow, apex
+class, and prompt template referenced by any action.
+
+**Input fields**:
+
+- Walker-derived `flows{}`, `apex{}`, `prompts{}`, keyed on api_name.
+- `node.signature` (or `_signature` fallback) — signature block.
+
+**Output shape**: `### Flows` / `### Apex classes` / `### Prompt
+templates` H3 buckets, each containing `#### \`<api_name>\`` + a fenced
+signature block or `_Signature not captured._` fallback. Prompt
+templates render as a flat bullet list (signature capture is
+per-template prose, not a flow/apex shape).
+
+**Empty/degenerate cases**: no backing artifacts in the tree ->
+`_No backing artifacts in tree._` italic fallback.
+
+---
+
+## 10. Unresolved refs + artifact pointers
+
+**Purpose**: surface every `_unresolved[]` entry and point at the
+sidecar files the reader can open.
+
+**Input fields**:
+
+- `tree._unresolved[]` — list of `{kind, api_name, reason}` records.
+
+**Output shape**: Either a 3-col `Kind | Api name | Reason` table or
+an `_No unresolved references._` italic fallback. Followed by an
+`### Artifact pointers` sub-heading with a bullet list of relative
+paths (tree JSON, manifest, summary).
+
+**Empty/degenerate cases**: always renders — the artifact-pointer list
+is unconditional.
+
+---
+
+## Conditional: Dependency graph
+
+**Purpose**: rendered only when `tree._unresolved[]` is non-empty OR
+the tree contains cycle annotations. Shows cross-artifact dependencies
+plus the unresolved nodes as dashed-outline markers.
+
+**Input fields**:
+
+- Walker-derived `edges[]`.
+- `tree._unresolved[]` — each becomes a `:::unresolved` styled node.
+- Walker-derived `cycles[]` — each becomes a dotted back-edge.
+
+**Output shape**: `graph LR` via `load_mermaid("dependency_graph",
+...)`. Includes a `classDef unresolved` class marker at the bottom of
+the template so unresolved nodes render with `stroke-dasharray`.
+
+**Empty/degenerate cases**: not rendered at all when both conditions
+are false. Above the `graph` cap -> truncation placeholder replaces
+the mermaid block.

--- a/skills/investigating-agentforce-architecture/references/contract.json
+++ b/skills/investigating-agentforce-architecture/references/contract.json
@@ -1,0 +1,244 @@
+{
+  "_doc": "retired-name references replaced with plugin-scoped layout. Machine-readable I/O contract for investigating-agentforce-architecture. Orchestrator code reads this file (not SKILL.md prose) to discover the input schema, output keys, STATUS enum, and error-contract rules. The architecture skill runs inline (no subagent).",
+  "_schema_version": "3.1",
+  "_schema_notes": "3.1 (2026-05-05) canonicalizes `invocation_type` on STANDARD_ACTION / UNKNOWN nodes in the metadata tree. Prior versions split this across `raw_invocation_type` (bundle-sourced nodes) and `raw_action_type` (flow-actionCall-sourced nodes). Both legacy keys are still tolerated by readers for one release.",
+  "input": {
+    "required": {
+      "org_alias": {
+        "type": "string",
+        "description": "sf CLI alias (e.g. 'my-org-alias'). Auth is always derived via `sf org display --target-org $ORG_ALIAS --json`."
+      },
+      "agent_api_name": {
+        "type": "string",
+        "regex": "^[A-Za-z0-9_]+$",
+        "description": "BotDefinition.DeveloperName (e.g. 'MyAgent'). Must match the regex above; INVALID_INPUT otherwise."
+      }
+    },
+    "optional": {
+      "agent_version_api_name": {
+        "type": "string",
+        "description": "BotVersion.DeveloperName (e.g. 'v5'). When omitted, the agent auto-picks the Active version with the highest natural-key sort (v10 > v9); VERSION_AUTO_PICKED=true in the RESULT block."
+      },
+      "org_id_15": {
+        "type": "string",
+        "regex": "^[A-Za-z0-9]{15}$",
+        "description": "15-char org ID. If omitted, derived from `sf org display`."
+      },
+      "org_id_18": {
+        "type": "string",
+        "regex": "^[A-Za-z0-9]{18}$",
+        "description": "18-char org ID. If omitted, derived from `sf org display`."
+      },
+      "session_id": {
+        "type": "string",
+        "description": "Only used to name the ephemeral $WORK_DIR. Random UUID if omitted."
+      },
+      "work_dir": {
+        "type": "absolute_path",
+        "description": "Ephemeral scratch. Default: /tmp/investigating-agentforce-architecture-<epoch>-<rand>."
+      },
+      "cache_root": {
+        "type": "absolute_path",
+        "description": "Internal rebuildable cache root. Default: ~/.claude/cache/investigating-agentforce-architecture. Allowlisted by tools/grant_allowlist.py."
+      },
+      "data_root": {
+        "type": "absolute_path",
+        "description": "Durable user-facing output root. Default: ~/.claude/data/investigating-agentforce-architecture."
+      },
+      "force_refresh": {
+        "type": "boolean",
+        "description": "If true, ignore cache and rewrite. Default: false."
+      }
+    },
+    "minimum_viable": {
+      "org_alias": "my-org-alias",
+      "agent_api_name": "MyAgent"
+    },
+    "notes": [
+      "Standalone and orchestrated modes accept the same input fields; no renames.",
+      "To bypass cache, delete the cache entry or pass force_refresh: true."
+    ]
+  },
+  "output": {
+    "format": "Two-part return message: (1) one-line prose status, (2) blank line, (3) === RESULT === key-value block. The KV block is always LAST in the output and always present.",
+    "parse_rule": "Find the line '=== RESULT ===', then read subsequent lines as KEY=VALUE pairs until EOF. Values are raw strings; no quoting; one pair per line.",
+    "parse_examples": {
+      "bash": "awk -F= '/^STATUS=/{print $2; exit}' <<< \"$subagent_output\"",
+      "python": "import re; dict(line.split('=', 1) for line in output.splitlines() if re.match(r'^[A-Z_]+=', line))"
+    },
+    "keys": {
+      "STATUS": {
+        "type": "enum",
+        "presence": "always",
+        "description": "Terminal status. See error_contract for per-status required keys.",
+        "values": [
+          "OK",
+          "PARTIAL_OK",
+          "INVALID_INPUT",
+          "AUTH_REQUIRED",
+          "AGENT_NOT_FOUND",
+          "AGENT_VERSION_NOT_FOUND",
+          "RETRIEVE_FAILED",
+          "WRITE_FAILED"
+        ]
+      },
+      "ERROR_DETAIL": {
+        "type": "string",
+        "presence": "on_error",
+        "description": "Human-readable explanation on any non-OK STATUS. Sanitized (no backticks/quotes/dollar signs/newlines)."
+      },
+      "AGENT_API_NAME": {
+        "type": "string",
+        "presence": "always",
+        "description": "Echo of input agent_api_name. May be empty on INVALID_INPUT if sanitize rejected before resolution."
+      },
+      "AGENT_VERSION": {
+        "type": "string",
+        "presence": "on_success_or_after_resolve",
+        "description": "Resolved BotVersion.DeveloperName (e.g. 'v5')."
+      },
+      "VERSION_AUTO_PICKED": {
+        "type": "boolean",
+        "presence": "on_success_or_after_resolve",
+        "description": "True iff agent_version_api_name was omitted and the agent auto-picked."
+      },
+      "AGENT_GENERATION": {
+        "type": "enum",
+        "presence": "always",
+        "values": ["classic", "nga", "unknown"],
+        "description": "classic = AiCopilot__ planner, nga = Atlas__ planner, unknown = anything else / not resolved."
+      },
+      "BOT_ID": {
+        "type": "string",
+        "presence": "on_success_or_after_resolve",
+        "description": "18-char BotDefinition.Id from SOQL."
+      },
+      "ORG_ID_15": {
+        "type": "string",
+        "presence": "on_success_or_after_auth",
+        "description": "15-char org ID. Cache-key prefix."
+      },
+      "ORG_ID_18": {
+        "type": "string",
+        "presence": "on_success_or_after_auth",
+        "description": "18-char org ID (from `sf org display`)."
+      },
+      "OUTPUT_JSON_PATH": {
+        "type": "absolute_path",
+        "presence": "on_success",
+        "description": "Durable {agent}_{version}_metadata_tree.json path under the resolved data_root."
+      },
+      "OUTPUT_SUMMARY_PATH": {
+        "type": "absolute_path",
+        "presence": "always_empty",
+        "description": "Reserved — historically pointed at {agent}_{version}_metadata_tree.summary.md. Dropped in ; field is now always emitted empty for RESULT-block shape stability."
+      },
+      "CACHE_PATH": {
+        "type": "absolute_path",
+        "presence": "on_success_or_after_cache_check",
+        "description": "Cache dir ($CACHE_ROOT/$ORG_ID_15/$AGENT__$VERSION/). Ends with /."
+      },
+      "CACHE_HIT": {
+        "type": "boolean",
+        "presence": "on_success_or_after_cache_check",
+        "description": "True iff the cache was served without any Metadata API retrieves."
+      },
+      "CACHED_AT_UTC": {
+        "type": "iso8601_utc_or_empty",
+        "presence": "on_success_or_after_cache_check",
+        "description": "ISO-8601 UTC built-at time. On cache hit this is the age of the cached snapshot; on cold build this is the just-computed timestamp."
+      },
+      "NODE_COUNT": {
+        "type": "integer",
+        "presence": "on_success",
+        "description": "Total nodes in the declared_action_tree."
+      },
+      "DEPTH": {
+        "type": "integer",
+        "presence": "on_success",
+        "description": "Max depth of the tree (BOT_DEFINITION = depth 0)."
+      },
+      "PARTIAL": {
+        "type": "boolean",
+        "presence": "on_success",
+        "description": "True iff the tree is incomplete (planner unresolved OR MAX_WAVE hit). When true, STATUS=PARTIAL_OK."
+      },
+      "UNRESOLVED_COUNT": {
+        "type": "integer",
+        "presence": "on_success",
+        "description": "Length of tree._unresolved[]."
+      },
+      "AVAILABLE_BOTS": {
+        "type": "csv",
+        "presence": "on_AGENT_NOT_FOUND",
+        "description": "Comma-separated list of all BotDefinition.DeveloperName values in the org."
+      },
+      "AVAILABLE_VERSIONS": {
+        "type": "csv",
+        "presence": "on_AGENT_VERSION_NOT_FOUND",
+        "description": "Format: 'v5(Active),v4(Inactive),...' — natural-key sorted DESC."
+      },
+      "RESULT_BLOCK_PATH": {
+        "type": "absolute_path",
+        "presence": "always",
+        "description": "Path to $DATA_DIR/last_result_block.txt — byte-for-byte tee written BEFORE stdout."
+      },
+      "WALL_TIME_SECONDS": {
+        "type": "float",
+        "presence": "always",
+        "description": "End-to-end wall-clock seconds. Two decimals. Target: 90-220s cold, <2s warm."
+      }
+    }
+  },
+  "error_contract": {
+    "OK": {
+      "description": "Tree built, zero unresolved, planner resolved.",
+      "required_keys": ["STATUS", "AGENT_API_NAME", "AGENT_VERSION", "VERSION_AUTO_PICKED", "AGENT_GENERATION", "BOT_ID", "ORG_ID_15", "ORG_ID_18", "OUTPUT_JSON_PATH", "OUTPUT_SUMMARY_PATH", "CACHE_PATH", "CACHE_HIT", "CACHED_AT_UTC", "NODE_COUNT", "DEPTH", "PARTIAL", "UNRESOLVED_COUNT", "RESULT_BLOCK_PATH", "WALL_TIME_SECONDS"],
+      "optional_keys": []
+    },
+    "PARTIAL_OK": {
+      "description": "Tree built but planner unresolved (Bot.bot had no planner) OR waves hit MAX_WAVE=5. tree._unresolved[] explains.",
+      "required_keys": ["STATUS", "AGENT_API_NAME", "AGENT_VERSION", "AGENT_GENERATION", "BOT_ID", "ORG_ID_15", "ORG_ID_18", "OUTPUT_JSON_PATH", "CACHE_PATH", "PARTIAL", "UNRESOLVED_COUNT", "WALL_TIME_SECONDS", "RESULT_BLOCK_PATH"],
+      "optional_keys": ["OUTPUT_SUMMARY_PATH", "CACHE_HIT", "CACHED_AT_UTC", "NODE_COUNT", "DEPTH", "VERSION_AUTO_PICKED", "ERROR_DETAIL"]
+    },
+    "INVALID_INPUT": {
+      "description": "agent_api_name failed [A-Za-z0-9_]+ regex, or other input validation (org_alias empty, ORG_ID_15 regex, $WORK_DIR symlink/foreign-owned).",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME"],
+      "optional_keys": ["ORG_ID_15", "ORG_ID_18"]
+    },
+    "AUTH_REQUIRED": {
+      "description": "`sf org display` returned nothing, or a SOQL/Metadata call failed with an auth error. Caller must run `sf org login web --alias $ORG_ALIAS`.",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME"],
+      "optional_keys": ["ORG_ID_15", "ORG_ID_18"]
+    },
+    "AGENT_NOT_FOUND": {
+      "description": "BotDefinition.DeveloperName not in the org. AVAILABLE_BOTS carries the CSV of what IS in the org.",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME", "AVAILABLE_BOTS"],
+      "optional_keys": ["ORG_ID_15", "ORG_ID_18"]
+    },
+    "AGENT_VERSION_NOT_FOUND": {
+      "description": "No matching BotVersion under the bot (explicit version doesn't exist, or no Active version found during auto-pick).",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME", "AVAILABLE_VERSIONS"],
+      "optional_keys": ["BOT_ID", "ORG_ID_15", "ORG_ID_18"]
+    },
+    "RETRIEVE_FAILED": {
+      "description": "`sf project retrieve start` failed (network, permissions, zip unreadable). ERROR_DETAIL carries the specifics.",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME", "AGENT_VERSION", "BOT_ID"],
+      "optional_keys": ["ORG_ID_15", "ORG_ID_18", "OUTPUT_JSON_PATH"]
+    },
+    "WRITE_FAILED": {
+      "description": "Filesystem write failed during finalize (DATA_DIR rename, CACHE_DIR rename, or tree rewrite).",
+      "required_keys": ["STATUS", "ERROR_DETAIL", "AGENT_API_NAME", "AGENT_VERSION"],
+      "optional_keys": ["BOT_ID", "ORG_ID_15", "ORG_ID_18", "CACHE_HIT", "CACHED_AT_UTC"]
+    }
+  },
+  "stability": {
+    "key_names": "Stable. Key-name changes require a NOTICE.md entry and a skill reinstall; consumers read this contract to discover the current key set.",
+    "error_codes": "The STATUS enum is fixed at 8 values. A new status is a breaking change for consumers that switch on STATUS.",
+    "path_format": "All path values are absolute (no tilde expansion required). One KEY=VALUE per line. No trailing whitespace.",
+    "order": "Keys inside the RESULT block appear in a stable order — orchestrators should not depend on order but may use it for human readability."
+  },
+  "referenced_files": {
+    "skill_md": "~/.claude/skills/investigating-agentforce-architecture/SKILL.md"
+  }
+}

--- a/skills/investigating-agentforce-architecture/references/soql_fields.md
+++ b/skills/investigating-agentforce-architecture/references/soql_fields.md
@@ -1,0 +1,512 @@
+# sObject field reference — architecture skill
+
+Field reference for the 13 sObjects this skill queries across the 15
+SOQL templates under `assets/soql/`. Two are reached via the Data API
+(`BotDefinition`, `BotVersion`); the remaining 11 are Tooling-only.
+
+**Source of truth: the live org** (`sf sobject describe --sobject <Name>
+[--use-tooling-api]`). Schemas verified against live Salesforce API
+v66.0 via `sf sobject describe` on `my-org-alias` + `my-org-alias-2`,
+2026-05-02. Official Salesforce Help pages describe logical structures
+that frequently diverge from the physical fields the REST / Tooling API
+actually expose. When a Help page disagrees with a live describe, trust
+the live describe — the names in this reference are what you query.
+
+The source of truth for "mandatory" is `scripts/probe_channels.py`'s
+`MANDATORY_FIELDS` map. A probe that sees any `[mandatory]` field
+missing flips to `status: "PROBE_FAILED"` — the skill aborts with a
+clean error rather than producing a subtly-wrong tree. `[optional]`
+fields degrade gracefully — missing ones are recorded but don't block
+the run.
+
+---
+
+## Casing gotchas
+
+- **Mixed case is mandatory for `GenAi*` sObjects.** API names are
+ `GenAiPlannerDefinition`, `GenAiPluginDefinition`, `GenAiFunctionDefinition`,
+ `GenAiPluginFunctionDef`, `GenAiPluginInstructionDef`,
+ `GenAiPlannerFunctionDef`, `GenAiPlannerAttrDefinition`. Lowercase
+ variants (`genai_planner_definition`, `genaiplannerdefinition`) do not
+ resolve. The SOQL parser is case-insensitive on keywords but
+ sObject + field names must match the describe output for Tooling API
+ calls to route correctly.
+- **`GenAiPluginFunctionDef` vs `GenAiPlannerFunctionDef` are different
+ tables.** Plugin-scope join (topic → function, via `PluginId`) vs
+ planner-bundle-scope join (planner → function, via `PlannerId`). Both
+ are 10-field join tables with nearly identical shape; keep them
+ straight.
+- **`BotVersion.DeveloperName` is the version id, not the version
+ label.** `DeveloperName` on BotVersion is the version API name (e.g.
+ `v5`), used as the second path segment under
+ `<org_id15>/<agent>__<version>/`. `MasterLabel` is the
+ human-readable label (e.g. "Version 5 — ported from staging"). Never
+ mix them — the data dir layout and the SKILL.md input contract both
+ key on `DeveloperName`.
+- **`complexvalue` fields require single-row retrieval.** `Metadata`
+ (on `Flow`, `FlowDefinition`, `GenAiPluginDefinition`,
+ `GenAiFunctionDefinition`), `SymbolTable` (on `ApexClass`), and
+ `AgentGraph` (on `GenAiPlannerDefinition`, often null in practice) are
+ `complexvalue` types. Salesforce enforces
+ `MALFORMED_QUERY: When retrieving results with Metadata or FullName
+ fields, the query qualifications must specify no more than one row for
+ retrieval.` Batch IN-clause SELECTs that return ≥2 rows fail. Use a
+ single-row equality (`WHERE Id = '<id>'`) per fetch; parallelize
+ across ids via `concurrent.futures`. `ApexClass.Body` +
+ `ApexClass.SymbolTable` is the one notable exception: the
+ `Name IN (...)` batch works even though `SymbolTable` is complex.
+
+---
+
+## Cross-sObject join map
+
+Every edge is strictly **forward** from the entry query
+(`GenAiPlannerDefinition WHERE DeveloperName = :planner_name`). No
+backward lookups.
+
+```
+BotDefinition (Data API, PK Id, matched by DeveloperName)
+ └── BotVersion (Data API, FK BotDefinitionId)
+ │ [resolved to planner name via Bot metadata retrieve]
+ ▼
+GenAiPlannerDefinition (Tooling, PK Id, matched by DeveloperName)
+ │
+ ├── GenAiPluginDefinition ← WHERE PlannerId = :plannerId
+ │ ├── GenAiPluginInstructionDef ← WHERE GenAiPluginDefinitionId IN (:topic_ids)
+ │ ├── GenAiPluginFunctionDef ← WHERE PluginId IN (:topic_ids)
+ │ │ └── Function picklist → GenAiFunctionDefinition.Id
+ │ └── GenAiFunctionDefinition ← WHERE PluginId IN (:topic_ids)
+ │
+ ├── GenAiPlannerFunctionDef ← WHERE PlannerId = :plannerId
+ │ └── Plugin picklist → GenAiPluginDefinition.Id (or external via retrieve)
+ │
+ ├── GenAiFunctionDefinition ← WHERE PluginId IN (:topic_ids)
+ │ │ (single-query — see functions_by_plugins.soql)
+ │ │
+ │ └── InvocationTargetType + InvocationTarget route to:
+ │ ├── flow → FlowDefinition (batch IN) → Flow.Metadata (parallel single-row)
+ │ ├── apex → ApexClass (batch IN, Body + SymbolTable)
+ │ ├── standardInvocableAction → (no further fetch — declared only)
+ │ └── generatePromptResponse → GenAiPromptTemplate (Metadata API retrieve)
+ │
+ └── GenAiPlannerAttrDefinition ← WHERE ParentId IN (:function_ids, :planner_id)
+ (polymorphic ParentId: GenAiFunctionDefinition OR GenAiPlannerDefinition)
+```
+
+Per-channel row counts + `_unresolved[]` reasons are recorded in
+`metadata_tree.json` under `_channels` and `_unresolved` keys.
+
+---
+
+## Data API sObjects (2)
+
+### `BotDefinition` (Data API) — one row per agent
+
+Root of the agent metadata. Matched by `DeveloperName`; the rest of the
+tree is resolved forward from the `BotVersion` child.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [mandatory] |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `AgentType` | picklist | yes | yes | [optional] — discriminator for classic vs NGA in some orgs |
+| `Type` | picklist | yes | yes | [optional] |
+| `AgentTemplate` | string | yes | yes | [optional] — e.g. `SvcCopilotTmpl__EinsteinAgentKind` |
+| `BotSource` | picklist | yes | yes | [optional] |
+| `AgentUser` | reference | yes | yes | [optional] — FK to `User` |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+### `BotVersion` (Data API) — one row per agent version
+
+Resolves the active version (or user-pinned version) for a given bot.
+Parent relationship: `BotDefinition` via `BotDefinitionId`.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `BotDefinitionId` | reference | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [optional] — version id (e.g. `v5`) |
+| `MasterLabel` | string | yes | yes | [optional] — human label |
+| `Status` | picklist | yes | yes | [optional] — `Active` on the current published version |
+| `VersionNumber` | int | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `AiReplyRecordVisibility` | picklist | yes | yes | [optional] |
+| `ResponseDelayMilliseconds` | int | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+
+---
+
+## Tooling API sObjects (11)
+
+All sObjects in this section are reachable via the Tooling API only
+(`sf data query --use-tooling-api` or `sf sobject describe --use-tooling-api`).
+
+### `ApexClass` (Tooling) — Apex source + parsed AST
+
+Source + full method/property AST for Apex referenced by
+`GenAiFunctionDefinition.InvocationTarget` when
+`InvocationTargetType = 'apex'`. Batch-safe on `Name IN (...)` or
+`Id IN (...)` (despite `SymbolTable` being `complexvalue`, Salesforce
+permits the batch for this particular sObject — verified live).
+
+**Note:** `SymbolTable` is **not part of `FIELDS(ALL)`** and must be
+named explicitly in the SELECT.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `Name` | string | no | yes | [mandatory] |
+| `Body` | textarea | yes | no | [optional] — full Apex source |
+| `SymbolTable` | complexvalue | yes | no | [optional] — parsed AST (methods, params, annotations, line/col) |
+| `ApiVersion` | double | no | yes | [optional] |
+| `IsValid` | boolean | no | yes | [optional] |
+| `Status` | picklist | no | yes | [optional] |
+| `LengthWithoutComments` | int | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `FullName` | string | yes | no | [optional] — complexvalue companion |
+| `Metadata` | complexvalue | yes | no | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+**Single-row requirement for complexvalue columns:** `Metadata` and
+`FullName` on `ApexClass` follow the standard `MALFORMED_QUERY` rule —
+batch IN-clause SELECTs that return ≥2 rows fail when these two are
+selected. `Body` + `SymbolTable` are the exception (batch works).
+Comments in `assets/soql/apex_class_bodies_by_ids.soql` +
+`apex_class_bodies_by_names.soql` pin this.
+
+### `Flow` (Tooling) — Flow version body
+
+Single-row retrieval required — `Metadata` and `FullName` are both
+`complexvalue`. Fired once per `activeVersionId` returned by
+`FlowDefinition`; parallelized via `ThreadPoolExecutor`.
+
+**Filterability quirk:** `FullName` is selectable but **not filterable**
+(`INVALID_FIELD: field 'FullName' can not be filtered in a query call`).
+Filter by `Id` instead.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DefinitionId` | reference | no | yes | [mandatory] |
+| `FullName` | string | yes | **no** | [optional] — complexvalue companion; not filterable |
+| `Metadata` | complexvalue | yes | no | [optional] — full flow JSON (actionCalls, subflows, variables, decisions, formulas, assignments, apexPluginCalls) |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `VersionNumber` | int | yes | yes | [optional] |
+| `ProcessType` | picklist | yes | yes | [optional] |
+| `Status` | picklist | yes | yes | [optional] |
+| `ApiVersion` | double | yes | yes | [optional] |
+| `IsActive` | boolean | no | yes | [optional] |
+| `IsTemplate` | boolean | no | yes | [optional] |
+| `RunInMode` | picklist | yes | yes | [optional] |
+| `Environments` | picklist | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `OverriddenFlowId` | reference | yes | yes | [optional] |
+| `SourceTemplateId` | reference | yes | yes | [optional] |
+| `TriggerType` | picklist | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+| `InstalledPackageName` | string | yes | yes | [optional] |
+
+**Single-row requirement:** `Metadata` and `FullName` force
+`WHERE Id = '<version_id>'`. The SOQL asset `flow_metadata_by_id.soql`
+encodes this as a single `Id = '...'` predicate.
+
+### `FlowDefinition` (Tooling) — Flow versioning index
+
+Two-hop feeder to `Flow`. Batch IN-clause works. Returns
+`ActiveVersionId` + `LatestVersionId` — the skill prefers active.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [mandatory] |
+| `ActiveVersionId` | reference | yes | yes | [optional] — FK to `Flow.Id` |
+| `LatestVersionId` | reference | yes | yes | [optional] — FK to `Flow.Id` |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `Metadata` | complexvalue | yes | no | [optional] — definition-level metadata (may carry what the Flow hop provides on some orgs) |
+| `FullName` | string | yes | no | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+### `GenAiPlannerDefinition` (Tooling) — planner root
+
+Entry query for the tree. Matched by `DeveloperName` (the
+`<genAiPlannerName>` extracted from the Bot metadata retrieve). The
+`PlannerType` picklist is the classifier for classic ReAct vs NGA.
+
+**Seven-value `PlannerType` picklist** (verified consistent across
+`my-org-alias`, `my-org-alias-2`, `my-org-alias-3`): grouped by
+namespace — `AiCopilot__*` = classic ReAct family,
+`Atlas__*` = NGA family. `startswith("Atlas__")` is a clean
+classic-vs-NGA discriminator.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [mandatory] |
+| `PlannerType` | picklist | yes | yes | [mandatory] |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `Capabilities` | textarea | yes | no | [optional] — null in every row tested on both classic + NGA |
+| `AgentGraph` | complexvalue | yes | no | [optional] — null in every row tested; single-row rule still applies |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `Metadata` | complexvalue | yes | no | [optional] |
+| `FullName` | string | yes | no | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `LastModifiedDate` | datetime | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+**Single-row requirement for complexvalue columns:** `AgentGraph`,
+`Metadata`, `FullName` — select individually; entry query pins
+`WHERE DeveloperName = '...' LIMIT 1`.
+
+### `GenAiPluginDefinition` (Tooling) — topics
+
+All topics for a planner via `WHERE PlannerId = :plannerId`. Carries
+`PluginType` + `Scope` for topic classification and `CanEscalate` /
+`IsLocal` for behavior flags.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [mandatory] |
+| `PluginType` | picklist | yes | yes | [optional] — topic type classifier |
+| `Scope` | textarea | yes | no | [optional] — natural-language topic scope |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `CanEscalate` | boolean | yes | yes | [optional] |
+| `IsLocal` | boolean | yes | yes | [optional] |
+| `Source` | picklist | yes | yes | [optional] |
+| `ParentId` | reference | yes | yes | [optional] — planner FK (sometimes referred to as `PlannerId` in SOQL filter clauses) |
+| `LocalDeveloperName` | string | yes | yes | [optional] |
+| `Language` | picklist | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `Metadata` | complexvalue | yes | no | [optional] |
+| `FullName` | string | yes | no | [optional] |
+| `ClassificationDescription` | textarea | yes | no | [optional] |
+| `GenAiFunctionInvoker` | string | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+
+**Single-row requirement:** `Metadata` + `FullName` require per-id
+retrieval. The production path doesn't SELECT `Metadata` on this sObject
+(see `plugins_by_planner.soql`) — it pulls `Scope` + scalar fields
+instead, which batch-safely over `PlannerId = :id`.
+
+### `GenAiPluginFunctionDef` (Tooling) — plugin-function join
+
+Join table: `GenAiPluginDefinition` → `GenAiFunctionDefinition`. Batch-
+safe on `PluginId IN (...)`.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `PluginId` | reference | no | yes | [mandatory] |
+| `Function` | picklist | yes | yes | [optional] — references `GenAiFunctionDefinition.Id` |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+### `GenAiPluginInstructionDef` (Tooling) — per-topic instructions
+
+Per-topic instruction text + ordering. Batch-safe on
+`GenAiPluginDefinitionId IN (...)`.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `GenAiPluginDefinitionId` | reference | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [optional] |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] — the instruction text |
+| `SortOrder` | int | yes | yes | [optional] |
+| `Language` | picklist | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `FullName` | string | yes | no | [optional] |
+| `Metadata` | complexvalue | yes | no | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+
+**Single-row requirement:** `Metadata` + `FullName` complexvalue pair;
+the production SOQL omits them (scalar fields batch-safely).
+
+### `GenAiFunctionDefinition` (Tooling) — actions
+
+The actions. Combined single-query fetches both bundle-scope (`PlannerId`)
+and topic-scope (`PluginId IN`) functions. `InvocationTargetType`
++ `InvocationTarget` route to the downstream fetch (Flow, Apex, prompt,
+standard invocable).
+
+**`InvocationTarget` format varies by planner shape** (the ID-prefix
+router lives in `scripts/resolve_invocation_target.py`):
+- Classic ReAct: DeveloperName string (e.g. `AGNT_SetUserSelectedOption`).
+- NGA: Salesforce 15/18-char Id (e.g. `01pVF...` = ApexClass,
+ `300VF...` = FlowDefinition, `0hf...` = GenAiPromptTemplate).
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `DeveloperName` | string | no | yes | [mandatory] |
+| `InvocationTarget` | string | yes | yes | [mandatory] |
+| `InvocationTargetType` | picklist | yes | yes | [optional] — `flow` / `apex` / `standardInvocableAction` / `generatePromptResponse` |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `IsLocal` | boolean | yes | yes | [optional] |
+| `IsConfirmationRequired` | boolean | yes | yes | [optional] |
+| `IsIncludeInProgressIndicator` | boolean | yes | yes | [optional] |
+| `ProgressIndicatorMessage` | string | yes | yes | [optional] |
+| `Source` | picklist | yes | yes | [optional] |
+| `PluginId` | reference | yes | yes | [optional] — topic-scope FK (null for bundle-scope functions) |
+| `PlannerId` | reference | yes | yes | [optional] — bundle-scope FK (null on NGA — attachment is plugin-only) |
+| `ParentId` | reference | yes | yes | [optional] |
+| `LocalDeveloperName` | string | yes | yes | [optional] |
+| `Language` | picklist | yes | yes | [optional] |
+| `InvocationTargetApiName` | string | yes | yes | [optional] |
+| `MissingValuePromptMessage` | string | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `Metadata` | complexvalue | yes | no | [optional] |
+| `FullName` | string | yes | no | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+
+**Single-row requirement:** `Metadata` + `FullName` complexvalue
+columns; production SOQL omits both to keep the `PlannerId / PluginId IN`
+batch path intact.
+
+### `GenAiPlannerFunctionDef` (Tooling) — planner-bundle join
+
+Bundle-scope join: planner → function. Analogous to
+`GenAiPluginFunctionDef` but keyed on `PlannerId`. Batch-safe on
+`PlannerId = :id`.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `PlannerId` | reference | no | yes | [mandatory] |
+| `Plugin` | picklist | yes | yes | [optional] — references plugin DeveloperName / id |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+| `SystemModstamp` | datetime | no | yes | [optional] |
+
+### `GenAiPlannerAttrDefinition` (Tooling) — parameter mappings
+
+The `attributeMappings` — I/O parameter bindings between actions and
+the planner. **Polymorphic `ParentId`**: points at either a
+`GenAiFunctionDefinition` (function-scope mappings) or
+`GenAiPlannerDefinition` (bundle-scope mappings). The production SOQL
+passes the union of function ids + planner id via
+`WHERE ParentId IN (:function_ids, :planner_id)`.
+
+`MappingType` is the `input` / `output` picklist; `ParameterName`
+identifies the bound variable on the planner side.
+
+| Name | Type | Nillable | Filterable | Tag |
+|---|---|---|---|---|
+| `Id` | id | no | yes | [mandatory] |
+| `ParentId` | reference | yes | yes | [optional] — polymorphic: GenAiFunctionDefinition \| GenAiPlannerDefinition |
+| `DeveloperName` | string | no | yes | [optional] |
+| `MasterLabel` | string | yes | yes | [optional] |
+| `Description` | textarea | yes | no | [optional] |
+| `MappingType` | picklist | yes | yes | [optional] — `input` / `output` |
+| `ParameterName` | string | yes | yes | [optional] |
+| `Language` | picklist | yes | yes | [optional] |
+| `NamespacePrefix` | string | yes | yes | [optional] |
+| `ManageableState` | picklist | yes | yes | [optional] |
+| `IsDeleted` | boolean | no | yes | [optional] |
+| `CreatedById` | reference | no | yes | [optional] |
+| `CreatedDate` | datetime | no | yes | [optional] |
+| `LastModifiedById` | reference | no | yes | [optional] |
+
+---
+
+## Known picklist values (live-API verified, 2026-05-02)
+
+| sObject | Field | Values |
+|---|---|---|
+| `GenAiPlannerDefinition` | `PlannerType` | Seven values split by namespace. Classic family: `AiCopilot__ReAct`, `AiCopilot__ReactAiPlannerV1`, `AiCopilot__SequentialPlannerIntentClassifier`. NGA family: `Atlas__ConcurrentMultiAgentOrchestration`, `Atlas__AnthropicCompatibleV1`, `Atlas__AtlasReactV1`, `Atlas__MainSubAgent` (exact set may vary by release — `startswith("Atlas__")` is the stable classic-vs-NGA discriminator). |
+| `GenAiFunctionDefinition` | `InvocationTargetType` | `flow`, `apex`, `standardInvocableAction`, `generatePromptResponse` |
+| `GenAiPlannerAttrDefinition` | `MappingType` | `input`, `output` |
+| `BotVersion` | `Status` | `Inactive`, `Active` (active = currently published version) |
+
+---
+
+## Mandatory-field enforcement
+
+The `[mandatory]` tags above mirror `scripts/probe_channels.py`:
+
+```python
+MANDATORY_FIELDS: Dict[str, set[str]] = {
+ "BotDefinition": {"Id", "DeveloperName"},
+ "BotVersion": {"Id", "BotDefinitionId"},
+ "ApexClass": {"Id", "Name"},
+ "Flow": {"Id", "MasterLabel", "DefinitionId"},
+ "FlowDefinition": {"Id", "DeveloperName"},
+ "GenAiPlannerDefinition": {"Id", "DeveloperName", "PlannerType"},
+ "GenAiPluginDefinition": {"Id", "DeveloperName"},
+ "GenAiFunctionDefinition": {"Id", "DeveloperName", "InvocationTarget"},
+ "GenAiPlannerAttrDefinition": {"Id"},
+}
+```
+
+`GenAiPluginFunctionDef`, `GenAiPluginInstructionDef`, and
+`GenAiPlannerFunctionDef` don't appear in `MANDATORY_FIELDS` — they're
+join tables whose `Id` + FK columns are present by construction on
+every query. The per-sObject tables above tag their FK columns as
+`[mandatory]` because the SOQL assets SELECT them; a probe that saw
+them missing would still flip `PROBE_FAILED` via the `Id` check, but
+the tag reflects "the skill's SOQL will fail if this column is gone."
+
+When a Salesforce quarterly release renames or removes a
+`[mandatory]` field, run with `--reprobe` to force a fresh describe and
+surface the drift cleanly.

--- a/skills/investigating-agentforce-architecture/scripts/_shared/__init__.py
+++ b/skills/investigating-agentforce-architecture/scripts/_shared/__init__.py
@@ -1,0 +1,1 @@
+# Shared path / fs-guard / sql helpers for investigating-agentforce-architecture.

--- a/skills/investigating-agentforce-architecture/scripts/_shared/fs_guard.py
+++ b/skills/investigating-agentforce-architecture/scripts/_shared/fs_guard.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+r"""Filesystem-safety and input-validation guard.
+
+One script, six check types. Emits a STATUS=INVALID_INPUT RESULT block on
+failure + tees to $ERROR_TEE on disk + exits 1.
+
+Guiding principle: the agent MUST suffix every call with `|| exit 1` — Python
+`sys.exit(1)` only terminates this subprocess, not the parent bash. A bare
+call without `|| exit 1` silently continues past a failed guard, which is
+the worst possible failure mode for a security check.
+
+Check types:
+    symlink     — path must NOT be a symlink (rejects pre-planted attacker bait)
+    owned       — path must be owned by current UID (rejects foreign-owned dirs)
+    uuid          — value must match ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
+    org_id_15     — value must match ^[A-Za-z0-9]{15}$ (Salesforce org ID slice)
+    api_name      — value must match ^[A-Za-z0-9_]+$ (Salesforce API identifier)
+    api_version   — value must match ^v[0-9]+\.[0-9]+$ (e.g. v60.0)
+    agent_version — value must match ^v[0-9]+$ (e.g. v5 — Agentforce agent version, no dot-minor)
+    not_empty     — value must be non-empty string
+
+Python-importable API:
+    validate_api_name(value, label="...")      — raises ValidationError on bad input
+    validate_api_version(value, label="...")   — raises ValidationError on bad input
+    validate_agent_version(value, label="...") — raises ValidationError on bad input
+    validate_org_id_15(value, label="...")     — raises ValidationError on bad input
+    ValidationError                            — carries (label, reason)
+
+The Python API is used by in-process callers (SOQL loader, path builders in
+config.py) that need a raise-based boundary rather than the process-exit
+CLI behavior. Regex is shared — do NOT duplicate API_NAME_RE / API_VERSION_RE.
+
+Usage:
+    python3 fs_guard.py <value> <label> <check> || exit 1
+
+    # Input validation
+    python3 fs_guard.py "$AGENT_API_NAME" agent_api_name api_name || exit 1
+    python3 fs_guard.py "$ORG_ALIAS"      org_alias      not_empty || exit 1
+
+    # Filesystem safety
+    python3 fs_guard.py "$WORK_DIR"  WORK_DIR  symlink || exit 1
+    python3 fs_guard.py "$WORK_DIR"  WORK_DIR  owned   || exit 1
+    python3 fs_guard.py "$ORG_ID_15" ORG_ID_15 org_id_15 || exit 1
+
+Inputs:
+    argv[1]     value or path to check
+    argv[2]     label (appears in ERROR_DETAIL; used to identify which guard tripped)
+    argv[3]     check type (one of the 6 above)
+    env         $ERROR_TEE (optional): path to disk-tee file. Defaults to
+                $HOME/.claude/data/investigating-agentforce-architecture/_last_error_result.txt.
+                Also reads $AGENT_API_NAME / $ORG_ID_18 / $ORG_ID_15 for
+                RESULT-block context if set.
+
+Outputs:
+    on failure: STATUS=INVALID_INPUT RESULT block on stdout + tee to disk, exit 1
+    on success: silent, exit 0
+    on bad argv: exit 1 with a minimal ERROR_DETAIL ("fs_guard internal: ...")
+"""
+import os
+import pathlib
+import re
+import sys
+
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+ORG_ID_15_RE = re.compile(r"^[A-Za-z0-9]{15}$")
+API_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+# api_version check — matches `v60.0`, `v66.0`, etc. Used before any
+# Path composition that embeds the api_version segment.
+API_VERSION_RE = re.compile(r"^v[0-9]+\.[0-9]+$")
+# Agent-version check — matches Agentforce version identifiers (`v1`, `v5`,
+# `v12`). Deliberately stricter than api_name (rejects free-form names like
+# `release_1`) and looser than api_version (rejects `v66.0` which is a REST
+# API version, never an agent version). Lives on its own so callers that
+# embed agent_version in a filesystem path get the tight regex, not the
+# permissive api_name fallback.
+AGENT_VERSION_RE = re.compile(r"^v[0-9]+$")
+VALID_CHECKS = {"symlink", "owned", "uuid", "org_id_15", "api_name", "api_version", "agent_version", "not_empty"}
+
+
+# -----------------------------------------------------------------------------
+# Python-importable API 
+# -----------------------------------------------------------------------------
+# In-process callers (soql_loader.load_soql, config.build_*_dir) need a
+# raise-based validation boundary, distinct from the CLI script's exit-1
+# behavior. The regexes are shared with the CLI checks above — do NOT
+# duplicate. If a regex changes, both surfaces update in lockstep.
+
+
+class ValidationError(ValueError):
+    """Raised by the Python-importable validators on bad input.
+
+    Carries the label (which field failed) + reason. Callers (e.g.
+    soql_loader.load_soql) convert this into `_unresolved[]` entries or
+    RESULT-level INVALID_INPUT responses as appropriate.
+    """
+
+    def __init__(self, label: str, reason: str) -> None:
+        self.label = label
+        self.reason = reason
+        super().__init__(f"{label}: {reason}")
+
+
+def validate_api_name(value, label: str = "value") -> None:
+    """Validate `value` against ^[A-Za-z0-9_]+$ (Salesforce API identifier).
+
+    used by soql_loader.load_soql at the substitution boundary to catch
+    injection attempts in names pulled from Bot XML, Flow.Metadata, ApexClass
+    SymbolTable, etc.
+
+    used by config.build_*_dir helpers for path components that must
+    not contain `..`, `/`, or other traversal characters.
+
+    Raises ValidationError on any of: None, non-string, empty, regex miss.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not API_NAME_RE.match(value):
+        # Preview first 20 chars so logs/_unresolved entries carry enough
+        # context to debug, without dumping an unbounded attacker-controlled
+        # string into output.
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match [A-Za-z0-9_]+ (preview={preview!r})",
+        )
+
+
+def validate_api_version(value, label: str = "api_version") -> None:
+    """Validate `value` against ^v[0-9]+\\.[0-9]+$ (Salesforce API version).
+
+    used by config.build_*_dir helpers. api_version is returned by
+    `sf org display` and later embedded in cache paths; reject anything that
+    could escape the cache subtree.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not API_VERSION_RE.match(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match v<major>.<minor> (preview={preview!r})",
+        )
+
+
+def validate_agent_version(value, label: str = "agent_version") -> None:
+    """Validate `value` against ^v[0-9]+$ (Agentforce agent version).
+
+    Strictly `v<digits>` with no dot-minor — matches the shape Agentforce
+    actually uses (`v1`, `v5`, `v12`). Rejects `release_1`, `v66.0`, `FOO`,
+    and anything else that could silently slip past a permissive api_name
+    check and land in a filesystem path.
+
+    used by path-builder helpers for the agent_version segment.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not AGENT_VERSION_RE.match(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match v<digits> (preview={preview!r})",
+        )
+
+
+def validate_org_id_15(value, label: str = "org_id_15") -> None:
+    """Validate `value` against ^[A-Za-z0-9]{15}$ (Salesforce 15-char org ID).
+
+    stricter than validate_api_name — enforces exact 15 chars AND
+    no underscores. `org_id_15` always comes from a Salesforce-generated
+    field, never from free-form input.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not ORG_ID_15_RE.match(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"must be exactly 15 alphanumeric chars (preview={preview!r})",
+        )
+
+
+def scrub(s: str) -> str:
+    # Same rules as sanitize.py; duplicated locally so this script has no
+    # intra-skill imports. Keeps the agent-script boundary clean.
+    bad = set("`$\"\\\r\t\0\n")
+    return "".join(c for c in (s or "") if c not in bad)
+
+
+def emit_failure(reason: str, label: str) -> None:
+    agent_api_name = scrub(os.environ.get("AGENT_API_NAME", ""))
+    org_id_18 = scrub(os.environ.get("ORG_ID_18", ""))
+    org_id_15 = scrub(os.environ.get("ORG_ID_15", ""))
+    label_safe = scrub(label)
+    reason_safe = scrub(reason)
+
+    block = (
+        "=== RESULT ===\n"
+        "STATUS=INVALID_INPUT\n"
+        f"ERROR_DETAIL={label_safe}: {reason_safe}\n"
+        f"AGENT_API_NAME={agent_api_name}\n"
+        f"ORG_ID_18={org_id_18}\n"
+        f"ORG_ID_15={org_id_15}\n"
+    )
+
+    # Default ERROR_TEE — skill-scoped data dir.
+    tee_default = str(
+        pathlib.Path.home()
+        / ".claude"
+        / "data"
+        / "investigating-agentforce-architecture"
+        / "_last_error_result.txt"
+    )
+    tee_path = os.environ.get("ERROR_TEE") or tee_default
+    try:
+        p = pathlib.Path(tee_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(block)
+    except OSError:
+        pass
+
+    sys.stdout.write(block)
+    sys.exit(1)
+
+
+def check_symlink(value: str, label: str) -> None:
+    if pathlib.Path(value).is_symlink():
+        emit_failure(f"path is a symlink (refusing to follow): {value}", label)
+
+
+def check_owned(value: str, label: str) -> None:
+    p = pathlib.Path(value)
+    if not p.exists():
+        return
+    try:
+        st = p.stat()
+    except OSError as e:
+        emit_failure(f"stat failed: {e}", label)
+        return
+    if st.st_uid != os.getuid():
+        emit_failure(f"foreign-owned (uid {st.st_uid} != current {os.getuid()}): {value}", label)
+
+
+def check_uuid(value: str, label: str) -> None:
+    if not UUID_RE.match(value):
+        emit_failure("does not match UUID pattern (8-4-4-4-12 lowercase hex)", label)
+
+
+def check_org_id_15(value: str, label: str) -> None:
+    if not ORG_ID_15_RE.match(value):
+        emit_failure("must be exactly 15 alphanumeric characters", label)
+
+
+def check_api_name(value: str, label: str) -> None:
+    if not API_NAME_RE.match(value):
+        emit_failure("does not match [A-Za-z0-9_]+ (Salesforce API name rules)", label)
+
+
+def check_api_version(value: str, label: str) -> None:
+    # api_version must be `vNN.N` — no slashes, no dots beyond the one,
+    # no path-traversal sequences.
+    if not API_VERSION_RE.match(value):
+        emit_failure("does not match v<major>.<minor> (e.g. v60.0)", label)
+
+
+def check_agent_version(value: str, label: str) -> None:
+    # Agent version must be `v<digits>` — no dots, no slashes.
+    if not AGENT_VERSION_RE.match(value):
+        emit_failure("does not match v<digits> (e.g. v5)", label)
+
+
+def check_not_empty(value: str, label: str) -> None:
+    if not value:
+        emit_failure("must not be empty", label)
+
+
+CHECKS = {
+    "symlink": check_symlink,
+    "owned": check_owned,
+    "uuid": check_uuid,
+    "org_id_15": check_org_id_15,
+    "api_name": check_api_name,
+    "api_version": check_api_version,
+    "agent_version": check_agent_version,
+    "not_empty": check_not_empty,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stdout.write(
+            "=== RESULT ===\n"
+            "STATUS=INVALID_INPUT\n"
+            "ERROR_DETAIL=fs_guard internal: wrong argv count (need value, label, check)\n"
+        )
+        return 1
+    value, label, check = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    for arg in (value, label, check):
+        if any(c == "\0" or (ord(c) < 0x20 and c not in "\t\n") for c in arg):
+            emit_failure("argv contains control characters", label or "argv")
+
+    if check not in VALID_CHECKS:
+        emit_failure(f"unknown check type '{check}' (valid: {', '.join(sorted(VALID_CHECKS))})", label)
+
+    CHECKS[check](value, label)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/_shared/paths.py
+++ b/skills/investigating-agentforce-architecture/scripts/_shared/paths.py
@@ -1,0 +1,105 @@
+"""Canonical path helpers for investigating-agentforce-architecture.
+
+Layout:
+
+    ~/.claude/data/investigating-agentforce-architecture/
+    └── <org_id_15>/
+        └── <agent_api_name>__<agent_version>/
+            ├── <agent>_<ver>_metadata_tree.json     ← rendered tree
+            └── .emit_ctx.json                       ← per-run shell ctx
+
+Validation strategy
+-------------------
+The three "agent-identity" segments (org_id_15, agent_api_name, agent_version)
+are validated by the regex helpers in the sibling ``fs_guard`` module. Any
+segment containing ``..``, ``/``, or characters outside its regex charclass
+raises ``PathValidationError`` — direct ``Path`` composition from unvalidated
+input would be a path-traversal vulnerability and is prohibited.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import fs_guard
+
+
+# -----------------------------------------------------------------------------
+# Roots
+# -----------------------------------------------------------------------------
+
+DATA_ROOT: Path = (
+    Path.home() / ".claude" / "data" / "investigating-agentforce-architecture"
+)
+CACHE_ROOT: Path = (
+    Path.home() / ".claude" / "cache" / "investigating-agentforce-architecture"
+)
+
+
+class PathValidationError(ValueError):
+    """Raised when a path segment fails validation.
+
+    Wraps fs_guard's ``ValidationError`` so callers have a single exception
+    type to catch.
+    """
+
+    def __init__(self, label: str, reason: str) -> None:
+        self.label = label
+        self.reason = reason
+        super().__init__(f"{label}: {reason}")
+
+
+# -----------------------------------------------------------------------------
+# Validation helpers
+# -----------------------------------------------------------------------------
+
+
+def _validate_agent_triple(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> None:
+    """Validate the three identity segments. Raises PathValidationError on
+    failure, wrapping fs_guard's ValidationError so callers don't need to
+    know about fs_guard internals."""
+    try:
+        fs_guard.validate_org_id_15(org_id_15, label="org_id_15")
+        fs_guard.validate_api_name(agent_api_name, label="agent_api_name")
+        fs_guard.validate_agent_version(agent_version, label="agent_version")
+    except fs_guard.ValidationError as e:
+        raise PathValidationError(e.label, e.reason) from e
+
+
+# -----------------------------------------------------------------------------
+# Path builders
+# -----------------------------------------------------------------------------
+
+
+def agent_dir(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> Path:
+    """Return ``DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/``.
+
+    All three segments are regex-validated before being joined.
+    """
+    _validate_agent_triple(org_id_15, agent_api_name, agent_version)
+    return DATA_ROOT / org_id_15 / f"{agent_api_name}__{agent_version}"
+
+
+def architecture_tree_path(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> Path:
+    """Return the path to the rendered metadata tree JSON.
+
+    Filename convention: ``<agent_api_name>_<agent_version>_metadata_tree.json``.
+    """
+    base = agent_dir(org_id_15, agent_api_name, agent_version)
+    return base / f"{agent_api_name}_{agent_version}_metadata_tree.json"
+
+
+def architecture_emit_ctx_path(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> Path:
+    """Return the path to the per-run ``.emit_ctx.json``.
+
+    The file is dotfile-named to signal per-run shell state.
+    """
+    base = agent_dir(org_id_15, agent_api_name, agent_version)
+    return base / ".emit_ctx.json"

--- a/skills/investigating-agentforce-architecture/scripts/_shared/sql.py
+++ b/skills/investigating-agentforce-architecture/scripts/_shared/sql.py
@@ -1,0 +1,10 @@
+"""SQL-escaping helpers for SOQL string literals.
+"""
+from __future__ import annotations
+
+
+def _escape_sql_literal(s: str) -> str:
+    """Double single quotes per SOQL escaping rule. Handles O'Brien →
+    O''Brien, `'; DROP --` → `''; DROP --` (still harmless because it's
+    wrapped in surrounding single quotes)."""
+    return s.replace("'", "''")

--- a/skills/investigating-agentforce-architecture/scripts/cache_check.py
+++ b/skills/investigating-agentforce-architecture/scripts/cache_check.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Cache hit/miss check for investigating-agentforce-architecture.
+
+Replaces old agent Phase 0.5 (manifest read, schema-version check, TTL age
+check, path-existence check, env export on hit, RESULT-block assembly).
+
+Flow:
+  1. If FORCE_REFRESH=true → emit CACHE_HIT=false, exit 0.
+  2. Read $CACHE_DIR/manifest.json. Any I/O or parse failure → miss.
+  3. if schema_version != config.SCHEMA_VERSION → miss,
+     emit CACHE_INVALIDATED_REASON=schema-version-mismatch, and
+     `shutil.rmtree` the cache dir (gated to paths under CACHE_ROOT).
+  4. If data_path file missing → miss (atomic rename failed mid-write).
+  5. If age > ttl_days (default 7) → miss (no rmtree — just stale).
+  6. Hit path:
+     - Copy {agent}_{ver}_metadata_tree.json from cache into DATA_DIR +
+       WORK_DIR.
+     - Copy `declared_action_tree.json` sidecar into WORK_DIR so emit ctx
+       + downstream greps work.
+     - Stdout: eval-able lines (CACHE_HIT=true, CACHED_AT_UTC, NODE_COUNT,
+       DEPTH, AGENT_GENERATION, BOT_ID, VERSION_AUTO_PICKED, PARTIAL,
+       UNRESOLVED_COUNT, OUTPUT_JSON_PATH, OUTPUT_SUMMARY_PATH).
+
+`{tree_base}.summary.md` was dropped from the output contract.
+Cache-hit no longer copies or regenerates a summary file; OUTPUT_SUMMARY_PATH
+is emitted empty for RESULT-block shape stability.
+
+Usage:
+    eval "$(python3 cache_check.py)"
+
+Inputs (env):
+    CACHE_DIR        required — $CACHE_ROOT/$ORG_ID_15/$AGENT__$VER
+    DATA_DIR         required — $DATA_ROOT/$ORG_ID_15/$AGENT__$VER
+    WORK_DIR         required
+    AGENT_API_NAME   required
+    AGENT_VERSION    required
+    FORCE_REFRESH    'true'|'false' (default false)
+
+Outputs:
+    stdout: eval-able K=V lines
+    files (hit only): DATA_DIR/{tree_base}.json and matching copy in WORK_DIR
+    exit 0 always (miss is not an error)
+"""
+import json
+import os
+import pathlib
+import shlex
+import shutil
+import sys
+import datetime as dt
+
+import config  # for SCHEMA_VERSION + CACHE_ROOT path-guard 
+
+
+# refuse to operate if CACHE_ROOT itself is a symlink.
+# _safe_rmtree_under_cache_root calls resolve() on both target and root; a
+# symlinked CACHE_ROOT collapses the is_relative_to check because both sides
+# land on the symlink target, so rmtree would happily delete whatever lives
+# there — outside the sanctioned cache subtree. The guard was designed to
+# prevent rmtree escaping the cache; if the root itself can escape, the
+# guard is moot. Fail fast at import time so the failure surfaces at the
+# correct layer (configuration, not deletion).
+#
+# Path.is_symlink() returns False for non-existent paths, which is the
+# correct behaviour for pristine installs (CACHE_ROOT hasn't been created
+# yet; the script will mkdir it on first write and subsequent imports will
+# validate the real directory).
+if config.CACHE_ROOT.is_symlink():
+    raise RuntimeError(
+        f"CACHE_ROOT is a symlink ({config.CACHE_ROOT} -> "
+        f"{config.CACHE_ROOT.resolve()}). This is rejected for safety; the "
+        "_safe_rmtree_under_cache_root guard cannot protect against a "
+        "symlinked-root escape. Resolve the symlink or update "
+        "config.CACHE_ROOT to a real directory."
+    )
+
+
+def miss(reason: str | None = None):
+    """Emit CACHE_HIT=false and exit 0.
+
+    if `reason` is provided, emit a second K=V line
+    `CACHE_INVALIDATED_REASON=<reason>` so downstream emit_result can
+    surface the invalidation cause in the RESULT block.
+    """
+    sys.stdout.write("CACHE_HIT=false\n")
+    if reason:
+        sys.stdout.write(f"CACHE_INVALIDATED_REASON={shlex.quote(reason)}\n")
+    sys.exit(0)
+
+
+def _safe_rmtree_under_cache_root(target: pathlib.Path) -> bool:
+    """`shutil.rmtree(target)` ONLY if `target` resolves under CACHE_ROOT.
+
+    Defence against a miscomputed cache_dir that could point outside the
+    sanctioned cache root (symlink shenanigans, env-var tampering, or a
+    future refactor that forgets to run through `build_agent_cache_dir`).
+    We resolve both sides to absolute paths and confirm CACHE_ROOT is a
+    prefix before handing to rmtree.
+
+    Returns True on successful deletion, False if the path was refused or
+    the rmtree itself failed. Never raises — callers on the miss() path
+    can't act on a failure anyway.
+    """
+    try:
+        target_abs = target.resolve(strict=False)
+        root_abs = config.CACHE_ROOT.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    # Path.is_relative_to exists on 3.9+. Explicit check is clearer than
+    # a try/except on relative_to().
+    try:
+        if not target_abs.is_relative_to(root_abs):
+            return False
+    except AttributeError:  # pragma: no cover — safety for <3.9
+        try:
+            target_abs.relative_to(root_abs)
+        except ValueError:
+            return False
+    if not target_abs.exists():
+        return True  # nothing to do, treat as successful no-op
+    try:
+        shutil.rmtree(target_abs)
+    except OSError:
+        return False
+    return True
+
+
+def main() -> int:
+    try:
+        cache_dir = pathlib.Path(os.environ["CACHE_DIR"])
+        data_dir = pathlib.Path(os.environ["DATA_DIR"])
+        work_dir = pathlib.Path(os.environ["WORK_DIR"])
+        agent_api_name = os.environ["AGENT_API_NAME"]
+        agent_version = os.environ["AGENT_VERSION"]
+    except KeyError as e:
+        sys.stderr.write(f"cache_check.py: missing env {e}\n")
+        miss()
+
+    if (os.environ.get("FORCE_REFRESH", "").strip().lower() == "true"):
+        miss()
+
+    manifest_path = cache_dir / "manifest.json"
+    if not manifest_path.is_file():
+        miss()
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        miss()
+
+    # Schema version gate.
+    # strict match against config.SCHEMA_VERSION. Any mismatch (too
+    # old OR unexpected future/unknown value) invalidates the cache, and
+    # we delete the cache directory so the next run starts clean — a
+    # stale tree under a legacy schema is worse than no cache, because
+    # downstream code may parse shapes it no longer understands. The
+    # legacy `< 2.4` check is subsumed (anything that doesn't equal the
+    # current SCHEMA_VERSION triggers this branch).
+    schema = str(manifest.get("schema_version") or "0")
+    if schema != config.SCHEMA_VERSION:
+        _safe_rmtree_under_cache_root(cache_dir)
+        miss("schema-version-mismatch")
+
+    # data_path existence
+    data_path_s = manifest.get("data_path") or ""
+    data_path = pathlib.Path(data_path_s) if data_path_s else None
+    if not data_path or not data_path.is_file():
+        miss()
+
+    # TTL age check
+    try:
+        built = dt.datetime.fromisoformat(
+            (manifest.get("built_at_utc") or "").replace("Z", "+00:00")
+        )
+    except ValueError:
+        miss()
+    age_days = (dt.datetime.now(dt.timezone.utc) - built).days
+    ttl = int(manifest.get("ttl_days") or 7)
+    if age_days > ttl:
+        miss()
+
+    # --- Hit path ---
+    tree_base = f"{agent_api_name}_{agent_version}_metadata_tree"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    dst_json = data_dir / f"{tree_base}.json"
+
+    # The manifest's data_path points at the authoritative tree copy. Re-copy
+    # to DATA_DIR + WORK_DIR so the filesystem layout is stable for callers.
+    try:
+        shutil.copy(data_path, dst_json)
+    except OSError:
+        miss()
+
+    # Stage a declared_action_tree.json sidecar in WORK_DIR for any downstream
+    # script that expects the generic name.
+    try:
+        shutil.copy(dst_json, work_dir / "declared_action_tree.json")
+    except OSError:
+        pass
+
+    # no summary.md handling — dropped from the output contract.
+    agent_meta = manifest.get("agent") or {}
+    kind_counts = manifest.get("kind_counts") or {}
+
+    exports = [
+        ("CACHE_HIT", "true"),
+        ("CACHED_AT_UTC", manifest.get("built_at_utc", "")),
+        ("NODE_COUNT", str(manifest.get("node_count", 0))),
+        ("DEPTH", str(manifest.get("depth", 0))),
+        ("AGENT_GENERATION", agent_meta.get("generation") or "unknown"),
+        ("BOT_ID", agent_meta.get("bot_id") or ""),
+        ("BOT_MASTER_LABEL", agent_meta.get("master_label") or ""),
+        ("VERSION_AUTO_PICKED", "true" if agent_meta.get("_version_auto_picked") else "false"),
+        ("PARTIAL", "true" if manifest.get("partial") else "false"),
+        ("UNRESOLVED_COUNT", str(manifest.get("unresolved_count", 0))),
+        ("OUTPUT_JSON_PATH", str(dst_json)),
+        # summary.md dropped from the output contract; field kept
+        # empty for RESULT-block shape stability.
+        ("OUTPUT_SUMMARY_PATH", ""),
+        ("PLANNER_NAME", agent_meta.get("planner_name") or ""),
+    ]
+    # Pass kind counts too, in case finalize.py runs later without re-parsing
+    # (it won't on cache hit, but the values keep the RESULT block complete).
+    for k, v in kind_counts.items():
+        exports.append((f"KC_{k}", str(v)))
+
+    sys.stdout.write("\n".join(f"{k}={shlex.quote(v)}" for k, v in exports) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/config.py
+++ b/skills/investigating-agentforce-architecture/scripts/config.py
@@ -1,0 +1,134 @@
+"""Shared paths + constants for investigating-agentforce-architecture.
+
+Resolves SKILL_ROOT under the bare-skill install path
+(`~/.claude/skills/investigating-agentforce-architecture/`).
+
+Path layout:
+
+    ~/.claude/data/investigating-agentforce-architecture/
+    └── <org_id_15>/
+        └── <agent_api_name>__<agent_version>/        ← architecture artifacts
+
+Every path component embedded in a cache / data directory must be
+regex-validated before being joined to a Path. Four components are in
+scope: `api_version`, `org_id15`, `agent_api_name`, `agent_version`.
+(`planner_name` is validated separately at the SOQL substitution
+boundary by `soql_loader.load_soql` — it never appears in a filesystem
+path.) The helpers below are the ONLY sanctioned way to build those
+paths — direct Path composition from unvalidated strings is a
+path-traversal vulnerability.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _resolve_skill_root() -> Path:
+    env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env:
+        return Path(env)
+    return Path.home() / ".claude" / "skills" / "investigating-agentforce-architecture"
+
+
+SKILL_ROOT = _resolve_skill_root()
+SOQL_DIR = SKILL_ROOT / "assets" / "soql"
+CLI_DIR = SKILL_ROOT / "assets" / "cli"
+MERMAID_DIR = SKILL_ROOT / "assets" / "mermaid"
+REFERENCES_DIR = SKILL_ROOT / "references"
+
+
+# -----------------------------------------------------------------------------
+# Shared path helpers — sourced from scripts/_shared/.
+# -----------------------------------------------------------------------------
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from _shared import paths as _paths  # type: ignore  # noqa: E402
+from _shared import fs_guard  # type: ignore  # noqa: E402,F401 — re-exported for sibling scripts + tests
+
+DATA_ROOT = _paths.DATA_ROOT
+CACHE_ROOT = _paths.CACHE_ROOT
+PROBE_CACHE_ROOT = CACHE_ROOT / "_channel_probe"
+
+# Cache TTL — 7 days. Probe TTL same.
+CACHE_TTL_DAYS = 7
+PROBE_TTL_DAYS = 7
+
+# BFS defensive termination guard.
+#
+# Historically this was `5` and acted as a functional constraint on
+# chain depth. That was wrong: shared utility flows like `handleFlowFault`
+# appear on every real flow's fault path, so any moderately nested tree
+# (`[FLOW] A → [FLOW] B → [FLOW] handleFlowFault`) tripped the cap and
+# surfaced the utility in `_pending_fetches` even though it is trivially
+# expandable. Cycle detection now runs via a per-branch ancestor path set
+# (`visited_in_path` in `inflate_flow_leaf`), which is the textbook-correct
+# primitive for this problem: the same flow visited on two sibling branches
+# is not a cycle, but the same flow visited along its own ancestor chain is.
+#
+# This constant is retained purely as a defensive last-resort termination
+# guard for pathological graphs that somehow evade per-branch cycle detection
+# (e.g. a bug regression in `_cycle_key`). In practice the per-branch set
+# terminates every real bot tree long before this depth is reached.
+MAX_BFS_DEPTH = 20
+
+# Schema version — 3.1 (2026-05-05) canonicalizes `invocation_type` on
+# STANDARD_ACTION nodes, formerly split across `raw_invocation_type` and
+# `raw_action_type`. Must match `parse_wave.init_tree`'s `_schema_version`
+# literal. Any bump forces a cache rebuild via `cache_check.py`'s gate.
+SCHEMA_VERSION = "3.1"
+
+# Default parallelism for ThreadPoolExecutor (Flow metadata fan-out).
+DEFAULT_PARALLELISM = 5
+
+
+# -----------------------------------------------------------------------------
+# validated path builders
+# -----------------------------------------------------------------------------
+# fs_guard is re-exported above from `scripts/_shared/`.
+# Sibling scripts (soql_loader, render_architecture, fetch_soql)
+# and the test suite import it as ``from config import fs_guard`` so the
+# resolution dance lives in one place.
+
+
+def build_agent_data_dir(org_id_15: str, agent_api_name: str, agent_version: str) -> Path:
+    """Return DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/.
+
+    Thin wrapper over ``_shared.paths.agent_dir`` — kept so existing
+    callers don't need to change import sites. The shared helper raises
+    ``paths.PathValidationError`` (a ValueError subclass); we re-raise
+    the underlying ``fs_guard.ValidationError`` so existing tests that
+    catch that specific type keep passing.
+    """
+    fs_guard.validate_org_id_15(org_id_15, label="org_id_15")
+    fs_guard.validate_api_name(agent_api_name, label="agent_api_name")
+    fs_guard.validate_api_name(agent_version, label="agent_version")
+    return _paths.DATA_ROOT / org_id_15 / f"{agent_api_name}__{agent_version}"
+
+
+def build_agent_cache_dir(org_id_15: str, agent_api_name: str, agent_version: str) -> Path:
+    """Return CACHE_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/.
+
+    Mirrors ``build_agent_data_dir`` under the cache root. Validation gate
+    matches — every segment regex-checked before the join.
+    """
+    fs_guard.validate_org_id_15(org_id_15, label="org_id_15")
+    fs_guard.validate_api_name(agent_api_name, label="agent_api_name")
+    fs_guard.validate_api_name(agent_version, label="agent_version")
+    return CACHE_ROOT / org_id_15 / f"{agent_api_name}__{agent_version}"
+
+
+def build_probe_cache_dir(org_id_15: str, api_version: str) -> Path:
+    """Return PROBE_CACHE_ROOT/<org_id_15>/<api_version>/.
+
+    org_id_15 via validate_api_name (regex tolerates 15-char alnum),
+    api_version via validate_api_version (enforces `vNN.N` shape — rejects
+    `..`, `/`, and any non-version string).
+    """
+    fs_guard.validate_org_id_15(org_id_15, label="org_id_15")
+    fs_guard.validate_api_version(api_version, label="api_version")
+    return PROBE_CACHE_ROOT / org_id_15 / api_version

--- a/skills/investigating-agentforce-architecture/scripts/fetch_soql.py
+++ b/skills/investigating-agentforce-architecture/scripts/fetch_soql.py
@@ -1,0 +1,689 @@
+"""SOQL-based body fetchers for Wave A (GenAi normalized DAG) + Wave B
+(Flow / Apex body bodies).
+
+Phase 2 Batch 1: this module is the single surface `main.py`'s orchestrator
+composes against. Every function in this module is a thin wrapper over
+`soql_loader` + `rest_client.{tooling_query, data_query}`. Three invariants:
+
+    1. Credentials always flow through a `creds_provider` closure
+       (`Callable[[], tuple[str, str]]`) so `retry_on_401`'s refresh path
+       can deliver fresh creds into the retry. See rest_client 
+    2. Empty list inputs short-circuit to `[]` WITHOUT firing a SOQL call.
+       `load_soql_in` refuses empty lists (SF syntax error), so callers
+       upstream shouldn't have to guard every batch site — guard once here.
+    3. `api_version` (.4-R4, 2026-05-02) is REQUIRED on every fetcher.
+       The prior `rest_client.tooling_query` pinned `v60.0` and that
+       floor was the source of on orgs running v66 — which
+       genuinely expose fields v60 does not (`BotDefinition.Description`
+       is the observed case). Callers read the version once via
+       `main._derive_org_ids` (from `sf org display --json`) and thread
+       it through here. Same defensive pattern as for
+       `on_401_refresh`: no default, so a missed call-site is a
+       TypeError at call time, not a silent regression.
+
+All failure paths use `rest_client.redact_error` implicitly: the helpers
+raise `RestClientError` with pre-redacted messages. Callers that log should
+call `redact_error(exc)` themselves rather than `str(exc)` on any wrapped
+urllib/subprocess exception — redaction at the reporting site is
+defence-in-depth.
+
+`on_401_refresh` is a REQUIRED keyword-only arg
+on every fetcher in this module. The previous default (`on_401_refresh
+or creds_provider`) silently collapsed to "re-read the same stale token"
+when a caller passed `None` — the retry would hit the identical stale
+token on the second attempt and 401 again, bypassing entirely.
+Making the parameter required surfaces that misuse as a TypeError at
+import/call time instead of as a silent auth failure under load.
+"""
+from __future__ import annotations
+
+import logging
+import urllib.error
+from typing import Callable, Tuple
+
+from rest_client import data_query, tooling_query
+from soql_loader import load_soql, load_soql_in
+
+logger = logging.getLogger(__name__)
+
+
+CredsProvider = Callable[[], Tuple[str, str]]
+
+
+# ---------------------------------------------------------------------------
+# Small record-extraction helper. SF REST query responses wrap the row list
+# under `.records`; tooling + data surfaces agree on this shape. One helper
+# keeps the Wave A/B fetchers trivial — they call `_records(tooling_query(...))`
+# and return a list[dict].
+# ---------------------------------------------------------------------------
+
+
+def _records(response: dict) -> list[dict]:
+    """Extract records list from a SOQL query response.
+
+    SF REST returns `{"totalSize": N, "done": true, "records": [...]}` on
+    both Data and Tooling APIs. A missing `records` key (malformed response,
+    empty result) degrades to `[]` — callers that need a single record
+    slice the list themselves; callers that batch don't have to branch on
+    "records missing".
+    """
+    if not isinstance(response, dict):
+        return []
+    recs = response.get("records")
+    if not isinstance(recs, list):
+        return []
+    return recs
+
+
+# ===========================================================================
+# Wave A — GenAi normalized fetchers (Tooling API only)
+# ===========================================================================
+# DAG, per plan section B.5:
+#
+# A1 planner_definition_by_agent_chain scalar: AGENT_NAME [+ VERSION]
+# A2 plugins_by_planner scalar: PLANNER_ID
+# A3 planner_bundle_functions scalar: PLANNER_ID
+# A4 functions_by_plugins list: PLUGIN_IDS
+# A5 plugin_instructions_by_plugin_ids list: PLUGIN_IDS
+# A6 plugin_functions_by_plugin_ids list: PLUGIN_IDS
+# A7 planner_attrs_by_parent_ids list: PARENT_IDS
+#
+# Ordering: A1 first (provides planner_id). Then A2 + A3 can parallelize.
+# Once A2 yields plugin_ids, A4 / A5 / A6 parallelize. A7 last once A4
+# yields function_ids.
+# ---------------------------------------------------------------------------
+
+
+def fetch_planner_definition(
+    agent_api_name: str,
+    version: str | None,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> dict | None:
+    """Wave A1: resolve the live GenAiPlannerDefinition for (agent, version).
+
+    Agentforce generates an accretive chain of planner DeveloperNames as
+    agents version up — v1 = `<Agent>`, v2 = `<Agent>_v2`, v3 =
+    `<Agent>_v2_v3`, ... The chain shape is unpredictable from
+    (agent, version) alone, but an invariant holds: for vN the
+    DeveloperName always starts with `<agent_api_name>` and ends with
+    `_v<N>` for N>=2; for v1 it is exactly `<agent_api_name>`. A single
+    SOQL LIKE lookup pinned to that shape lands on the correct row
+    regardless of chain depth.
+
+    Branching:
+      * `version` is None / empty / "v1" → exact match. SOQL built
+        inline as `LIKE '<agent_api_name>'` (no wildcards — degenerate
+        LIKE is equivalent to `=`). The v1 branch bypasses the chain
+        template because the template's `%\\_{{VERSION}}` tail has no
+        sensible empty-version rendering.
+      * v2+ → LIKE `<agent_api_name>%\\_<version>`. The backslash escapes
+        the single-char wildcard `_` so `_v2` matches literally, not as
+        "any character then v2".
+
+    Escaping note (2026-05-05): the SOQL template on disk carries `\\_`
+    (one backslash, one underscore) because the REST Query endpoint
+    consumes the body verbatim — no shell, no extra quoting layer. If a
+    future caller ever shells this through `bash -c`, the backslash would
+    need doubling; we don't currently have that call path.
+
+    Disambiguation: if the LIKE returns multiple rows (e.g. a longer
+    chain name ALSO matches the pattern because it happens to end in
+    `_v2` too), pick the shortest DeveloperName — the canonical chain
+    ends at exactly `<agent_api_name>...<_v{version}>` with no suffix,
+    so shortest always wins.
+
+    Returns the planner dict or `None` if no row matches.
+
+    `load_soql` revalidates each substituted value against
+    `[A-Za-z0-9_]+` . `agent_api_name` and `version` satisfy that
+    regex; the `%\\_` literals live in the SOQL template, not in a
+    substituted variable, so they never traverse the validator.
+    """
+    v = (version or "").strip()
+    if v in ("", "v1"):
+        # v1 branch: DeveloperName is exactly `<agent_api_name>`. A LIKE
+        # with no wildcards is equivalent to `=`. We can't re-use the
+        # chain template with an empty VERSION (load_soql rejects empty
+        # strings AND the template's trailing `%\_{{VERSION}}` wouldn't
+        # collapse cleanly), so build the SOQL directly here. We still
+        # run the agent_api_name through the same validator load_soql
+        # uses, so the v1 path has no weaker injection surface than the
+        # v2+ path.
+        from config import fs_guard  # re-exported from _shared/
+        from soql_loader import SoqlParamError as _SoqlParamError
+        try:
+            fs_guard.validate_api_name(agent_api_name, label="AGENT_NAME")
+        except fs_guard.ValidationError as e:
+            raise _SoqlParamError("AGENT_NAME", agent_api_name, e.reason) from None
+        soql = (
+            "SELECT Id, DeveloperName, MasterLabel, Description, "
+            "PlannerType, Capabilities, AgentGraph\n"
+            "FROM GenAiPlannerDefinition\n"
+            f"WHERE DeveloperName LIKE '{agent_api_name}'"
+        )
+    else:
+        soql = load_soql(
+            "planner_definition_by_agent_chain",
+            AGENT_NAME=agent_api_name,
+            VERSION=v,
+        )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    recs = _records(resp)
+    if not recs:
+        return None
+    # Disambiguate on shortest DeveloperName — the canonical chain row
+    # has no suffix beyond `_v<N>`. A longer row means the LIKE also
+    # matched a deeper-chain planner that happens to share the suffix.
+    recs.sort(key=lambda r: len(r.get("DeveloperName") or ""))
+    return recs[0]
+
+
+def fetch_plugins_by_planner(
+    planner_id: str,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A2: topic list for a planner."""
+    soql = load_soql("plugins_by_planner", PLANNER_ID=planner_id)
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_planner_bundle_functions(
+    planner_id: str,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A3: planner-bundle-scope function join rows (classic).
+
+    NGA planners have no bundle-scope functions (PlannerId is null on
+    every row); this query returns [] on NGA orgs. Caller doesn't have
+    to branch.
+    """
+    soql = load_soql("planner_bundle_functions", PLANNER_ID=planner_id)
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_functions_by_plugins(
+    plugin_ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A4: actions (GenAiFunctionDefinition) under a planner's plugins.
+
+    User invariant: a planner never has direct functions (PlannerId-only
+    rows with no PluginId are orphan data, not live actions). The prior
+    `PlannerId = '<id>' OR ...` leg dragged in those orphans and
+    surfaced them as stray root-level children. The query is now a
+    single IN-list over plugin_ids; the PlannerId + ParentId columns
+    stay in the SELECT for downstream consumers (parse_bundle, etc.)
+    that still read them.
+
+    Empty `plugin_ids` short-circuits — a SequentialPlannerIntent-
+    Classifier bot with zero plugins has no plugin-scope functions to
+    fetch. `load_soql_in` refuses empty lists; we guard here so callers
+    don't have to.
+    """
+    if not plugin_ids:
+        return []
+    soql = load_soql_in(
+        "functions_by_plugins",
+        list_params={"PLUGIN_IDS": plugin_ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_plugin_instructions(
+    plugin_ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A5: per-topic instruction rows.
+
+    Empty `plugin_ids` → []; no SOQL fired. SequentialPlannerIntent-
+    Classifier bots and NGA single-planner shapes hit this path.
+    """
+    if not plugin_ids:
+        return []
+    soql = load_soql_in(
+        "plugin_instructions_by_plugin_ids",
+        list_params={"PLUGIN_IDS": plugin_ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_plugin_functions(
+    plugin_ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A6: plugin → function join rows."""
+    if not plugin_ids:
+        return []
+    soql = load_soql_in(
+        "plugin_functions_by_plugin_ids",
+        list_params={"PLUGIN_IDS": plugin_ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_planner_attrs(
+    parent_ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave A7: attribute mappings for a list of parent ids.
+
+    Polymorphic ParentId: pass the UNION of function_ids + planner_id.
+    Bot shape with zero functions (no actions registered) → []; no SOQL
+    fired. Caller must include the planner_id even when function_ids is
+    empty — this helper doesn't fabricate it.
+    """
+    if not parent_ids:
+        return []
+    soql = load_soql_in(
+        "planner_attrs_by_parent_ids",
+        list_params={"PARENT_IDS": parent_ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+# ===========================================================================
+# Wave B — body fetchers (Flow, Apex). Tooling API.
+# ===========================================================================
+# These are the leaves: once Wave A gives us the function rows, we resolve
+# every InvocationTarget into one of flow / apex / prompt (prompt body
+# lands via retrieve in Batch 2, not here).
+#
+# The single-row Flow.Metadata path is the big parallelism opportunity —
+# `fetch_flow_metadata` is called N times (one per version id) and
+# dispatched through `parallel_retrieve.fetch_bodies_parallel`.
+# ---------------------------------------------------------------------------
+
+
+def fetch_apex_bodies_by_names(
+    names: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave B3 classic: Apex bodies keyed by DeveloperName.
+
+    Returns `[{Id, Name, Body, SymbolTable, ApiVersion, IsValid}, ...]`.
+    Batch-safe on `Name IN (...)` even though SymbolTable is
+    complexvalue (confirmed live — see references/soql_fields.md).
+    """
+    if not names:
+        return []
+    soql = load_soql_in(
+        "apex_class_bodies_by_names",
+        list_params={"NAMES_LIST": names},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_apex_bodies_by_ids(
+    ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave B3 NGA: Apex bodies keyed by Id.
+
+    NGA functions store InvocationTarget as Salesforce Ids (e.g. `01p...`);
+    this is the reverse-lookup path that translates back to Name + Body.
+    """
+    if not ids:
+        return []
+    soql = load_soql_in(
+        "apex_class_bodies_by_ids",
+        list_params={"APEX_IDS_LIST": ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_flow_definition_view_by_durable_ids(
+    durable_ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Data API fallback: resolve managed-installed flow names via
+    `FlowDefinitionView`.
+
+    `FlowDefinition` (Tooling) does not index managed-installed flows for
+    subscriber orgs — the Tooling query for a `ns__BareName` returns zero
+    rows even when the flow genuinely exists. `FlowDefinitionView` (Data
+    API only, NOT Tooling) does expose those rows via its `DurableId`
+    column, which for managed-installed flows IS the qualified
+    `ns__BareName` string.
+
+    Caveats baked into the consumer contract (see
+    `fetch_flow_definition_ids_by_names` downstream projection):
+      * `FlowDefinitionView.ActiveVersionId` is a composite display
+        string (e.g. `SvcCopilotTmpl__VerifyCode-1`), not a real
+        `Flow.Id`. It cannot be used to fetch the flow body XML —
+        managed flow bodies are IP-protected and not retrievable.
+      * Callers must project these rows with `ActiveVersionId=None` and
+        `_body_available=False` so the Wave B metadata fetcher skips
+        body retrieval for them.
+
+    Empty input short-circuits to `[]` without firing a SOQL call —
+    matches the contract on every other list-shaped fetcher in this
+    module.
+    """
+    if not durable_ids:
+        return []
+    soql = load_soql_in(
+        "flow_definition_view_by_durable_ids",
+        list_params={"DURABLE_IDS_LIST": durable_ids},
+    )
+    resp = data_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_flow_definition_ids_by_names(
+    names: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave B1 classic: resolve Flow DeveloperName list → FlowDefinition rows.
+
+    Returns `[{Id, DeveloperName, NamespacePrefix, ActiveVersionId,
+    _bare_developer_name, _source, _body_available, ...}, ...]`.
+    Two-hop to `Flow` via `ActiveVersionId`; this is the first hop.
+
+    Resolution path (2026-05-05, post-retirement of the managed-ns
+    Tooling bucket): fire ONE Tooling `FlowDefinition` query for every
+    input name verbatim — the template filters `NamespacePrefix IS NULL`
+    so only unmanaged rows come back. Managed names like
+    `ns__BareName` return zero rows from Tooling on subscriber orgs
+    regardless of how we bucket them (live scouting confirmed Tooling
+    FlowDefinition simply does not index managed-installed flows for
+    subscribers), so attempting per-namespace Tooling queries adds cost
+    and returns nothing useful. Anything the unmanaged query doesn't
+    resolve falls through to `FlowDefinitionView` (Data API), which DOES
+    expose managed-installed flows via `DurableId = ns__BareName`.
+
+    FlowDefinitionView rows carry `Id=None`, `ActiveVersionId=None`,
+    `_body_available=False`, and `_source="FlowDefinitionView"` so
+    downstream flow metadata retrieval short-circuits (there's no real
+    version Id to fetch a body with, and managed flow bodies are
+    IP-protected regardless).
+
+    Real Tooling rows carry `_source="FlowDefinition"` and
+    `_body_available=True` set explicitly — consumers can dispatch on
+    source rather than inferring from absence.
+    """
+    if not names:
+        return []
+
+    rows: list[dict] = []
+    # Track every input name we successfully resolve via the Tooling
+    # FlowDefinition path. Anything left over goes through the
+    # FlowDefinitionView fallback.
+    resolved_names: set[str] = set()
+
+    # Unmanaged Tooling query: template explicitly filters
+    # `NamespacePrefix = NULL`. Managed-qualified names (`ns__BareName`)
+    # passed through here will simply return zero rows — which is fine,
+    # the view fallback below catches them. The null-ns filter is
+    # load-bearing: dropping it would widen to unrelated managed rows
+    # that happen to collide on a bare DeveloperName.
+    #
+    # Bug G fix: the SOQL template uses `= NULL`, NOT `IS NULL`. Tooling
+    # Query API rejects `IS NULL` with `MALFORMED_QUERY: unexpected
+    # token: 'NamespacePrefix IS'`. Only the Data API parser accepts
+    # both forms. Commit aa01d52 mistakenly switched this template to
+    # `IS NULL` (to silence a Prizm scanner false-positive) on the
+    # premise that "both forms parse identically" — true for Data API,
+    # false for Tooling. That broke wave-B subflow resolution: every
+    # call here 400'd, the FDV fallback below also returned zero
+    # because it filters by Salesforce Id (300...), and BFS hit the
+    # iteration cap. Do NOT re-introduce `IS NULL` in this template.
+    soql = load_soql_in(
+        "flow_definition_ids_by_names",
+        list_params={"NAMES_LIST": list(names)},
+    )
+    # Bug D.2 fix: tolerate HTTPError on the Tooling call. A single name
+    # in `names` that violates Salesforce's DeveloperName limits (e.g.
+    # length >40 chars, or chars Salesforce treats as non-identifier
+    # despite passing fs_guard.validate_api_name) causes the WHOLE batch
+    # to 400. Without this `try`, the entire wave-B round failed and the
+    # FDV fallback below was never reached — managed names were never
+    # resolved, BFS hit the iteration cap, operator saw cryptic
+    # `wave-b-iteration-cap` entries instead of the actual root cause.
+    # On HTTPError, fall through with `resolved_names` empty so every
+    # input is re-tried via FDV; FDV uses Data API (different validation)
+    # and tends to accept names Tooling rejects.
+    try:
+        resp = tooling_query(
+            creds_provider, soql,
+            api_version=api_version,
+            on_401_refresh=on_401_refresh,
+        )
+        for r in _records(resp):
+            dev_name = r.get("DeveloperName")
+            if dev_name:
+                r["_bare_developer_name"] = dev_name
+                r["_source"] = "FlowDefinition"
+                r["_body_available"] = True
+                rows.append(r)
+                resolved_names.add(dev_name)
+    except urllib.error.HTTPError as exc:
+        # Don't propagate — the FDV fallback below handles every
+        # unresolved name. Log enough for triage; rest_client already
+        # attached `_response_body_preview` (Bug D.1) so the body is
+        # available downstream if a caller wants to inspect.
+        logger.debug(
+            "fetch_flow_definition_ids_by_names: Tooling batch failed "
+            "(HTTP %d); falling through to FlowDefinitionView for all %d names",
+            getattr(exc, "code", 0), len(names),
+        )
+
+    # FlowDefinitionView fallback — Data API. Any input name Tooling
+    # didn't resolve is re-queried as a DurableId. Managed-installed
+    # flows are the motivating case; the view also covers unmanaged
+    # rows the Tooling surface misses for any other reason.
+    unresolved_names = [n for n in names if n not in resolved_names]
+    if unresolved_names:
+        view_rows = fetch_flow_definition_view_by_durable_ids(
+            sorted(set(unresolved_names)),
+            creds_provider,
+            api_version=api_version,
+            on_401_refresh=on_401_refresh,
+        )
+        for view_row in view_rows:
+            durable_id = view_row.get("DurableId")
+            if not durable_id:
+                continue
+            rows.append({
+                "Id": None,
+                # Qualified ns__bare (matches bundle invocationTarget +
+                # parse_wave visited-set dedupe key).
+                "DeveloperName": durable_id,
+                "NamespacePrefix": view_row.get("NamespacePrefix"),
+                # ActiveVersionId on FlowDefinitionView is a composite
+                # display string (`ns__Name-<n>`), NOT a real Flow.Id.
+                # Null it so downstream `fetch_flow_metadata` dispatch
+                # skips body retrieval for these rows.
+                "ActiveVersionId": None,
+                "_bare_developer_name": view_row.get("ApiName"),
+                "_body_available": False,
+                "_source": "FlowDefinitionView",
+                "_flow_view_label": view_row.get("Label"),
+                "_flow_view_manageable_state": view_row.get("ManageableState"),
+            })
+
+    return rows
+
+
+def fetch_flow_definition_by_ids(
+    ids: list[str],
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Wave B1 NGA: reverse-lookup FlowDefinition Id → DeveloperName.
+
+    NGA functions store Ids (`300...`). This resolves them back to names
+    so the tree's leaf nodes can carry the human-readable DeveloperName
+    and the active version id for Wave B2.
+    """
+    if not ids:
+        return []
+    soql = load_soql_in(
+        "flow_definition_by_ids",
+        list_params={"FLOW_DEF_IDS_LIST": ids},
+    )
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_flow_metadata(
+    flow_version_id: str,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> dict | None:
+    """Wave B2: single-row Flow.Metadata fetch.
+
+    `complexvalue` fields (Metadata + FullName) force a single-row
+    retrieval (`WHERE Id = '<id>'`). Returns the row dict or `None` on
+    miss. Called once per version id; parallelism happens in `main.py`
+    via `parallel_retrieve.fetch_bodies_parallel`.
+    """
+    soql = load_soql("flow_metadata_by_id", FLOW_VERSION_ID=flow_version_id)
+    resp = tooling_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    recs = _records(resp)
+    return recs[0] if recs else None
+
+
+# ===========================================================================
+# Bot resolution (Data API) — Phase 4 of main.py. Separate from Wave A/B
+# because the routing is DATA_QUERY not tooling, and the shape is simpler.
+# ===========================================================================
+
+
+def fetch_bot_versions(
+    agent_api_name: str,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> list[dict]:
+    """Data API: resolve bot versions for a given bot DeveloperName.
+
+    Mirrors `resolve_bot.py` step 1 but routed through `data_query` so
+    the 401-refresh path is active. `resolve_bot.py` itself shells out
+    to `sf data query` and is retained as the env-var-driven entry-point
+    for Bash harness callers; `main.py` uses this in-process variant.
+    """
+    soql = load_soql("bot_version_lookup", AGENT_API_NAME=agent_api_name)
+    resp = data_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    return _records(resp)
+
+
+def fetch_bot_definition_details(
+    agent_api_name: str,
+    creds_provider: CredsProvider,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> dict | None:
+    """Data API: BotDefinition metadata (MasterLabel, AgentTemplate, ...).
+
+    Returns the single matching BotDefinition row or None. Feeds the
+    `tree["agent"]` fields in parse_wave's init_tree.
+    """
+    soql = load_soql("bot_definition_details", AGENT_API_NAME=agent_api_name)
+    resp = data_query(
+        creds_provider, soql,
+        api_version=api_version,
+        on_401_refresh=on_401_refresh,
+    )
+    recs = _records(resp)
+    return recs[0] if recs else None
+
+

--- a/skills/investigating-agentforce-architecture/scripts/finalize.py
+++ b/skills/investigating-agentforce-architecture/scripts/finalize.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Finalize: write DATA_DIR + CACHE_DIR atomically, build manifest.
+
+Replaces old agent Phase 7. Steps:
+  1. Load $WORK_DIR/declared_action_tree.json.
+  2. Compute _partial = !(planner_ok && _pending_fetches empty); strip _visited.
+  3. Stage DATA_DIR at $DATA_DIR.tmp: copy tree as {api}_{ver}_metadata_tree.json.
+  4. rmtree final DATA_DIR; rename .tmp → DATA_DIR.
+  5. Stage CACHE_DIR at $CACHE_DIR.tmp: copy metadata/<wave> dirs + sidecars.
+  6. Write manifest.json.
+  7. rmtree final CACHE_DIR; rename .tmp → CACHE_DIR.
+  8. Seed .gitignore on data_root + cache_root parents.
+  9. Write $WORK_DIR/.built_at.txt (ISO-Z UTC).
+
+the previously-emitted `{api}_{ver}_metadata_tree.summary.md` is
+dropped from the output contract — it was a redundant summary of the tree
+JSON. Consumers should read the JSON directly.
+
+Usage:
+    python3 finalize.py
+
+Inputs (env):
+    WORK_DIR       required
+    CACHE_DIR      required
+    DATA_DIR       required
+    PLANNER_NAME   optional — empty → tree marked partial
+    AGENT_API_NAME, AGENT_VERSION — used for filenames
+
+Outputs:
+    $DATA_DIR/{api}_{ver}_metadata_tree.json
+    $DATA_DIR/last_built_at.txt
+    $CACHE_DIR/manifest.json + metadata/<wave>/... + parsed sidecars
+    $WORK_DIR/.built_at.txt
+    exit 0 success, 1 on any write failure → caller emits STATUS=WRITE_FAILED
+"""
+import datetime
+import json
+import os
+import pathlib
+import shutil
+import sys
+
+
+def sort_tree_in_place(root: dict) -> None:
+    """Sort `root.children` and each TOPIC's children alphabetically.
+
+    Ordering rules (2026-05-05, schema 3.1):
+    - `BOT_DEFINITION.children`: TOPIC nodes first (by `api_name`
+      case-insensitive), then non-topic plannerActions (by kind, then
+      `api_name`). This preserves the "planner-level actions as a
+      distinct trailing group" convention for readers who scan the
+      rendered tree top-down.
+    - Each TOPIC's children: alphabetical by `api_name`
+      case-insensitive.
+    - FLOW children are NOT sorted — flow-actionCall / subflow order
+      is the flow author's execution sequence, not a set.
+    - GEN_AI_FUNCTION / APEX / PROMPT_TEMPLATE / STANDARD_ACTION leaves
+      don't have children that warrant sorting.
+
+    Applied as a final pass after tree assembly and before the
+    authoritative JSON write, so ordering is pinned at the single
+    source of truth — the renderer doesn't re-sort.
+    """
+    if not isinstance(root, dict):
+        return
+    children = root.get("children") or []
+    if not children:
+        return
+
+    def _root_sort_key(node: dict) -> tuple:
+        kind = node.get("kind") or ""
+        api = (node.get("api_name") or "").casefold()
+        # TOPIC first (tier 0), everything else second (tier 1). Within
+        # each tier, stable by kind + api_name case-insensitive.
+        tier = 0 if kind == "TOPIC" else 1
+        return (tier, kind, api)
+
+    root["children"] = sorted(children, key=_root_sort_key)
+
+    for child in root["children"]:
+        if child.get("kind") == "TOPIC":
+            child_children = child.get("children") or []
+            child["children"] = sorted(
+                child_children,
+                key=lambda n: (n.get("api_name") or "").casefold(),
+            )
+
+
+def main() -> int:
+    try:
+        work_dir = pathlib.Path(os.environ["WORK_DIR"])
+        cache_dir = pathlib.Path(os.environ["CACHE_DIR"])
+        data_dir = pathlib.Path(os.environ["DATA_DIR"])
+        agent_api_name = os.environ["AGENT_API_NAME"]
+        agent_version = os.environ["AGENT_VERSION"]
+    except KeyError as e:
+        sys.stderr.write(f"finalize.py: missing env {e}\n")
+        return 1
+
+    planner_name = os.environ.get("PLANNER_NAME", "")
+    tree_path = work_dir / "declared_action_tree.json"
+
+    try:
+        tree = json.loads(tree_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"finalize.py: cannot read {tree_path}: {e}\n")
+        return 1
+
+    # Compute _partial. _pending_fetches drains as wave-B BFS resolves
+    # refs; failures (HTTP 4xx, iteration-cap exhaustion, managed-flow
+    # filter mismatch) move OUT of _pending_fetches and into _unresolved.
+    # If we only check _pending_fetches we'd silently call a run with
+    # _unresolved entries "converged" — STATUS=OK with hidden failures.
+    # Both buckets must be empty for a clean run.
+    planner_ok = bool(planner_name)
+    pending_total = sum(len(v) for v in (tree.get("_pending_fetches") or {}).values())
+    unresolved_count = len(tree.get("_unresolved") or [])
+    waves_converged = pending_total == 0 and unresolved_count == 0
+    tree["_partial"] = not (planner_ok and waves_converged)
+
+    # Bug F fix: parse_wave + main set _partial_reason from
+    # _pending_fetches only (legacy predicate). When _pending is empty
+    # but _unresolved is non-empty, those writers set reason=None. The
+    # promotion above flips _partial=True from the unresolved bucket, so
+    # the reason needs a matching promotion or PARTIAL_REASON= ends up
+    # blank in the RESULT block.
+    if tree["_partial"] and not tree.get("_partial_reason"):
+        if not planner_ok:
+            tree["_partial_reason"] = "no-planner"
+        elif unresolved_count > 0:
+            tree["_partial_reason"] = "unresolved-refs"
+        else:
+            tree["_partial_reason"] = "pending-refs"
+
+    # Strip _visited (internal state — not part of the durable artifact)
+    tree.pop("_visited", None)
+
+    # Pin deterministic child ordering as the last assembly step before
+    # the authoritative write — see `sort_tree_in_place` docstring for
+    # the ordering rules. Downstream readers (render_architecture,
+    # summarize_tree, third-party tooling) therefore see a single
+    # canonical order from disk; they don't re-sort.
+    sort_tree_in_place(tree.get("root") or {})
+
+    # Rewrite the authoritative tree before copying it anywhere else
+    try:
+        tmp = tree_path.with_suffix(tree_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(tree, indent=2))
+        os.replace(tmp, tree_path)
+    except OSError as e:
+        sys.stderr.write(f"finalize.py: cannot rewrite tree: {e}\n")
+        return 1
+
+    built_at = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    a = tree.get("agent", {}) or {}
+    tree_base = f"{agent_api_name}_{agent_version}_metadata_tree"
+
+    # --- DATA_DIR staging ---
+    # summary.md dropped from the output contract; DATA_DIR now
+    # holds only the tree JSON + last_built_at.txt (+ whatever the caller
+    # writes alongside, e.g. architecture.md from render_architecture).
+    #
+    # The prior pattern was `rmtree(data_dir); data_tmp.rename(data_dir)` —
+    # destructive of any co-tenant content under `<agent>__<ver>/`. We
+    # now iterate staging's children and overwrite each one into data_dir
+    # individually, leaving unrelated siblings intact. See
+    # `main.py:_swap_dir_atomic` for the production path with the same
+    # invariant.
+    data_tmp = data_dir.with_suffix(".tmp")
+    try:
+        if data_tmp.exists():
+            shutil.rmtree(data_tmp)
+        data_tmp.mkdir(parents=True)
+        shutil.copy(tree_path, data_tmp / f"{tree_base}.json")
+
+        (data_tmp / "last_built_at.txt").write_text(built_at + "\n")
+
+        data_dir.mkdir(parents=True, exist_ok=True)
+        for staged in list(data_tmp.iterdir()):
+            target = data_dir / staged.name
+            if target.exists() or target.is_symlink():
+                if target.is_dir() and not target.is_symlink():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            shutil.move(str(staged), str(target))
+        shutil.rmtree(data_tmp, ignore_errors=True)
+    except OSError as e:
+        sys.stderr.write(f"finalize.py: DATA_DIR write failed: {e}\n")
+        try:
+            if data_tmp.exists():
+                shutil.rmtree(data_tmp)
+        except OSError:
+            pass
+        return 1
+
+    # --- CACHE_DIR staging ---
+    cache_tmp = cache_dir.with_suffix(".tmp")
+    try:
+        if cache_tmp.exists():
+            shutil.rmtree(cache_tmp)
+        cache_tmp.mkdir(parents=True)
+
+        # Mirror sf_meta/<wave>/ into metadata/<wave>/ verbatim so cache has:
+        # retrieve.json (sf CLI output — critical for debugging silent
+        # retrieves that produced zero members)
+        # unpackaged/ (parsed XML tree)
+        # unpackaged.zip is intentionally skipped — it's byte-for-byte the
+        # same as unpackaged/ and doubles cache size on every run.
+        meta_dir = cache_tmp / "metadata"
+        meta_dir.mkdir()
+        sf_meta = work_dir / "sf_meta"
+        if sf_meta.exists():
+            for wave_dir in sorted(sf_meta.iterdir()):
+                if not wave_dir.is_dir():
+                    continue
+                dst = meta_dir / wave_dir.name
+                dst.mkdir(parents=True, exist_ok=True)
+                for item in wave_dir.iterdir():
+                    if item.name == "unpackaged.zip":
+                        continue  # redundant with unpackaged/
+                    if item.is_dir():
+                        shutil.copytree(item, dst / item.name, dirs_exist_ok=True)
+                    else:
+                        shutil.copy(item, dst / item.name)
+
+        # Copy every WORK_DIR top-level artifact except:
+        # - .emit_ctx.json (per-run shell state, irrelevant to cache)
+        # - .built_at.txt (recorded in manifest.built_at_utc)
+        # - sf_meta/ (handled above)
+        # This catches declared_action_tree.json, _bundle_parsed.json,
+        # _agent_generation.txt, _bot_definition.json, _bot_versions.json,
+        # and anything future scripts write as top-level sidecars.
+        SKIP_NAMES = {".emit_ctx.json", ".built_at.txt", "sf_meta"}
+        for item in work_dir.iterdir():
+            if item.name in SKIP_NAMES:
+                continue
+            if item.name.endswith(".tmp"):
+                continue  # atomic-write staging from some other script
+            if item.is_dir():
+                shutil.copytree(item, cache_tmp / item.name, dirs_exist_ok=True)
+            elif item.is_file():
+                shutil.copy(item, cache_tmp / item.name)
+
+        manifest = {
+            "built_at_utc": built_at,
+            "schema_version": tree.get("_schema_version", "2.4"),
+            "agent": a,
+            "node_count": tree.get("node_count", 0),
+            "depth": tree.get("depth", 0),
+            "kind_counts": tree.get("_kind_counts", {}),
+            "ttl_days": 7,
+            "data_path": str(data_dir / f"{tree_base}.json"),
+            "partial": tree.get("_partial", False),
+            "unresolved_count": len(tree.get("_unresolved", []) or []),
+        }
+        (cache_tmp / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir)
+        cache_tmp.rename(cache_dir)
+    except OSError as e:
+        sys.stderr.write(f"finalize.py: CACHE_DIR write failed: {e}\n")
+        try:
+            if cache_tmp.exists():
+                shutil.rmtree(cache_tmp)
+        except OSError:
+            pass
+        return 1
+
+    # --- .gitignore seeding on parent dirs (data_root + cache_root) ---
+    for root in (cache_dir.parent.parent, data_dir.parent.parent):
+        try:
+            gi = root / ".gitignore"
+            if not gi.exists():
+                root.mkdir(parents=True, exist_ok=True)
+                gi.write_text("*\n")
+        except OSError:
+            pass
+
+    # --- .built_at.txt for emit ctx ---
+    try:
+        (work_dir / ".built_at.txt").write_text(built_at + "\n")
+    except OSError as e:
+        sys.stderr.write(f"finalize.py: .built_at.txt write failed: {e}\n")
+        # Non-fatal — finalize succeeded; emit can recompute
+
+    print(f"[finalize] built_at: {built_at}")
+    print(f"[finalize] data  written: {data_dir}/{tree_base}.json")
+    print(f"[finalize] cache written: {cache_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/main.py
+++ b/skills/investigating-agentforce-architecture/scripts/main.py
@@ -1,0 +1,2736 @@
+"""Phase 2 Batch 1: pipeline orchestrator for investigating-agentforce-architecture.
+
+Composes Phase 1 primitives (config, rest_client, sf_cli, soql_loader,
+probe_channels, fetch_soql, parallel_retrieve, parse_wave, finalize) into
+the 13-phase flow defined in the plan.
+
+NOT a credential holder. Credentials live in a single mutable cell
+(`_creds_cell`) that both `creds_provider()` and `refresh_fn()` close over.
+Every SOQL call uses `creds_provider` so `retry_on_401`'s refresh path
+ can deliver fresh creds into the retry — storing the URL/token
+in function args would defeat the refresh entirely.
+
+Phase ordering:
+  1  parse args                    (Bash harness does phases 1-3 today;
+  2  resolve creds (sf org display)   P2 Batch 1 runs them in-process too)
+  3  probe channels
+  4  resolve bot + version
+  5  cache check
+  6  Wave A (7 parallel Tooling queries, DAG-ordered)
+  7  join Wave A → _bundle_parsed.json-shaped dict
+  8  Wave B (Flow + Apex bodies, parallel)
+  9  parse_wave -> declared_action_tree.json
+  10 render architecture.md (Batch 2 — stubbed)
+  11 finalize (atomic writes + manifest)
+  12 emit RESULT
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from functools import partial
+from pathlib import Path
+from typing import Callable, Tuple
+
+# Phase 2 Batch 1: all cross-module wiring routes through config so a future
+# relocation of DATA_ROOT / CACHE_ROOT only touches one file.
+from config import (
+    CACHE_TTL_DAYS,
+    DATA_ROOT,
+    SCHEMA_VERSION,
+    build_agent_cache_dir,
+    build_agent_data_dir,
+)
+from rest_client import RestClientError, redact_error
+from sf_cli import AuthRequired, SfCliError, run_sf
+from soql_loader import SoqlParamError
+
+# Phase 2 Batch 1 imports — functional pipeline primitives.
+from fetch_soql import (
+    fetch_apex_bodies_by_ids,
+    fetch_apex_bodies_by_names,
+    fetch_bot_definition_details,
+    fetch_bot_versions,
+    fetch_flow_definition_by_ids,
+    fetch_flow_definition_ids_by_names,
+    fetch_flow_metadata,
+    fetch_functions_by_plugins,
+    fetch_planner_attrs,
+    fetch_planner_bundle_functions,
+    fetch_planner_definition,
+    fetch_plugin_functions,
+    fetch_plugin_instructions,
+    fetch_plugins_by_planner,
+)
+from metadata_listing import (
+    list_prompt_template_metadata,
+    retrieve_prompt_templates,
+)
+from parallel_retrieve import fetch_bodies_parallel
+from parse_bundle import classify_generation
+from probe_channels import probe_channels
+from resolve_invocation_target import looks_like_sf_id, resolve_or_unresolved
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="architecture")
+    p.add_argument("--org-alias", required=True)
+    p.add_argument("--agent", required=True, dest="agent_api_name")
+    p.add_argument("--version", dest="agent_version")
+    p.add_argument("--force", action="store_true", dest="force_refresh")
+    # --reprobe forces a fresh channel-probe run on pipeline start.
+    p.add_argument("--reprobe", action="store_true")
+    p.add_argument("--parallelism", type=int, default=5)
+    p.add_argument("--max-mermaid-nodes", type=int, default=80)
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--cache-root")
+    p.add_argument("--data-root")
+    return p.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 Batch 1: credentials
+# ---------------------------------------------------------------------------
+# Single mutable cell read by `creds_provider`. `refresh_fn` rewrites the
+# cell. `retry_on_401` in rest_client invokes refresh_fn for side effect;
+# the next invocation of creds_provider picks up the new tuple. See
+# rest_client 
+
+
+def _build_creds_plumbing(
+    initial_creds: Tuple[str, str],
+    resolve_creds: Callable[[], Tuple[str, str]],
+    *,
+    dedupe_window_s: float = 1.0,
+) -> Tuple[
+    Callable[[], Tuple[str, str]],
+    Callable[[], Tuple[str, str]],
+    "list[Tuple[str, str]]",
+]:
+    """Build the (creds_provider, refresh_fn, creds_cell) triple.
+
+     + `creds_provider` re-reads `creds_cell`
+    on every call so a refresh actually lands in the NEXT SOQL attempt.
+    `refresh_fn` is serialized by an internal `threading.Lock` + a
+    `time.monotonic()` dedupe window — N concurrent 401s against the same
+    stale token collapse to ONE `resolve_creds()` spawn per window. That
+    caps real `sf org display` spawns at roughly 1/second regardless of
+    pool size.
+
+    Extracted from `main()` so the closure is testable without threading
+    a whole pipeline run through argparse + mocks.
+
+    Returns (creds_provider, refresh_fn, creds_cell). The cell is
+    returned so callers/tests can inspect the current tuple directly
+    (it's the single source of truth the provider reads from).
+    """
+    creds_cell: list[Tuple[str, str]] = [initial_creds]
+    lock = threading.Lock()
+    last_refresh_mono = [0.0]
+
+    def creds_provider() -> Tuple[str, str]:
+        return creds_cell[0]
+
+    def refresh_fn() -> Tuple[str, str]:
+        with lock:
+            now = time.monotonic()
+            if now - last_refresh_mono[0] < dedupe_window_s:
+                # Another thread refreshed within the dedupe window — reuse.
+                return creds_cell[0]
+            creds_cell[0] = resolve_creds()
+            last_refresh_mono[0] = now
+            return creds_cell[0]
+
+    return creds_provider, refresh_fn, creds_cell
+
+
+_REDACTION_MARKER_FRAGMENT = "show-access-token"
+"""Substring that uniquely identifies the sf CLI v2 redaction placeholder
+(`"[REDACTED] Use 'sf org auth show-access-token' to view"`). We match on
+this fragment rather than the full literal because the upstream wording
+has shifted between sf CLI builds, but the embedded subcommand name has
+been stable since cli#3560 landed."""
+
+
+def _resolve_creds(org_alias: str) -> Tuple[str, str]:
+    """Resolve (instance_url, access_token) for ``org_alias``.
+
+    Two-path strategy per forcedotcom/cli#3560 (effective 2026-05-27):
+
+      1. **Primary** — call ``sf org display`` for instanceUrl, then
+         ``sf org auth show-access-token`` for the access token. This is
+         the upstream long-term path; ``SF_TEMP_SHOW_SECRETS`` is
+         decommissioned in summer 2026.
+      2. **Fallback** — if the dedicated command isn't shipped in the
+         installed sf CLI version (older releases), fall back to the
+         legacy ``sf org display --verbose`` with the
+         ``SF_TEMP_SHOW_SECRETS=true`` env var that ``run_sf`` injects
+         unconditionally. The fallback is detected by the redaction
+         placeholder appearing in the ``accessToken`` field — exact match
+         on the substring ``show-access-token`` (see
+         ``_REDACTION_MARKER_FRAGMENT``).
+
+    sf_cli.run_sf already redacts stderr on failure paths. Any
+    exception surfaces as `AuthRequired` / `SfCliError`; caller routes
+    through `_emit_fail`.
+    """
+    display_data = run_sf("org_display", ORG_ALIAS=org_alias)
+    display_result = display_data.get("result") or {}
+    instance_url = display_result.get("instanceUrl") or ""
+    if not instance_url:
+        raise AuthRequired(
+            "sf org display returned an incomplete payload (missing instanceUrl)"
+        )
+
+    # Primary path: dedicated command. Catches both the unknown-command
+    # case (older sf CLI) and any AuthRequired surfaced from the recipe.
+    try:
+        token_data = run_sf("show_access_token", ORG_ALIAS=org_alias)
+    except SfCliError:
+        # Older sf CLI versions emit "is not a sf command" on stderr; the
+        # recipe surfaces that as SfCliError. Fall back to the
+        # SF_TEMP_SHOW_SECRETS path via the org_display payload we
+        # already have.
+        access_token = display_result.get("accessToken") or ""
+    else:
+        token_result = token_data.get("result") or {}
+        access_token = token_result.get("accessToken") or ""
+
+    # Defensive fallback: if the dedicated command silently returned an
+    # empty token OR sf CLI redacted the org_display token to the
+    # placeholder, try the org_display payload directly. SF_TEMP_SHOW_SECRETS
+    # is set unconditionally by run_sf so this works as long as the env
+    # var is still honoured by the installed sf CLI.
+    if not access_token or _REDACTION_MARKER_FRAGMENT in access_token:
+        legacy_token = display_result.get("accessToken") or ""
+        if legacy_token and _REDACTION_MARKER_FRAGMENT not in legacy_token:
+            access_token = legacy_token
+
+    if not access_token or _REDACTION_MARKER_FRAGMENT in access_token:
+        raise AuthRequired(
+            "could not retrieve a usable access token via sf org auth "
+            "show-access-token (primary) or sf org display (fallback); "
+            "ensure sf CLI is logged in for this org and either the "
+            "dedicated command is available or SF_TEMP_SHOW_SECRETS is "
+            "still honoured."
+        )
+
+    return instance_url, access_token
+
+
+def _derive_org_ids(org_alias: str) -> Tuple[str, str, str]:
+    """Run `sf org display --json` once more for org_id_15 + org_id_18 +
+    api_version.
+
+    Reused call: the second `sf org display` is cheap and keeps the
+    creds-resolve + org-ids functions uncoupled. When a run passes both
+    through together, the overhead is two spawn()s not one — fine given
+    the whole pipeline is O(seconds).
+
+    Returns (org_id_15, org_id_18, api_version) — all strings. api_version
+    matches `vNN.N` (validated by probe_channels' path builder downstream).
+
+    Gap 3 fix (2026-05-05): returns the 18-char id as well so downstream
+    emit helpers can populate the RESULT-block `ORG_ID_18` field. The
+    18-char value comes straight from `sf org display`; we do NOT compute
+    it from the 15-char prefix.
+    """
+    data = run_sf("org_display", ORG_ALIAS=org_alias)
+    result = data.get("result") or {}
+    org_id_18 = result.get("id") or ""
+    # SF org id is 18 chars; the 15-char slice is the stable prefix used
+    # everywhere in this skill. Fail fast if shorter.
+    if len(org_id_18) < 15:
+        raise SfCliError(f"sf org display returned malformed id (len={len(org_id_18)})")
+    org_id_15 = org_id_18[:15]
+    api_version_raw = str(result.get("apiVersion") or "")
+    # apiVersion from sf CLI is "60.0" shape; our validator requires "v60.0".
+    api_version = api_version_raw if api_version_raw.startswith("v") else f"v{api_version_raw}"
+    return org_id_15, org_id_18, api_version
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: bot resolution (in-process; Data API via fetch_soql)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_bot(
+    agent_api_name: str,
+    explicit_version: str | None,
+    creds_provider: Callable[[], Tuple[str, str]],
+    refresh_fn: Callable[[], Tuple[str, str]],
+    *,
+    api_version: str,
+) -> dict | None:
+    """Resolve (bot_id, version, master_label, planner_name, bot_def_details).
+
+    Returns a dict with:
+        bot_id, version, master_label, version_auto_picked (bool),
+        bot_definition (dict row from BotDefinition details query),
+        all_versions (list of {version, status}) — retained for error ctx.
+
+    Returns None on AGENT_NOT_FOUND. Caller distinguishes by checking the
+    absence — not by catching an exception — to keep the error-emit path
+    a flat if-chain.
+
+    `api_version` is threaded in from
+    `_derive_org_ids`. The Data-API helpers require it — see
+    `rest_client.data_query` for why the old hardcoded `v60.0` was
+    wrong (real orgs run v66 and expose fields v60 does not).
+    """
+    versions = fetch_bot_versions(
+        agent_api_name, creds_provider,
+        api_version=api_version, on_401_refresh=refresh_fn,
+    )
+    if not versions:
+        return None
+
+    # Natural-key sort: v10 > v9 > v2 > v1. Copy the scheme from
+    # resolve_bot.py so multi-version bots rank consistently across the
+    # in-process + shell-out entry points.
+    def _natural_key(v: dict) -> list:
+        import re
+        dn = v.get("DeveloperName") or ""
+        return [int(p) if p.isdigit() else p for p in re.split(r"(\d+)", dn)]
+
+    versions.sort(key=_natural_key, reverse=True)
+
+    picked = None
+    if explicit_version:
+        for v in versions:
+            if v.get("DeveloperName") == explicit_version:
+                picked = v
+                break
+        version_auto_picked = False
+    else:
+        for v in versions:
+            if v.get("Status") == "Active":
+                picked = v
+                break
+        version_auto_picked = True
+
+    if not picked:
+        # Signal "version miss" distinctly from "bot miss". Caller emits
+        # STATUS=AGENT_VERSION_NOT_FOUND with AVAILABLE_VERSIONS.
+        return {
+            "bot_id": "",
+            "version": explicit_version or "",
+            "master_label": "",
+            "version_auto_picked": False,
+            "all_versions": [
+                {
+                    "version": v.get("DeveloperName") or "",
+                    "status": v.get("Status") or "",
+                }
+                for v in versions
+            ],
+            "_version_not_found": True,
+        }
+
+    bot_id = picked.get("BotDefinitionId") or ""
+    bd_node = picked.get("BotDefinition") or {}
+    master_label = bd_node.get("MasterLabel") or ""
+    chosen_version = picked.get("DeveloperName") or ""
+
+    # Phase 2 Batch 1: pull BotDefinition metadata once for the tree's
+    # `agent` block. Non-fatal if the second query fails — tree falls
+    # back to defaults.
+    try:
+        bot_def = fetch_bot_definition_details(
+            agent_api_name, creds_provider,
+            api_version=api_version, on_401_refresh=refresh_fn,
+        )
+    except (RestClientError, SoqlParamError):
+        bot_def = None
+
+    # Planner-name resolution moved to Wave A — `fetch_planner_definition`
+    # now takes (agent_api_name, chosen_version) and performs a chain-LIKE
+    # lookup (`<agent>%\_<vN>`). The canonical planner DeveloperName comes
+    # back on the row and propagates downstream via the bundle join.
+    return {
+        "bot_id": bot_id,
+        "version": chosen_version,
+        "master_label": master_label,
+        "version_auto_picked": version_auto_picked,
+        "bot_definition": bot_def or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: cache check
+# ---------------------------------------------------------------------------
+
+
+def _cache_is_fresh(cache_dir: Path) -> dict | None:
+    """Return the manifest dict if the cache is hot + fresh, else None.
+
+    Checks: manifest exists, schema_version matches, TTL not expired,
+    data_path is a real file. Any failure degrades to `None` so the
+    caller falls through to the pipeline-run path.
+
+    Mirrors cache_check.py's shell-level logic; duplicated in-process so
+    main.py can branch without shelling out.
+    """
+    import datetime as dt
+
+    manifest_path = cache_dir / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if str(manifest.get("schema_version") or "0") != SCHEMA_VERSION:
+        return None
+
+    data_path_s = manifest.get("data_path") or ""
+    if not data_path_s or not Path(data_path_s).is_file():
+        return None
+
+    try:
+        built = dt.datetime.fromisoformat(
+            (manifest.get("built_at_utc") or "").replace("Z", "+00:00")
+        )
+    except ValueError:
+        return None
+
+    age_days = (dt.datetime.now(dt.timezone.utc) - built).days
+    ttl = int(manifest.get("ttl_days") or CACHE_TTL_DAYS)
+    if age_days > ttl:
+        return None
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Wave A
+# ---------------------------------------------------------------------------
+
+
+def _run_wave_a(
+    agent_api_name: str,
+    version: str | None,
+    creds_provider: Callable[[], Tuple[str, str]],
+    refresh_fn: Callable[[], Tuple[str, str]],
+    *,
+    api_version: str,
+    parallelism: int = 5,
+) -> dict | None:
+    """Run the 7-query GenAi normalized DAG in layered parallel steps.
+
+    A1 resolves the live `GenAiPlannerDefinition` from (agent_api_name,
+    version) via a chain-LIKE lookup — Agentforce's accretive planner
+    naming (v1=`<Agent>`, v2=`<Agent>_v2`, v3=`<Agent>_v2_v3`, ...) means
+    (agent, version) alone is the only reliable key. The resolved row's
+    `DeveloperName` is the canonical planner_name that propagates
+    downstream via the bundle join in `_join_wave_a_to_bundle`.
+
+    Returns a dict:
+        {
+            "planner": {...},
+            "plugins": [...],                  # A2
+            "bundle_functions_join": [...],    # A3
+            "functions": [...],                # A4
+            "instructions": [...],             # A5
+            "plugin_functions_join": [...],    # A6
+            "attrs": [...],                    # A7
+        }
+    Returns None if A1 yields no planner row — caller emits a clean
+    error instead of failing later in the join.
+
+    Failures:
+      * RestClientError / HTTPError on A1 → propagates. No graceful path
+        when the planner itself is unreachable.
+      * A2..A7 failures: one failure in a parallel layer doesn't abort
+        the layer (fetch_bodies_parallel's contract). We surface the
+        exception list to the caller as `None` entries; the caller
+        merges them into _unresolved[] with reason `wave-a-X-failed:...`.
+    """
+    # A1 — scalar, no parallelism. api_version threads through
+    # every fetcher; see module docstring + fetch_soql.py.
+    planner = fetch_planner_definition(
+        agent_api_name, version, creds_provider,
+        api_version=api_version, on_401_refresh=refresh_fn,
+    )
+    if not planner:
+        return None
+
+    planner_id = planner.get("Id")
+    if not planner_id:
+        # Planner row missing Id — malformed response. Treat as miss.
+        return None
+
+    # Layer 2: A2 + A3 in parallel
+    layer2 = fetch_bodies_parallel(
+        [
+            partial(
+                fetch_plugins_by_planner,
+                planner_id, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+            partial(
+                fetch_planner_bundle_functions,
+                planner_id, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+        ],
+        max_workers=parallelism,
+    )
+    plugins = layer2[0][1] if layer2[0][0] else []
+    bundle_functions_join = layer2[1][1] if layer2[1][0] else []
+
+    plugin_ids = [p.get("Id") for p in plugins if p.get("Id")]
+
+    # Layer 3: A4 + A5 + A6 in parallel
+    layer3 = fetch_bodies_parallel(
+        [
+            partial(
+                fetch_functions_by_plugins,
+                plugin_ids, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+            partial(
+                fetch_plugin_instructions,
+                plugin_ids, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+            partial(
+                fetch_plugin_functions,
+                plugin_ids, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+        ],
+        max_workers=parallelism,
+    )
+    functions = layer3[0][1] if layer3[0][0] else []
+    instructions = layer3[1][1] if layer3[1][0] else []
+    plugin_functions_join = layer3[2][1] if layer3[2][0] else []
+
+    # Layer 4: A7 alone, parent_ids = function_ids. Planner-level attrs
+    # returned 0 rows live (a planner never carries direct attrs) so the
+    # prior `function_ids ∪ {planner_id}` widened the IN-list for no
+    # payoff. Keep the list minimal; dedupe defensively in case a
+    # function Id repeats across bundles.
+    parent_ids = list(dict.fromkeys(
+        f.get("Id") for f in functions if f.get("Id")
+    ))
+    try:
+        attrs = fetch_planner_attrs(
+            parent_ids, creds_provider,
+            api_version=api_version, on_401_refresh=refresh_fn,
+        )
+    except (RestClientError, SoqlParamError):
+        attrs = []
+
+    return {
+        "planner": planner,
+        "plugins": plugins,
+        "bundle_functions_join": bundle_functions_join,
+        "functions": functions,
+        "instructions": instructions,
+        "plugin_functions_join": plugin_functions_join,
+        "attrs": attrs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: join Wave A → _bundle_parsed.json shape
+# ---------------------------------------------------------------------------
+
+
+def _join_wave_a_to_bundle(
+    bot_info: dict,
+    wave_a: dict,
+) -> dict:
+    """Reshape normalized Wave-A rows into the bundle dict parse_wave expects.
+
+    `parse_bundle.py` wrote XML-shaped bundles keyed by:
+      plannerType, plannerName, generation, description, masterLabel,
+      topics[{name, actions[{name, invocationTarget, invocationTargetType, ...}]}],
+      plannerActions[{...}]
+
+    We reconstruct that shape from the Tooling rows so parse_wave's
+    `init_tree` + `build_root_children` accept the dict unchanged.
+    """
+    planner = wave_a["planner"]
+    planner_type = planner.get("PlannerType") or ""
+    generation = classify_generation(planner_type)
+
+    functions_by_id = {f.get("Id"): f for f in wave_a["functions"] if f.get("Id")}
+    # Plugin join: map plugin_id → ordered function_ids
+    plugin_fn_map: dict[str, list[str]] = {}
+    for row in wave_a["plugin_functions_join"]:
+        pid = row.get("PluginId")
+        fn_id = row.get("Function")
+        if pid and fn_id:
+            plugin_fn_map.setdefault(pid, []).append(fn_id)
+
+    def _action_dict(fn: dict) -> dict:
+        """Shape a GenAiFunctionDefinition row as a bundle-action dict."""
+        return {
+            "name": fn.get("DeveloperName") or fn.get("Id") or "",
+            "localDeveloperName": fn.get("LocalDeveloperName"),
+            "masterLabel": fn.get("MasterLabel"),
+            "description": fn.get("Description"),
+            "invocationTarget": fn.get("InvocationTarget"),
+            "invocationTargetType": (fn.get("InvocationTargetType") or "").strip(),
+            "source": fn.get("Source"),
+        }
+
+    topics = []
+    for plugin in wave_a["plugins"]:
+        pid = plugin.get("Id")
+        fn_ids = plugin_fn_map.get(pid, [])
+        actions = [
+            _action_dict(functions_by_id[fid])
+            for fid in fn_ids if fid in functions_by_id
+        ]
+        topics.append({
+            "name": plugin.get("DeveloperName") or "",
+            "localDeveloperName": plugin.get("LocalDeveloperName"),
+            "masterLabel": plugin.get("MasterLabel"),
+            "description": plugin.get("Description"),
+            "canEscalate": bool(plugin.get("CanEscalate")),
+            "pluginType": plugin.get("PluginType"),
+            "actions": actions,
+        })
+
+    # A planner never has direct functions (user invariant, verified
+    # against my-org-alias). The previous `PlannerId`-leg query leaked
+    # orphan rows (e.g. `AnswerQuestionsWithKnowledge_*`) as root-level
+    # children. Key retained for downstream compatibility with callers
+    # that read `bundle.get("plannerActions", [])` (parse_wave, a few
+    # _route / _normalize paths); always emits an empty list now.
+    return {
+        "plannerType": planner_type,
+        "plannerName": planner.get("DeveloperName"),
+        "generation": generation,
+        "description": planner.get("Description"),
+        "masterLabel": planner.get("MasterLabel"),
+        "topics": topics,
+        "plannerActions": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 8: Wave B (Flow + Apex body fetches)
+# ---------------------------------------------------------------------------
+
+
+def _collect_wave_b_targets(bundle_parsed: dict) -> dict[str, list[str]]:
+    """Walk topics + plannerActions. Return {kind: [invocation_target, ...]}.
+
+    Deduplicates per-kind. Caller routes each kind through the appropriate
+    fetch_soql helper.
+    """
+    apex_names: set[str] = set()
+    apex_ids: set[str] = set()
+    flow_names: set[str] = set()
+    flow_ids: set[str] = set()
+    # Bug 1 fix (2026-05-05): prompt-template targets can arrive as either
+    # DeveloperNames (classic) OR 0hf-prefix Ids (observed in live orgs —
+    # GenAiFunctionDefinition.InvocationTarget sometimes stores the Id).
+    # Route to separate buckets so the Id bucket can be resolved → DevName
+    # by _normalize_prompt_template_id_targets before Wave B retrieve.
+    prompt_template_ids: set[str] = set()
+    unresolved: list[dict] = []
+
+    def _route(target: str, ttype: str) -> None:
+        t = (ttype or "").lower()
+        if not target:
+            return
+        # Bug 1 fix: prompt-template targets can arrive as either
+        # DeveloperNames (classic) OR 0hf-prefix Ids. The Metadata API
+        # retrieve expects DeveloperName; an Id sent verbatim returns
+        # zero members and the target stays in _pending_fetches forever.
+        # Route 0hf Ids into a separate bucket for post-lookup rewrite
+        # via _normalize_prompt_template_id_targets (parallel to the
+        # existing _normalize_flow_id_targets pattern).
+        if t in ("prompttemplate", "generatepromptresponse") or t.startswith("prompt") or t.startswith("genai"):
+            if looks_like_sf_id(target) and target[:3].lower() == "0hf":
+                prompt_template_ids.add(target)
+            return
+        # bundle-declared kinds that never carry an Id.
+        # Standard actions store their identifier (not an SF Id) directly
+        # in InvocationTarget. Skip the ID router entirely — routing them
+        # through resolve_or_unresolved would pollute `_unresolved` with
+        # misleading "invalid-id-format" entries.
+        if t == "standardinvocableaction":
+            return
+        # for flow/apex, only consult the ID router
+        # when the target actually looks like a Salesforce Id. Classic
+        # DeveloperNames (e.g. `MyFlow`, `AGNT_Foo`) don't
+        # match the Id shape and used to land in _unresolved with reason
+        # `invalid-id-format` — noise. Short-circuit: if it's not an Id
+        # shape, skip the router and trust the invocationTargetType.
+        if t in ("flow", "apex") and looks_like_sf_id(target):
+            kind, _channel = resolve_or_unresolved(target, unresolved)
+            if kind == "apex":
+                apex_ids.add(target)
+                return
+            if kind in ("flow_definition", "flow_version"):
+                flow_ids.add(target)
+                return
+            # Unknown Id prefix: resolve_or_unresolved already appended
+            # to `unresolved` with reason "unknown-id-prefix:..." — fall
+            # through; the target stays unrouted and surfaces there.
+            return
+        # Classic path: InvocationTarget is a DeveloperName.
+        if t == "apex":
+            apex_names.add(target)
+        elif t == "flow":
+            flow_names.add(target)
+        # Any other unrecognized type: silently skip. parse_wave will
+        # classify the node as UNKNOWN and it surfaces via _kind_counts.
+
+    for topic in bundle_parsed.get("topics", []) or []:
+        for a in topic.get("actions", []) or []:
+            _route(a.get("invocationTarget") or "",
+                   a.get("invocationTargetType") or "")
+    for a in bundle_parsed.get("plannerActions", []) or []:
+        _route(a.get("invocationTarget") or "",
+               a.get("invocationTargetType") or "")
+
+    return {
+        "apex_names": sorted(apex_names),
+        "apex_ids": sorted(apex_ids),
+        "flow_names": sorted(flow_names),
+        "flow_ids": sorted(flow_ids),
+        "prompt_template_ids": sorted(prompt_template_ids),
+        "_unresolved": unresolved,
+    }
+
+
+def _fetch_wave_b_by_names(
+    *,
+    apex_names: list[str],
+    apex_ids: list[str],
+    flow_names: list[str],
+    flow_ids: list[str],
+    prompt_template_ids: list[str] | None = None,
+    creds_provider: Callable[[], Tuple[str, str]],
+    refresh_fn: Callable[[], Tuple[str, str]],
+    api_version: str,
+    org_alias: str,
+    parallelism: int = 5,
+) -> dict:
+    """Fire body fetches for an explicit set of Apex/Flow identifiers.
+
+    Factored out of `_run_wave_b` so the iterative Wave B caller
+    (`_iterate_wave_b`) can reuse the same shape on subflow rounds —
+    every round's fetch concurrency + error handling semantics must
+    match the initial round exactly (same parallel layer, same
+    unresolved bookkeeping).
+
+    Returns a dict with:
+        apex_rows: list of ApexClass records (Name keyed)
+        flow_def_rows: list of FlowDefinition records (DeveloperName keyed)
+        flow_metadata: dict {version_id: Flow record}
+        unresolved: list of {id, reason} from fetch failures
+
+    Any empty input list short-circuits that branch — callers can pass
+    subsets safely (e.g. subflow rounds typically pass only flow_names).
+    """
+    unresolved: list[dict] = []
+
+    # First hop: resolve IDs back to names where applicable. The results
+    # merge into the same rowsets the name-keyed path produces.
+    # api_version threads into every fetch call.
+    if apex_ids:
+        try:
+            apex_by_id_rows = fetch_apex_bodies_by_ids(
+                apex_ids, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            )
+        except (RestClientError, SoqlParamError) as e:
+            unresolved.append({"kind": "APEX", "reason": f"apex-by-id-failed:{redact_error(e)}"})
+            apex_by_id_rows = []
+    else:
+        apex_by_id_rows = []
+
+    if flow_ids:
+        try:
+            flow_def_by_id_rows = fetch_flow_definition_by_ids(
+                flow_ids, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            )
+        except (RestClientError, SoqlParamError) as e:
+            unresolved.append({"kind": "FLOW", "reason": f"flow-def-by-id-failed:{redact_error(e)}"})
+            flow_def_by_id_rows = []
+    else:
+        flow_def_by_id_rows = []
+
+    # Bug 1 fix: GenAiPromptTemplate is NOT SOQL-queryable (not on Tooling,
+    # not on Data API). The only way to resolve Id → DeveloperName is
+    # `sf org list metadata -m GenAiPromptTemplate`. We list every prompt
+    # template in the org, build an Id → fullName map, filter to the Ids
+    # we care about, and project to the same {Id, DeveloperName} shape the
+    # rest of the pipeline expects.
+    #
+    # Failure is non-fatal — the Ids stay in the bucket and surface in
+    # `_pending_fetches` rather than masking the real issue.
+    if prompt_template_ids:
+        try:
+            rows = list_prompt_template_metadata(org_alias)
+        except (SfCliError, AuthRequired) as e:
+            unresolved.append({
+                "kind": "PROMPT_TEMPLATE",
+                "reason": f"prompt-template-listmetadata-failed:{redact_error(e)}",
+            })
+            rows = []
+        wanted = set(prompt_template_ids)
+        prompt_template_id_rows = [
+            {"Id": r["id"], "DeveloperName": r["fullName"]}
+            for r in rows
+            if isinstance(r, dict) and r.get("id") in wanted and r.get("fullName")
+        ]
+    else:
+        prompt_template_id_rows = []
+
+    # Parallel layer: apex-by-name + flow-def-by-name. Empty name lists
+    # still produce a task, but the downstream fetcher short-circuits on
+    # empty input — the overhead is a single worker dispatch which is
+    # cheaper than conditionally building the task list.
+    name_layer = fetch_bodies_parallel(
+        [
+            partial(
+                fetch_apex_bodies_by_names,
+                apex_names, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+            partial(
+                fetch_flow_definition_ids_by_names,
+                flow_names, creds_provider,
+                api_version=api_version, on_401_refresh=refresh_fn,
+            ),
+        ],
+        max_workers=parallelism,
+    )
+    apex_name_rows = name_layer[0][1] if name_layer[0][0] else []
+    flow_def_name_rows = name_layer[1][1] if name_layer[1][0] else []
+    # Bug D.1 fix: include the response body preview captured by
+    # rest_client._query_once when the failure was an HTTPError. Without
+    # it, all wave-B 400s collapse to "HTTP Error 400: Bad Request" with
+    # no signal about which name caused the malformed query. Falls back
+    # to None (existing shape) for non-HTTPError failures.
+    for ok, r in (name_layer[0], name_layer[1]):
+        if not ok:
+            entry = {"kind": "APEX_OR_FLOW", "reason": f"wave-b-batch-failed:{redact_error(r)}"}
+            preview = getattr(r, "_response_body_preview", None)
+            if preview:
+                entry["response_body_preview"] = preview
+            unresolved.append(entry)
+
+    apex_rows = [*apex_name_rows, *apex_by_id_rows]
+    flow_def_rows = [*flow_def_name_rows, *flow_def_by_id_rows]
+
+    # Second hop: one Flow.Metadata single-row call per ActiveVersionId.
+    # Parallelized via fetch_bodies_parallel.
+    version_ids = [
+        r.get("ActiveVersionId") for r in flow_def_rows
+        if r.get("ActiveVersionId")
+    ]
+    metadata_tasks = [
+        partial(
+            fetch_flow_metadata,
+            vid, creds_provider,
+            api_version=api_version, on_401_refresh=refresh_fn,
+        )
+        for vid in version_ids
+    ]
+    metadata_results = fetch_bodies_parallel(
+        metadata_tasks, max_workers=parallelism,
+    )
+    flow_metadata: dict[str, dict] = {}
+    for vid, (ok, result_or_exc) in zip(version_ids, metadata_results):
+        if ok and isinstance(result_or_exc, dict):
+            flow_metadata[vid] = result_or_exc
+        elif not ok:
+            unresolved.append({
+                "kind": "FLOW",
+                "version_id": vid,
+                "reason": f"flow-metadata-failed:{redact_error(result_or_exc)}",
+            })
+
+    return {
+        "apex_rows": apex_rows,
+        "flow_def_rows": flow_def_rows,
+        "flow_metadata": flow_metadata,
+        "prompt_template_id_rows": prompt_template_id_rows,
+        "unresolved": unresolved,
+    }
+
+
+def _run_wave_b(
+    bundle_parsed: dict,
+    creds_provider: Callable[[], Tuple[str, str]],
+    refresh_fn: Callable[[], Tuple[str, str]],
+    *,
+    api_version: str,
+    org_alias: str,
+    parallelism: int = 5,
+) -> dict:
+    """Fire body fetches for every Apex/Flow target in the bundle.
+
+    Returns a dict with:
+        apex_rows: list of ApexClass records (Name keyed)
+        flow_def_rows: list of FlowDefinition records (DeveloperName keyed)
+        flow_metadata: dict {version_id: Flow record}
+        unresolved: list of {id, reason} from NGA ID routing
+
+    Only covers the top-level identifiers enumerated directly in
+    `bundle_parsed`. Subflows referenced inside fetched Flow.Metadata
+    bodies (e.g. shared utility flows like `handleFlowFault`) are
+    discovered AFTER this function returns and need a second round of
+    fetching — see `_iterate_wave_b`.
+    """
+    targets = _collect_wave_b_targets(bundle_parsed)
+
+    fetched = _fetch_wave_b_by_names(
+        apex_names=targets["apex_names"],
+        apex_ids=targets["apex_ids"],
+        flow_names=targets["flow_names"],
+        flow_ids=targets["flow_ids"],
+        prompt_template_ids=targets.get("prompt_template_ids") or [],
+        creds_provider=creds_provider,
+        refresh_fn=refresh_fn,
+        api_version=api_version,
+        org_alias=org_alias,
+        parallelism=parallelism,
+    )
+
+    # Merge the routing-layer unresolved entries (unknown-id-prefix, etc.)
+    # with the fetch-layer ones. Order: routing first, fetch second — it's
+    # the order they're discovered in the pipeline.
+    fetched["unresolved"] = [*targets["_unresolved"], *fetched["unresolved"]]
+    return fetched
+
+
+# ---------------------------------------------------------------------------
+# iterative Wave B for nested-subflow discovery
+# ---------------------------------------------------------------------------
+
+
+def _extract_refs_from_flow_metadata(
+    flow_metadata: dict[str, dict],
+) -> Tuple[set[str], set[str]]:
+    """Scan fetched Flow.Metadata dicts for downstream subflow + apex refs.
+
+    Returns `(subflow_names, apex_names)` — both DeveloperName sets.
+    Subsets of the data that `_build_flow_children` walks, narrowed to
+    just the name-extraction we need before we have enough information
+    to build the full child list.
+
+    The extractor is intentionally permissive: missing keys / non-dict
+    entries / blank names all drop silently. Parsing shape mirrors the
+    `Metadata.actionCalls[]` + `Metadata.subflows[]` layout documented
+    in the fetch_flow_metadata docstring and exercised by the
+    CLASSIC_FLOW_METADATA fixture.
+
+    Apex discovery from actionCalls is deliberate — a subflow body CAN
+    reference a new Apex class the parent tree didn't see (actionType
+    == "apex" && actionName == <new class>). Missing those means the
+    iterated tree has unexpanded APEX leaves even after flows resolve.
+    """
+    subflow_names: set[str] = set()
+    apex_names: set[str] = set()
+    for record in (flow_metadata or {}).values():
+        if not isinstance(record, dict):
+            continue
+        md = record.get("Metadata")
+        if not isinstance(md, dict):
+            continue
+        for ac in md.get("actionCalls") or []:
+            if not isinstance(ac, dict):
+                continue
+            if (ac.get("actionType") or "") == "apex":
+                nm = ac.get("actionName") or ""
+                if nm:
+                    apex_names.add(nm)
+        for sub in md.get("subflows") or []:
+            if not isinstance(sub, dict):
+                continue
+            nm = sub.get("flowName") or ""
+            if nm:
+                subflow_names.add(nm)
+    return subflow_names, apex_names
+
+
+def _iterate_wave_b(
+    initial_wave_b: dict,
+    creds_provider: Callable[[], Tuple[str, str]],
+    refresh_fn: Callable[[], Tuple[str, str]],
+    *,
+    api_version: str,
+    org_alias: str,
+    parallelism: int = 5,
+    max_iterations: int = 5,
+) -> dict:
+    """Drive Wave B to fixed-point for nested subflow / apex discovery.
+
+    The initial `_run_wave_b` call only enumerates top-level flow refs
+    from `bundle_parsed`. When those flow bodies reference subflows
+    (via `Metadata.subflows[].flowName`) or new Apex classes (via
+    `Metadata.actionCalls[]`), their bodies were never fetched — so
+    `_build_flow_children` would shape them as leaf nodes with no
+    children even though the real subtree has content.
+
+    Per round:
+      1. Extract subflow + apex refs from the current flow_metadata.
+      2. Diff against already-fetched DeveloperNames.
+      3. If diff empty → converged, return.
+      4. Fetch the diff via `_fetch_wave_b_by_names`.
+      5. Merge into the running wave_b dict.
+      6. Repeat.
+
+    Safety:
+      * `max_iterations=5` — empirically 2-3 is enough on real bots
+        (handleFlowFault etc.). Hit the cap → remaining unfetched names
+        surface via parse_wave's `_pending_fetches.FLOW` (their names
+        are never added to `visited_by_kind["FLOW"]` since they're
+        absent from `flow_def_rows`) and a marker lands in `unresolved`
+        for triage.
+      * Fetch failures in a round are tolerated by `_fetch_wave_b_by_names`
+        — the affected names simply don't make it into `flow_def_rows`
+        and naturally surface as pending.
+
+    Returns the (possibly enlarged) wave_b dict; caller mutates nothing.
+    """
+    if max_iterations <= 0:
+        return initial_wave_b
+
+    # Running state: copy so callers see their original dict untouched.
+    merged_apex_rows = list(initial_wave_b.get("apex_rows") or [])
+    merged_flow_def_rows = list(initial_wave_b.get("flow_def_rows") or [])
+    merged_flow_metadata: dict[str, dict] = dict(
+        initial_wave_b.get("flow_metadata") or {}
+    )
+    merged_unresolved = list(initial_wave_b.get("unresolved") or [])
+
+    fetched_flow_names: set[str] = {
+        r.get("DeveloperName") for r in merged_flow_def_rows
+        if r.get("DeveloperName")
+    }
+    fetched_apex_names: set[str] = {
+        r.get("Name") for r in merged_apex_rows if r.get("Name")
+    }
+
+    for _round in range(max_iterations):
+        subflow_names, apex_names = _extract_refs_from_flow_metadata(
+            merged_flow_metadata
+        )
+        new_flow_names = sorted(subflow_names - fetched_flow_names)
+        new_apex_names = sorted(apex_names - fetched_apex_names)
+        if not new_flow_names and not new_apex_names:
+            # Fixed-point reached.
+            return {
+                "apex_rows": merged_apex_rows,
+                "flow_def_rows": merged_flow_def_rows,
+                "flow_metadata": merged_flow_metadata,
+                "prompt_template_id_rows": initial_wave_b.get(
+                    "prompt_template_id_rows"
+                ) or [],
+                "unresolved": merged_unresolved,
+            }
+
+        round_result = _fetch_wave_b_by_names(
+            apex_names=new_apex_names,
+            apex_ids=[],
+            flow_names=new_flow_names,
+            flow_ids=[],
+            creds_provider=creds_provider,
+            refresh_fn=refresh_fn,
+            api_version=api_version,
+            org_alias=org_alias,
+            parallelism=parallelism,
+        )
+        merged_apex_rows.extend(round_result["apex_rows"])
+        merged_flow_def_rows.extend(round_result["flow_def_rows"])
+        merged_flow_metadata.update(round_result["flow_metadata"])
+        merged_unresolved.extend(round_result["unresolved"])
+
+        # Update fetched-name bookkeeping — we only track rows we
+        # actually received (fetch failure ⇒ not fetched ⇒ will be
+        # retried next round, bounded by the iteration cap).
+        for r in round_result["flow_def_rows"]:
+            nm = r.get("DeveloperName")
+            if nm:
+                fetched_flow_names.add(nm)
+        for r in round_result["apex_rows"]:
+            nm = r.get("Name")
+            if nm:
+                fetched_apex_names.add(nm)
+
+    # Iteration cap hit. Scan one more time to see what's still pending
+    # so we can surface it clearly in `unresolved`. These names will also
+    # land in `_pending_fetches.FLOW` via parse_wave's visited-vs-pending
+    # diff (they're absent from flow_def_rows ⇒ absent from
+    # visited_by_kind["FLOW"]).
+    subflow_names, apex_names = _extract_refs_from_flow_metadata(
+        merged_flow_metadata
+    )
+    still_pending_flows = sorted(subflow_names - fetched_flow_names)
+    still_pending_apex = sorted(apex_names - fetched_apex_names)
+    for nm in still_pending_flows:
+        merged_unresolved.append({
+            "kind": "FLOW",
+            "api_name": nm,
+            "reason": f"wave-b-iteration-cap:{max_iterations}-rounds-exhausted",
+        })
+    for nm in still_pending_apex:
+        merged_unresolved.append({
+            "kind": "APEX",
+            "api_name": nm,
+            "reason": f"wave-b-iteration-cap:{max_iterations}-rounds-exhausted",
+        })
+
+    return {
+        "apex_rows": merged_apex_rows,
+        "flow_def_rows": merged_flow_def_rows,
+        "flow_metadata": merged_flow_metadata,
+        "prompt_template_id_rows": initial_wave_b.get(
+            "prompt_template_id_rows"
+        ) or [],
+        "unresolved": merged_unresolved,
+    }
+
+
+# ---------------------------------------------------------------------------
+# build flow_children from in-memory Wave B metadata
+# ---------------------------------------------------------------------------
+
+
+def _build_flow_children(
+    flow_metadata: dict[str, dict],
+    flow_def_rows: list[dict],
+) -> dict[str, list[dict]]:
+    """Produce `{flow_developer_name: [child_ref, ...]}` from Wave B data.
+
+    Mirrors the shape `parse_wave.harvest_waves` produces from on-disk
+    flow XML, but sourced from the in-memory `Flow.Metadata` JSON that
+    Wave B already fetched via the Tooling REST API (the `Metadata`
+    complexvalue field decodes to a plain dict — see
+    `fetch_flow_metadata` + test fixture `CLASSIC_FLOW_METADATA`). The
+    shape parse_wave expects per child:
+
+        {"kind": "APEX",            "api_name": <name>, "element_name": <elem>}
+        {"kind": "PROMPT_TEMPLATE", "api_name": <name>, "element_name": <elem>}
+        {"kind": "STANDARD_ACTION", "api_name": <name>, "element_name": <elem>,
+         "invocation_type": <actionType>}
+        {"kind": "FLOW",            "api_name": <target_flow_name>,
+         "element_name": <elem>}
+        {"kind": "UNKNOWN",         "api_name": <name>, "element_name": <elem>,
+         "invocation_type": <actionType>}
+
+    Keying is by FlowDefinition.DeveloperName (not ActiveVersionId) —
+    `walk_and_inflate` looks up by `leaf["api_name"]`, which the bundle
+    populates with the Flow's DeveloperName.
+
+    Flows whose ActiveVersionId is missing (inactive / draft-only) or
+    whose fetched metadata was None are silently skipped — they never
+    had a body to walk. actionCall entries missing required fields
+    (`actionType`, `actionName`, or `name`) degrade to UNKNOWN via
+    `classify_action_call`, which already tolerates blanks. Subflow
+    entries missing `flowName` are dropped entirely (no api_name to
+    descend into).
+    """
+    import parse_wave
+
+    # Build ActiveVersionId → DeveloperName lookup. FlowDefinition rows with
+    # no ActiveVersionId (inactive flows, or flows only materializing a
+    # Latest version) skip this map — `flow_metadata` is keyed on
+    # ActiveVersionId too, so they drop out symmetrically.
+    version_to_name: dict[str, str] = {}
+    for row in flow_def_rows or []:
+        vid = row.get("ActiveVersionId")
+        dev_name = row.get("DeveloperName")
+        if vid and dev_name:
+            version_to_name[vid] = dev_name
+
+    flow_children: dict[str, list[dict]] = {}
+    for version_id, record in (flow_metadata or {}).items():
+        flow_name = version_to_name.get(version_id)
+        if not flow_name:
+            # No matching FlowDefinition row — can't key the children list.
+            continue
+        if not isinstance(record, dict):
+            continue
+        md = record.get("Metadata") or {}
+        if not isinstance(md, dict):
+            continue
+
+        children: list[dict] = []
+
+        # actionCalls — each entry has `name` (element id), `actionType`,
+        # `actionName`. `actionType`/`actionName` may be missing on edge
+        # cases (flow authored against an older API version that omits
+        # the field); classify_action_call tolerates empty strings and
+        # will return UNKNOWN.
+        for ac in md.get("actionCalls") or []:
+            if not isinstance(ac, dict):
+                continue
+            element_name = ac.get("name")
+            action_type = ac.get("actionType") or ""
+            action_name = ac.get("actionName") or ""
+            if not element_name:
+                # An unnamed actionCall can't be addressed in the tree
+                # view; drop rather than synthesize a placeholder.
+                continue
+            children.append(
+                parse_wave.classify_action_call(action_type, action_name, element_name)
+            )
+
+        # subflows — each has `name` (element id) + `flowName` (target).
+        for sub in md.get("subflows") or []:
+            if not isinstance(sub, dict):
+                continue
+            element_name = sub.get("name")
+            target = sub.get("flowName")
+            if not element_name or not target:
+                continue
+            children.append({
+                "kind": "FLOW",
+                "element_name": element_name,
+                "api_name": target,
+            })
+
+        flow_children[flow_name] = children
+
+    return flow_children
+
+
+# ---------------------------------------------------------------------------
+# Flow-ID → DeveloperName normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize_flow_id_targets(bundle_parsed: dict, flow_def_rows: list[dict]) -> None:
+    """Rewrite action invocationTargets that are Flow IDs → DeveloperNames.
+
+    Mutates `bundle_parsed` in place. No-op when no flow_def_rows match.
+
+    Classic bots occasionally store 300Uv-prefix FlowDefinition IDs or
+    301-prefix Flow version IDs in `GenAiFunctionDefinition.InvocationTarget`
+    instead of DeveloperNames. Wave B's FlowDefinition fetch (by-id branch)
+    already resolved those IDs; the rows carry both Id + ActiveVersionId +
+    DeveloperName. We build a bi-directional map (300-id → name, 301-id →
+    name via ActiveVersionId) and rewrite every action whose target is a
+    known ID.
+
+    Unmatched IDs (Flow genuinely not queryable or belongs to a managed
+    package we can't see) stay as-is so the pipeline surfaces them in
+    _pending_fetches rather than silently discarding.
+    """
+    # Build ID → DeveloperName lookup from both Id and ActiveVersionId keys.
+    id_to_name: dict[str, str] = {}
+    for row in flow_def_rows or []:
+        dev_name = row.get("DeveloperName")
+        if not dev_name:
+            continue
+        row_id = row.get("Id")
+        if row_id:
+            id_to_name[row_id] = dev_name
+        active_ver = row.get("ActiveVersionId")
+        if active_ver:
+            id_to_name[active_ver] = dev_name
+
+    if not id_to_name:
+        return
+
+    def _rewrite_action(action: dict) -> None:
+        target = action.get("invocationTarget")
+        ttype = (action.get("invocationTargetType") or "").strip().lower()
+        if ttype != "flow" or not isinstance(target, str):
+            return
+        resolved = id_to_name.get(target)
+        if resolved:
+            # Preserve the original ID for traceability — consumers that
+            # need it can still read `_original_invocation_target_id`.
+            action["_original_invocation_target_id"] = target
+            action["invocationTarget"] = resolved
+
+    for topic in bundle_parsed.get("topics") or []:
+        for action in topic.get("actions") or []:
+            _rewrite_action(action)
+    for action in bundle_parsed.get("plannerActions") or []:
+        _rewrite_action(action)
+
+
+def _normalize_prompt_template_id_targets(
+    bundle_parsed: dict, prompt_template_rows: list[dict],
+) -> None:
+    """Rewrite action invocationTargets that are GenAiPromptTemplate Ids
+    (0hf-prefix) → DeveloperNames.
+
+    Bug 1 fix (2026-05-05): when GenAiFunctionDefinition.InvocationTarget
+    stores a 0hf-prefix prompt template Id instead of a DeveloperName
+    (observed in live my-org-alias org), the Metadata API retrieve
+    can't match it — Wave B enqueues the Id as-is and the template
+    stays in `_pending_fetches.PROMPT_TEMPLATE` forever.
+
+    Parallel to `_normalize_flow_id_targets`: build an Id → DeveloperName
+    map from `list_prompt_template_metadata` rows (projected to
+    {Id, DeveloperName} shape by `_fetch_wave_b_by_names`), mutate the
+    bundle in place. Unmatched Ids stay as-is (genuinely missing template,
+    or the Metadata API listing failed).
+    """
+    id_to_name: dict[str, str] = {}
+    for row in prompt_template_rows or []:
+        row_id = row.get("Id")
+        dev_name = row.get("DeveloperName")
+        if row_id and dev_name:
+            id_to_name[row_id] = dev_name
+
+    if not id_to_name:
+        return
+
+    def _rewrite_action(action: dict) -> None:
+        target = action.get("invocationTarget")
+        ttype = (action.get("invocationTargetType") or "").strip().lower()
+        # Match the same ttype predicate used by _route for prompt-template
+        # targets — otherwise a Flow action whose target happens to collide
+        # with a prompt template Id (unlikely but possible) wouldn't be
+        # caught. _route's predicate is the authority on what's a prompt.
+        is_prompt_ttype = (
+            ttype in ("prompttemplate", "generatepromptresponse")
+            or ttype.startswith("prompt")
+            or ttype.startswith("genai")
+        )
+        if not is_prompt_ttype or not isinstance(target, str):
+            return
+        resolved = id_to_name.get(target)
+        if resolved:
+            action["_original_invocation_target_id"] = target
+            action["invocationTarget"] = resolved
+
+    for topic in bundle_parsed.get("topics") or []:
+        for action in topic.get("actions") or []:
+            _rewrite_action(action)
+    for action in bundle_parsed.get("plannerActions") or []:
+        _rewrite_action(action)
+
+
+def _normalize_apex_id_targets(
+    bundle_parsed: dict, apex_by_id_rows: list[dict],
+) -> None:
+    """Rewrite action invocationTargets that are Apex (01p-prefix Id)
+    -> ApexClass Name.
+
+    Gap B fix (2026-05-05): when GenAiFunctionDefinition.InvocationTarget
+    stores a 01p-prefix ApexClass Id instead of a class Name (observed in
+    live my-org-alias org, e.g. 01p000000000000AAA ->
+    MyController), downstream Wave B body retrieval enqueues
+    the Id as-is into `_pending_fetches.APEX` and the tree renders the raw
+    Id instead of the class name.
+
+    Parallel to `_normalize_prompt_template_id_targets`: build an Id ->
+    Name map from `fetch_apex_bodies_by_ids` rows (ApexClass uses `Name`,
+    not `DeveloperName`), mutate the bundle in place. Unmatched Ids stay
+    as-is (genuinely missing class, or the by-Id fetch failed).
+    """
+    id_to_name: dict[str, str] = {}
+    for row in apex_by_id_rows or []:
+        row_id = row.get("Id")
+        class_name = row.get("Name")
+        if row_id and class_name:
+            id_to_name[row_id] = class_name
+
+    if not id_to_name:
+        return
+
+    def _rewrite_action(action: dict) -> None:
+        target = action.get("invocationTarget")
+        ttype = (action.get("invocationTargetType") or "").strip().lower()
+        # Match the same ttype predicate used by _route for apex targets.
+        # Mirrors the prompt-template normalizer's ttype gate so a Flow
+        # action whose target happens to collide with an ApexClass Id
+        # (unlikely but possible) isn't miscaught.
+        is_apex_ttype = ttype in ("apex", "apexaction") or ttype.startswith("apex")
+        if not is_apex_ttype or not isinstance(target, str):
+            return
+        # Prefix-gate the rewrite to the ApexClass key prefix (01p).
+        # Mirrors the `target[:3].lower() == "01p"` check in _collect_wave_b_targets.
+        if target[:3].lower() != "01p":
+            return
+        resolved = id_to_name.get(target)
+        if resolved:
+            action["_original_invocation_target_id"] = target
+            action["invocationTarget"] = resolved
+
+    for topic in bundle_parsed.get("topics") or []:
+        for action in topic.get("actions") or []:
+            _rewrite_action(action)
+    for action in bundle_parsed.get("plannerActions") or []:
+        _rewrite_action(action)
+
+
+# ---------------------------------------------------------------------------
+# Signature derivation — Apex + Flow (rendered in Section 7 of architecture.md)
+# ---------------------------------------------------------------------------
+
+
+def _derive_apex_signature(apex_row: dict) -> str | None:
+    """Return a compact one-line signature string for an Apex class, or None.
+
+    Sourced from `SymbolTable.methods[]` on the ApexClass Tooling row. Picks
+    the "primary" method:
+      1. Prefer a method annotated `@InvocableMethod` (what Flow / Agentforce
+         actually invoke — typically exactly one per Agentforce-relevant
+         class).
+      2. Else prefer a `global` or `public static` non-constructor method.
+      3. Else fall back to the first method in SymbolTable source order.
+
+    Format: `<modifiers> <returnType> <name>(<p1_type> <p1_name>, ...)`. If
+    `returnType` is absent (constructor shape) it's omitted. Parameters are
+    rendered as `<type> <name>`; empty param list becomes `()`.
+
+    Returns None when `SymbolTable` is missing/empty or contains no method
+    candidates. Body parsing is intentionally NOT attempted — too brittle.
+    """
+    if not isinstance(apex_row, dict):
+        return None
+    symbol_table = apex_row.get("SymbolTable")
+    if not isinstance(symbol_table, dict):
+        return None
+    methods = symbol_table.get("methods")
+    if not isinstance(methods, list) or not methods:
+        return None
+
+    def _is_invocable(m: dict) -> bool:
+        anns = m.get("annotations") or []
+        for ann in anns:
+            if isinstance(ann, dict):
+                if (ann.get("name") or "").lower() == "invocablemethod":
+                    return True
+            elif isinstance(ann, str):
+                if ann.lower() == "invocablemethod":
+                    return True
+        return False
+
+    def _is_constructor(m: dict) -> bool:
+        # SymbolTable represents constructors via `constructors[]`, but some
+        # payloads fold them into `methods[]` with a null/empty returnType.
+        rt = m.get("returnType")
+        return not rt
+
+    def _is_promoted(m: dict) -> bool:
+        mods = [str(x).lower() for x in (m.get("modifiers") or [])]
+        if _is_constructor(m):
+            return False
+        if "global" in mods:
+            return True
+        if "public" in mods and "static" in mods:
+            return True
+        return False
+
+    candidates = [m for m in methods if isinstance(m, dict)]
+    if not candidates:
+        return None
+
+    primary: dict | None = next((m for m in candidates if _is_invocable(m)), None)
+    if primary is None:
+        primary = next((m for m in candidates if _is_promoted(m)), None)
+    if primary is None:
+        # Last-resort: first method. Skip if it's purely a private/local helper
+        # with no chance of being the public entry point — those add noise.
+        primary = candidates[0]
+        mods = [str(x).lower() for x in (primary.get("modifiers") or [])]
+        if "private" in mods and not _is_invocable(primary):
+            return None
+
+    modifiers = [str(x) for x in (primary.get("modifiers") or [])]
+    return_type = primary.get("returnType") or ""
+    name = primary.get("name") or ""
+    if not name:
+        return None
+
+    params_out: list[str] = []
+    for p in primary.get("parameters") or []:
+        if not isinstance(p, dict):
+            continue
+        p_type = p.get("type") or ""
+        p_name = p.get("name") or ""
+        if p_type and p_name:
+            params_out.append(f"{p_type} {p_name}")
+        elif p_type:
+            params_out.append(p_type)
+        elif p_name:
+            params_out.append(p_name)
+    params_str = ", ".join(params_out)
+
+    parts: list[str] = []
+    if modifiers:
+        parts.append(" ".join(modifiers))
+    if return_type:
+        parts.append(return_type)
+    parts.append(f"{name}({params_str})")
+    return " ".join(parts)
+
+
+def _derive_flow_signature(flow_metadata_record: dict) -> str | None:
+    """Return a compact signature string for a Flow, or None.
+
+    Sourced from `Metadata.variables[]` on the Tooling Flow record
+    (`fetch_flow_metadata` output — the `flow_metadata_record` is the
+    full Tooling row, and `.Metadata` is the decoded complexvalue dict).
+
+    Flow variables carry boolean `isInput` / `isOutput` flags. A variable
+    with `isInput: true` contributes to the `in:` side; `isOutput: true`
+    contributes to the `out:` side; a variable can set both (round-trip)
+    and will appear on BOTH sides. Variables with neither flag are locals
+    and are skipped.
+
+    Format: `in: <name>: <type>[, ...] | out: <name>: <type>[, ...]`.
+    If only one side has entries, only that side is emitted. Returns None
+    when neither side has entries.
+
+    Collection variables render as `List<<dataType>>`. sObject variables
+    use the `objectType` field (e.g. `List<Case>` rather than
+    `List<SObject>`). Insertion order from `variables[]` is preserved —
+    we deliberately do not sort, to keep the signature aligned with the
+    flow author's declared order.
+    """
+    if not isinstance(flow_metadata_record, dict):
+        return None
+    md = flow_metadata_record.get("Metadata")
+    if not isinstance(md, dict):
+        # Test convenience: accept a bare Metadata dict, not just the full row.
+        if "variables" in flow_metadata_record:
+            md = flow_metadata_record
+        else:
+            return None
+
+    variables = md.get("variables") or []
+    if not isinstance(variables, list):
+        return None
+
+    def _render_type(var: dict) -> str:
+        data_type = (var.get("dataType") or "").strip()
+        obj_type = (var.get("objectType") or "").strip()
+        apex_class = (var.get("apexClass") or "").strip()
+        dt_lower = data_type.lower()
+        # sObject variables carry the concrete SObject name in `objectType`
+        # (e.g. `Case`). Apex-typed variables carry the concrete class name
+        # in `apexClass` (e.g. `CX_OrgSelector.Org`). Without the apexClass
+        # branch, collections of Apex-typed values render as the useless
+        # `List<Apex>` instead of `List<CX_OrgSelector.Org>`.
+        if dt_lower == "sobject" and obj_type:
+            base = obj_type
+        elif dt_lower == "apex" and apex_class:
+            base = apex_class
+        else:
+            base = data_type or "Object"
+        if var.get("isCollection"):
+            return f"List<{base}>"
+        return base
+
+    inputs: list[str] = []
+    outputs: list[str] = []
+    for v in variables:
+        if not isinstance(v, dict):
+            continue
+        name = v.get("name")
+        if not name:
+            continue
+        rendered = f"{name}: {_render_type(v)}"
+        if v.get("isInput"):
+            inputs.append(rendered)
+        if v.get("isOutput"):
+            outputs.append(rendered)
+
+    if not inputs and not outputs:
+        return None
+
+    parts: list[str] = []
+    if inputs:
+        parts.append("in: " + ", ".join(inputs))
+    if outputs:
+        parts.append("out: " + ", ".join(outputs))
+    return " | ".join(parts)
+
+
+def _stamp_signatures(
+    node: dict,
+    apex_sigs: dict[str, str],
+    flow_sigs: dict[str, str],
+    flow_reasons: dict[str, str] | None = None,
+) -> None:
+    """Recursively stamp `node["signature"]` on matching APEX / FLOW leaves.
+
+    Shared utility flows / helpers that appear in multiple branches all
+    receive the same stamped signature — they point at the same
+    FlowDefinition / ApexClass, so the signature is the same.
+
+    Gap 2 fix (2026-05-05): when a FLOW leaf has no signature but *does*
+    have an explanation in `flow_reasons` (e.g. managed-pkg body not
+    retrievable via the Data API fallback), stamp `node["_signature_reason"]`
+    so the renderer can distinguish a silent hole from a known limitation.
+    """
+    if not isinstance(node, dict):
+        return
+    kind = node.get("kind")
+    name = node.get("api_name")
+    if kind == "APEX" and name and name in apex_sigs:
+        node["signature"] = apex_sigs[name]
+    elif kind == "FLOW" and name:
+        if name in flow_sigs:
+            node["signature"] = flow_sigs[name]
+        elif flow_reasons and name in flow_reasons:
+            node["_signature_reason"] = flow_reasons[name]
+    for child in node.get("children") or []:
+        _stamp_signatures(child, apex_sigs, flow_sigs, flow_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Gap C (2026-05-05): prompt template body retrieve + stamp
+# ---------------------------------------------------------------------------
+
+
+def _is_prompt_ttype(ttype: str) -> bool:
+    """Mirror the ttype predicate used by `_route` /
+    `_normalize_prompt_template_id_targets` so collection + rewrite +
+    retrieve all recognize the same action kind."""
+    t = (ttype or "").strip().lower()
+    return (
+        t in ("prompttemplate", "generatepromptresponse")
+        or t.startswith("prompt")
+        or t.startswith("genai")
+    )
+
+
+def _collect_prompt_template_names(bundle_parsed: dict) -> set[str]:
+    """Walk topics + plannerActions, collect prompt-template DeveloperNames.
+
+    Called AFTER `_normalize_prompt_template_id_targets` — any 0hf-prefix
+    Id that resolved via Wave B's Id-list-metadata should already be a
+    DeveloperName. Defensive: drop anything that still looks Id-shaped
+    (0hf prefix) so we don't send a malformed
+    `GenAiPromptTemplate:0hfUv...` spec to the retrieve CLI.
+    """
+    names: set[str] = set()
+
+    def _collect(action: dict) -> None:
+        ttype = action.get("invocationTargetType") or ""
+        if not _is_prompt_ttype(ttype):
+            return
+        target = action.get("invocationTarget")
+        if not isinstance(target, str) or not target:
+            return
+        if target[:3].lower() == "0hf":
+            # Id never got rewritten — the list_metadata lookup missed it
+            # (managed-pkg template, permission issue). Skip; it stays in
+            # _pending_fetches with the Id as the key.
+            return
+        names.add(target)
+
+    for topic in bundle_parsed.get("topics") or []:
+        for action in topic.get("actions") or []:
+            _collect(action)
+    for action in bundle_parsed.get("plannerActions") or []:
+        _collect(action)
+    return names
+
+
+def _collect_flow_nested_prompt_template_names(
+    node: dict,
+    already_retrieved: dict[str, dict],
+    out: set[str],
+) -> None:
+    """Walk the finalized tree and collect PROMPT_TEMPLATE leaves whose
+    body wasn't stamped during the bundle-scoped retrieve.
+
+    Bundle-scoped `_collect_prompt_template_names` only sees prompt
+    templates declared as top-level topic/planner InvocationTargets.
+    Prompt templates referenced from inside a Flow (via a
+    `generatePromptResponse` actionCall) are discovered later during
+    Wave B's BFS of flow XML and end up as PROMPT_TEMPLATE leaves in the
+    tree — but their names never reached the first retrieve, so their
+    `_body_available` stays False and content is silently lost.
+
+    Defensive: drop 0hf-Id-shape names (managed-pkg templates whose Id
+    never rewrote to a DeveloperName) — sending
+    `GenAiPromptTemplate:0hfUv...` to the retrieve CLI yields a
+    malformed spec; the Id stays in `_pending_fetches.PROMPT_TEMPLATE`
+    as intended.
+    """
+    if not isinstance(node, dict):
+        return
+    if node.get("kind") == "PROMPT_TEMPLATE":
+        name = node.get("api_name")
+        if (
+            isinstance(name, str)
+            and name
+            and name[:3].lower() != "0hf"
+            and not node.get("_body_available", False)
+        ):
+            body = already_retrieved.get(name)
+            if not (body and body.get("content")):
+                out.add(name)
+    for child in node.get("children") or []:
+        _collect_flow_nested_prompt_template_names(child, already_retrieved, out)
+
+
+def _stamp_prompt_template_bodies(
+    node: dict,
+    bodies: dict[str, dict],
+) -> None:
+    """Recursively stamp prompt-template body fields onto matching
+    PROMPT_TEMPLATE leaves.
+
+    For each leaf whose `api_name` matches a key in `bodies`, attach:
+      - master_label, content, inputs, active_version_identifier
+      - _body_available = True
+
+    Leaves with no matching body get `_body_available = False` so the
+    renderer can distinguish "no body retrieved" from "body successfully
+    empty". Shared templates appearing in multiple branches receive the
+    same stamped body (they reference the same DeveloperName).
+    """
+    if not isinstance(node, dict):
+        return
+    kind = node.get("kind")
+    name = node.get("api_name")
+    if kind == "PROMPT_TEMPLATE" and name:
+        body = bodies.get(name)
+        if body:
+            node["master_label"] = body.get("masterLabel")
+            node["content"] = body.get("content")
+            node["inputs"] = body.get("inputs") or []
+            node["active_version_identifier"] = body.get(
+                "activeVersionIdentifier"
+            )
+            node["_body_available"] = True
+        else:
+            node["_body_available"] = False
+    for child in node.get("children") or []:
+        _stamp_prompt_template_bodies(child, bodies)
+
+
+# ---------------------------------------------------------------------------
+# Phase 9: build declared_action_tree.json via parse_wave primitives
+# ---------------------------------------------------------------------------
+
+
+def _run_parse_wave(
+    bot_info: dict,
+    bundle_parsed: dict,
+    wave_b: dict,
+    args: argparse.Namespace,
+    work_dir: Path,
+) -> dict:
+    """Invoke parse_wave's init_tree + root-children builder in-process.
+
+    parse_wave was written to be invoked as a subprocess with env vars
+    carrying AGENT_API_NAME / AGENT_VERSION / BOT_ID / etc. For Phase 2
+    Batch 1 we set those env vars transiently and call the module's
+    public helpers — no subprocess overhead, same behavior.
+    """
+    import parse_wave
+
+    # parse_wave reads these via os.environ.
+    prior_env = {
+        "AGENT_API_NAME": os.environ.get("AGENT_API_NAME"),
+        "AGENT_VERSION": os.environ.get("AGENT_VERSION"),
+        "BOT_ID": os.environ.get("BOT_ID"),
+        "BOT_MASTER_LABEL": os.environ.get("BOT_MASTER_LABEL"),
+        "VERSION_AUTO_PICKED": os.environ.get("VERSION_AUTO_PICKED"),
+    }
+    os.environ["AGENT_API_NAME"] = args.agent_api_name
+    os.environ["AGENT_VERSION"] = bot_info["version"]
+    os.environ["BOT_ID"] = bot_info["bot_id"]
+    os.environ["BOT_MASTER_LABEL"] = bot_info["master_label"]
+    os.environ["VERSION_AUTO_PICKED"] = "true" if bot_info["version_auto_picked"] else "false"
+
+    try:
+        # Persist the bundle for parse_wave's finalize_cap path.
+        bundle_out = work_dir / "_bundle_parsed.json"
+        bundle_out.write_text(json.dumps(bundle_parsed, indent=2))
+
+        # Persist a fake _bot_definition.json so init_tree reads real
+        # metadata for the agent block.
+        bd_file = work_dir / "_bot_definition.json"
+        bd_file.write_text(json.dumps({
+            "result": {"records": [bot_info.get("bot_definition") or {}]},
+        }))
+
+        tree = parse_wave.init_tree(work_dir, bundle_parsed)
+
+        # Build root children + track bundle-derived BFS refs.
+        # call the public `empty_kind_sets` /
+        # `BFS_KINDS` symbols — reaching into `parse_wave._*` reopened the
+        # leading-underscore surface that closed for `redact_text`.
+        visited_by_kind = parse_wave.empty_kind_sets()
+        aux_visited: set[tuple[str, str]] = set()
+        children, bundle_refs = parse_wave.build_root_children(
+            bundle_parsed, visited_by_kind, aux_visited,
+        )
+        tree["root"]["children"] = children
+
+        # Merge Flow metadata into flow_children. parse_wave wants this as
+        # `{flow_name: [child_refs]}`. Build it from the in-memory
+        # `Flow.Metadata` JSON Wave B already fetched — the Tooling REST
+        # API decodes the `Metadata` complexvalue field into a plain dict,
+        # so no XML parsing is needed (see `_build_flow_children` +
+        # fixture `CLASSIC_FLOW_METADATA`). Without this, every FLOW leaf
+        # in `metadata_tree.json` shipped with `children: []` and the
+        # user's recursive-tree view was flat.
+        flow_children = _build_flow_children(
+            wave_b["flow_metadata"], wave_b["flow_def_rows"],
+        )
+
+        # BFS routing for bundle refs.
+        pending_by_kind, _cycles = parse_wave.bfs_step(
+            parse_wave.empty_kind_sets(), visited_by_kind, bundle_refs,
+        )
+
+        # Depth-cap accumulator threaded through inflate.
+        depth_cap_pending = parse_wave.empty_kind_sets()
+        parse_wave.walk_and_inflate(
+            tree["root"], flow_children, pending_out=depth_cap_pending,
+        )
+
+        # Merge any Apex / Flow we actually fetched into visited — they
+        # no longer count as pending.
+        for row in wave_b["apex_rows"]:
+            nm = row.get("Name")
+            if nm:
+                visited_by_kind["APEX"].add(nm)
+        for row in wave_b["flow_def_rows"]:
+            nm = row.get("DeveloperName")
+            if nm:
+                visited_by_kind["FLOW"].add(nm)
+        # Gap C (2026-05-05): prompt templates whose bodies we retrieved
+        # count as visited and must drop out of _pending_fetches.
+        # Templates the retrieve didn't return (permission / managed-pkg /
+        # retrieve failure) stay out of `visited` so they surface there,
+        # mirroring the Flow-by-name "no rows = stays pending" pattern.
+        prompt_template_bodies = wave_b.get("prompt_template_bodies") or {}
+        for name in prompt_template_bodies:
+            if name:
+                visited_by_kind["PROMPT_TEMPLATE"].add(name)
+
+        # Stamp Apex / Flow signatures onto every matching tree node so
+        # render_architecture.py can populate Section 7. Wave B already
+        # fetched SymbolTable (Apex) + Metadata (Flow); we just project it
+        # onto `{kind, api_name}` leaves here. Shared utility flows /
+        # helpers that appear in multiple positions all receive the same
+        # stamped signature — that's the correct behavior (same definition).
+        apex_sigs: dict[str, str] = {}
+        for row in wave_b["apex_rows"]:
+            nm = row.get("Name")
+            if not nm:
+                continue
+            sig = _derive_apex_signature(row)
+            if sig:
+                apex_sigs[nm] = sig
+
+        flow_sigs: dict[str, str] = {}
+        # Gap 2 fix (2026-05-05): explain silent signature holes. Managed
+        # flows come back from `fetch_flow_definition_ids_by_names` via the
+        # FlowDefinitionView fallback with _source="FlowDefinitionView",
+        # ActiveVersionId=None, _body_available=False — by design, since
+        # managed-pkg flow bodies are IP-protected. Previously every such
+        # row produced an unexplained "_Signature not captured._" in the
+        # rendered markdown. Now we surface the structural reason.
+        #
+        # For the generic "no usable metadata record" case (Tooling row
+        # present but flow_metadata missing — e.g. metadata fetch failed
+        # or the flow has no active version at all) we also stamp a reason
+        # so the renderer never silently drops the node.
+        flow_reasons: dict[str, str] = {}
+        flow_metadata_by_vid = wave_b.get("flow_metadata") or {}
+        for row in wave_b["flow_def_rows"]:
+            dev_name = row.get("DeveloperName") or row.get("_bare_developer_name")
+            if not dev_name:
+                continue
+            source = row.get("_source") or ""
+            if source == "FlowDefinitionView":
+                ns = row.get("NamespacePrefix") or ""
+                reason = (
+                    f"managed-package (ns={ns}); body not retrievable via Tooling/Metadata API"
+                    if ns
+                    else "managed-package; body not retrievable via Tooling/Metadata API"
+                )
+                flow_reasons[dev_name] = reason
+                continue
+            active_ver = row.get("ActiveVersionId")
+            if not active_ver:
+                flow_reasons[dev_name] = "no active version"
+                continue
+            md_record = flow_metadata_by_vid.get(active_ver)
+            if not md_record:
+                flow_reasons[dev_name] = "flow metadata fetch returned no record"
+                continue
+            sig = _derive_flow_signature(md_record)
+            if sig:
+                flow_sigs[dev_name] = sig
+            else:
+                flow_reasons[dev_name] = "flow metadata has no in/out params"
+
+        _stamp_signatures(tree["root"], apex_sigs, flow_sigs, flow_reasons)
+
+        # Gap C: stamp retrieved prompt-template bodies onto the tree.
+        # Leaves with a matching body gain content/master_label/inputs;
+        # leaves without get `_body_available = False` so the renderer
+        # can distinguish "retrieve missed" from "body truly absent".
+        _stamp_prompt_template_bodies(tree["root"], prompt_template_bodies)
+
+        for kind in parse_wave.BFS_KINDS:
+            pending_by_kind[kind] |= depth_cap_pending.get(kind, set())
+
+        depth_cap_tripped = any(depth_cap_pending[k] for k in parse_wave.BFS_KINDS)
+
+        tree["_pending_fetches"] = {
+            k: sorted(pending_by_kind.get(k, set()) - visited_by_kind.get(k, set()))
+            for k in parse_wave.BFS_KINDS
+        }
+
+        any_pending = any(tree["_pending_fetches"][k] for k in parse_wave.BFS_KINDS)
+        if depth_cap_tripped:
+            tree["_partial"] = True
+            tree["_partial_reason"] = "max-depth-cap"
+        elif any_pending:
+            tree["_partial"] = True
+            tree.setdefault("_partial_reason", "pending-refs")
+        else:
+            tree["_partial"] = False
+            tree["_partial_reason"] = None
+
+        # Surface Wave-B-level unresolved items (e.g. unknown ID prefixes).
+        for u in wave_b.get("unresolved", []) or []:
+            tree.setdefault("_unresolved", []).append(u)
+
+        node_count, depth, kind_counts = parse_wave.compute_stats(tree["root"])
+        tree["node_count"] = node_count
+        tree["depth"] = depth
+        tree["_kind_counts"] = kind_counts
+
+        all_visited: set[tuple[str, str]] = set(aux_visited)
+        for kind, names in visited_by_kind.items():
+            for n in names:
+                all_visited.add((kind, n))
+        tree["_visited"] = [list(v) for v in sorted(all_visited)]
+
+        tree_path = work_dir / "declared_action_tree.json"
+        tmp = tree_path.with_suffix(tree_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(tree, indent=2))
+        os.replace(tmp, tree_path)
+        return tree
+    finally:
+        # Restore env so test runners that reuse the process don't leak
+        # state across invocations.
+        for k, v in prior_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Phase 11: finalize
+# ---------------------------------------------------------------------------
+
+
+def _swap_dir_atomic(target: Path, staging: Path) -> None:
+    """Per-file overwrite from `staging` into `target` — preserves any
+    unrelated sibling content already present in `target`.
+
+    P0 fix (2026-05-05): the prior implementation did
+    ``os.replace(target, backup); os.replace(staging, target)`` — an
+    atomic whole-directory swap that was correct in isolation but
+    DESTRUCTIVE of co-tenants. The `<agent>__<ver>/` dir is co-tenanted:
+    co-tenants write per-session subdirs
+    (`<session_id>/`) alongside architecture's files. Swapping the whole
+    directory silently wiped every cached session trace.
+
+    New behavior: iterate `staging`'s immediate children and `os.replace`
+    each one into `target`. The directory `target` itself is never
+    moved or deleted, so any session subdirs under it survive.
+
+    Trade-off: the old helper supported atomic rollback (restore from
+    backup on failure). The per-file pattern cannot — a crash partway
+    through the loop leaves architecture's output in a split state
+    (some new files, some old). This is acceptable because:
+      - per-file `os.replace` is still atomic (no empty-path window
+        for any individual file, so the "concurrent reader sees
+        empty dir" bug that  addressed is still closed);
+      - `last_built_at.txt` is written LAST by the caller, so
+        consumers can treat its presence as the success sentinel;
+      - architecture is re-runnable, co-tenant session traces are not.
+
+    Callers must still guarantee `staging` is on the same filesystem as
+    `target` (helper constructs `staging` as a sibling of `target`, so
+    that holds by construction).
+    """
+    import shutil
+
+    if not staging.is_dir():
+        raise OSError(f"staging dir missing: {staging}")
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    for src in staging.iterdir():
+        dst = target / src.name
+        # Clear any existing destination so `os.replace` lands cleanly
+        # when the incoming type differs (file replacing dir or vice
+        # versa). For same-type overwrites `os.replace` would handle
+        # files on its own, but directories require an empty target or
+        # same-name existing dir — safer to unify both here.
+        if dst.exists() or dst.is_symlink():
+            if dst.is_dir() and not dst.is_symlink():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+        os.replace(src, dst)
+
+    # Staging should be empty now; best-effort teardown.
+    try:
+        staging.rmdir()
+    except OSError:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _run_finalize(
+    data_dir: Path,
+    cache_dir: Path,
+    tree: dict,
+    work_dir: Path,
+    agent_api_name: str,
+    agent_version: str,
+    planner_name: str,
+) -> None:
+    """Atomic-write tree + summary + manifest. Keep it simple.
+
+    For Phase 2 Batch 1 we replicate finalize.py's essential behavior
+    (tree + manifest) but skip the sf_meta mirror — there's no
+    sf_meta dir when main.py runs the pipeline SOQL-first. Metadata-API
+    retrieves land in Batch 2/3.
+
+    both `data_dir` and `cache_dir` are swapped
+    via `_swap_dir_atomic` to close the "rmtree then rename" empty-dir
+    window. A crash during the second swap restores the original from
+    the staging-sibling `.<name>.backup.<pid>` rather than leaving an
+    empty path.
+    """
+    import datetime as dt
+    import shutil
+
+    built_at = dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    tree_base = f"{agent_api_name}_{agent_version}_metadata_tree"
+
+    # Finalize's _partial computation. Mirrors finalize.py:109-117 — both
+    # buckets (_pending_fetches AND _unresolved) must be empty for a
+    # clean run. _unresolved captures wave-B failures (HTTP 4xx,
+    # iteration-cap exhaustion, managed-flow filter misses) that have
+    # already been moved out of _pending_fetches; checking only the
+    # latter would silently call a partial run "converged".
+    planner_ok = bool(planner_name)
+    pending_total = sum(len(v) for v in (tree.get("_pending_fetches") or {}).values())
+    unresolved_count = len(tree.get("_unresolved") or [])
+    waves_converged = pending_total == 0 and unresolved_count == 0
+    tree["_partial"] = not (planner_ok and waves_converged)
+    tree.pop("_visited", None)
+
+    # Pin deterministic child ordering as the last assembly step before
+    # the authoritative write. Shared with the standalone `finalize.py`
+    # subprocess so both paths produce byte-identical trees. Downstream
+    # readers see one canonical order from disk; they do not re-sort.
+    from finalize import sort_tree_in_place
+    sort_tree_in_place(tree.get("root") or {})
+
+    # staging names are siblings (same parent) so the
+    # `os.replace` used by `_swap_dir_atomic` is a same-filesystem atomic
+    # rename. `.staging.<pid>` disambiguates concurrent pipelines on the
+    # same host.
+    data_parent = data_dir.parent
+    data_staging = data_parent / f".{data_dir.name}.staging.{os.getpid()}"
+    if data_staging.exists():
+        shutil.rmtree(data_staging)
+    data_staging.mkdir(parents=True)
+    tree_out = data_staging / f"{tree_base}.json"
+    tree_out.write_text(json.dumps(tree, indent=2))
+
+    # P2.2-1: phase 10 (architecture.md renderer). Imported lazily so a
+    # renderer bug can't break the existing Batch 1 pipeline before the
+    # tree JSON has been written — the tree + manifest remain the
+    # authoritative outputs, architecture.md is a derived artifact.
+    #
+    # filename now self-identifying —
+    # `{agent_api_name}_{agent_version}_architecture.md` (e.g.
+    # `MyAgent_v5_architecture.md`). Same shape as the tree JSON,
+    # minus the `_metadata_tree` suffix. The `.error` sidecar follows
+    # the same shape.
+    arch_base = f"{agent_api_name}_{agent_version}"
+    arch_name = f"{arch_base}_architecture.md"
+    arch_error_name = f"{arch_base}_architecture.md.error"
+    try:
+        from render_architecture import render as _render_architecture
+        _render_architecture(tree_out, data_staging / arch_name)
+    except Exception as e:
+        # Best-effort: a render failure downgrades the run to "tree OK,
+        # architecture skipped" rather than aborting finalize. The
+        # reason string surfaces in the next-run logs for triage.
+        (data_staging / arch_error_name).write_text(
+            f"render_architecture failed: {type(e).__name__}: {e}\n"
+        )
+
+    # dropped `{tree_base}.summary.md` from the output contract —
+    # was a redundant summary of the tree JSON; consumers should read the
+    # JSON directly. See CHANGELOG for details.
+    (data_staging / "last_built_at.txt").write_text(built_at + "\n")
+
+    _swap_dir_atomic(data_dir, data_staging)
+
+    # CACHE_DIR staging — same two-phase swap.
+    cache_parent = cache_dir.parent
+    cache_staging = cache_parent / f".{cache_dir.name}.staging.{os.getpid()}"
+    if cache_staging.exists():
+        shutil.rmtree(cache_staging)
+    cache_staging.mkdir(parents=True)
+
+    manifest = {
+        "built_at_utc": built_at,
+        "schema_version": tree.get("_schema_version", SCHEMA_VERSION),
+        "agent": tree.get("agent", {}),
+        "node_count": tree.get("node_count", 0),
+        "depth": tree.get("depth", 0),
+        "kind_counts": tree.get("_kind_counts", {}),
+        "ttl_days": CACHE_TTL_DAYS,
+        "data_path": str(data_dir / f"{tree_base}.json"),
+        "partial": tree.get("_partial", False),
+        "unresolved_count": len(tree.get("_unresolved", []) or []),
+    }
+    (cache_staging / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    # Copy tree + bundle sidecar for cache replay
+    (cache_staging / "declared_action_tree.json").write_text(json.dumps(tree, indent=2))
+    bundle_src = work_dir / "_bundle_parsed.json"
+    if bundle_src.is_file():
+        (cache_staging / "_bundle_parsed.json").write_text(bundle_src.read_text())
+
+    _swap_dir_atomic(cache_dir, cache_staging)
+
+
+# ---------------------------------------------------------------------------
+# Emit helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_built_at_utc(cache_dir: Path | None) -> str:
+    if cache_dir is None:
+        return ""
+    try:
+        return json.loads((cache_dir / "manifest.json").read_text()).get("built_at_utc", "") or ""
+    except (OSError, ValueError):
+        return ""
+
+
+def _emit_fail(
+    args: argparse.Namespace,
+    extra_ctx: dict | None,
+    status: str,
+    error_detail: str = "",
+    start_epoch: float | None = None,
+) -> int:
+    """Write an .emit_ctx.json with STATUS=<status>.
+
+    STATUS enum (from emit_result.py):
+        OK, PARTIAL_OK, INVALID_INPUT, AUTH_REQUIRED, AGENT_NOT_FOUND,
+        AGENT_VERSION_NOT_FOUND, RETRIEVE_FAILED, WRITE_FAILED.
+
+    For probe failures, the plan's description suggested SCHEMA_DRIFT
+    but emit_result doesn't carry that enum value. We map probe failures
+    to RETRIEVE_FAILED with an explicit error_detail — the RESULT block's
+    ERROR_DETAIL carries the "schema-drift" reason. Adding a new enum
+    value would require touching emit_result (out of scope P1 primitive);
+    the mapping preserves emit_result's existing contract.
+
+    Returns the exit code the caller should return.
+    """
+    work_dir = Path(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ctx = {
+        "status": status,
+        "error_detail": error_detail,
+        "agent_api_name": args.agent_api_name,
+        "agent_version": args.agent_version or "",
+        "version_auto_picked": False,
+        "agent_generation": "unknown",
+        "bot_id": "",
+        "org_id_15": "",
+        "org_id_18": "",
+        "cache_hit": False,
+        "cached_at_utc": "",
+        "cache_path": "",
+        "output_json_path": "",
+        "output_summary_path": "",
+        "node_count": 0,
+        "depth": 0,
+        "partial": status == "PARTIAL_OK",
+        "partial_reason": "",
+        "pending_fetches_count": 0,
+        "unresolved_count": 0,
+        "available_bots": "",
+        "available_versions": "",
+        # Bug fix (2026-05-05): start_epoch captured once at pipeline entry
+        # and threaded through every _emit_* helper. Previously each helper
+        # re-captured time.time() AFTER the pipeline had already run, so
+        # emit_result.py computed WALL_TIME_SECONDS against a timestamp taken
+        # ~tens of seconds AFTER the real work finished and reported ~0.0s.
+        "start_epoch": start_epoch if start_epoch is not None else time.time(),
+        "data_dir": str(DATA_ROOT),
+        "work_dir": str(work_dir),
+        # failure paths never invoke the renderer.
+        "architecture_path": "",
+        "render_failed": False,
+        "render_error_detail": "",
+    }
+    if extra_ctx:
+        ctx.update(extra_ctx)
+    (work_dir / ".emit_ctx.json").write_text(json.dumps(ctx, indent=2))
+    return 1
+
+
+def _emit_cache_hit(
+    args: argparse.Namespace,
+    data_dir: Path,
+    cache_dir: Path,
+    manifest: dict,
+    start_epoch: float | None = None,
+    *,
+    org_id_15: str = "",
+    org_id_18: str = "",
+) -> int:
+    work_dir = Path(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    agent_version = manifest.get("agent", {}).get("version", "")
+    tree_base = f"{args.agent_api_name}_{agent_version}_metadata_tree"
+
+    # on a cache hit the renderer is NOT re-invoked — but the
+    # architecture.md from the prior run is a legitimate output of the
+    # cached data_dir. Surface it when present, skip the .error sidecar
+    # since render_failed semantics only apply to THIS run's renderer.
+    # filename rename to `{agent}_{ver}_architecture.md` —
+    # NB `tree_base` above still carries the `_metadata_tree` suffix (it
+    # names the JSON); architecture filenames drop the suffix.
+    arch_base = f"{args.agent_api_name}_{agent_version}"
+    arch_path = data_dir / f"{arch_base}_architecture.md"
+    architecture_path = str(arch_path) if arch_path.is_file() else ""
+
+    ctx = {
+        "status": "OK",
+        "error_detail": "",
+        "agent_api_name": args.agent_api_name,
+        "agent_version": manifest.get("agent", {}).get("version", ""),
+        "version_auto_picked": manifest.get("agent", {}).get("_version_auto_picked", False),
+        "agent_generation": manifest.get("agent", {}).get("generation", "unknown"),
+        "bot_id": manifest.get("agent", {}).get("bot_id", ""),
+        "org_id_15": org_id_15,
+        "org_id_18": org_id_18,
+        "cache_hit": True,
+        "cached_at_utc": manifest.get("built_at_utc", ""),
+        "cache_path": str(cache_dir),
+        "output_json_path": str(data_dir / f"{tree_base}.json"),
+        # summary.md dropped from the output contract. Field kept
+        # empty for RESULT-block shape stability.
+        "output_summary_path": "",
+        "node_count": int(manifest.get("node_count", 0) or 0),
+        "depth": int(manifest.get("depth", 0) or 0),
+        "partial": bool(manifest.get("partial", False)),
+        "partial_reason": "",
+        "pending_fetches_count": 0,
+        "unresolved_count": int(manifest.get("unresolved_count", 0) or 0),
+        "available_bots": "",
+        "available_versions": "",
+        # Bug fix (2026-05-05): see _emit_fail note — start_epoch is captured
+        # at pipeline entry and threaded through. Cache-hit paths are short-
+        # running so the drift is smaller, but the field should still reflect
+        # the invocation's real wall time.
+        "start_epoch": start_epoch if start_epoch is not None else time.time(),
+        "data_dir": str(data_dir),
+        "work_dir": str(work_dir),
+        # architecture-render outcome signals. render_failed
+        # stays False for cache replays — that flag tracks THIS run's
+        # renderer, not the cached run's; a cache hit implies no retry.
+        "architecture_path": architecture_path,
+        "render_failed": False,
+        "render_error_detail": "",
+    }
+    (work_dir / ".emit_ctx.json").write_text(json.dumps(ctx, indent=2))
+    return 0
+
+
+def _emit_ok(
+    args: argparse.Namespace,
+    data_dir: Path,
+    tree: dict,
+    bot_info: dict,
+    org_id_15: str,
+    start_epoch: float | None = None,
+    cache_dir: Path | None = None,
+    org_id_18: str = "",
+) -> int:
+    work_dir = Path(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    agent_version = bot_info["version"]
+    tree_base = f"{args.agent_api_name}_{agent_version}_metadata_tree"
+    pending_total = sum(len(v) for v in (tree.get("_pending_fetches") or {}).values())
+
+    # surface architecture-render outcome on the success path.
+    # finalize writes either `{agent}_{ver}_architecture.md` (render OK) or
+    # `{agent}_{ver}_architecture.md.error` (render raised) into the
+    # data_dir; we read whichever is present and plumb the fields through
+    # the ctx. emit_result consumes the boolean to auto-promote
+    # OK -> PARTIAL_OK when the tree landed but the diagram render failed.
+    # filename rename — self-identifying shape. `tree_base` above
+    # is for the JSON path (carries `_metadata_tree`); architecture uses
+    # the unsuffixed agent+version base.
+    arch_base = f"{args.agent_api_name}_{agent_version}"
+    arch_path = data_dir / f"{arch_base}_architecture.md"
+    arch_sidecar = data_dir / f"{arch_base}_architecture.md.error"
+    architecture_path = str(arch_path) if arch_path.is_file() else ""
+    render_failed = arch_sidecar.is_file()
+    render_error_detail = ""
+    if render_failed:
+        try:
+            raw = arch_sidecar.read_text(errors="replace").strip()
+        except OSError:
+            raw = ""
+        if raw:
+            # Single-line cap, 200-char truncation, scrubbed via the
+            # rest_client redactor (same contract as write_emit_ctx).
+            from rest_client import redact_text as _redact
+            render_error_detail = _redact(raw.splitlines()[0])[:200]
+
+    ctx = {
+        "status": "PARTIAL_OK" if tree.get("_partial") else "OK",
+        "error_detail": "",
+        "agent_api_name": args.agent_api_name,
+        "agent_version": bot_info["version"],
+        "version_auto_picked": bot_info["version_auto_picked"],
+        "agent_generation": tree.get("agent", {}).get("generation", "unknown"),
+        "bot_id": bot_info["bot_id"],
+        "org_id_15": org_id_15,
+        # Gap 3 fix (2026-05-05): the 18-char id is available from
+        # `sf org display` in _derive_org_ids but was previously dropped.
+        # Now threaded from pipeline entry so the RESULT contract field is
+        # actually populated on success.
+        "org_id_18": org_id_18,
+        "cache_hit": False,
+        "cached_at_utc": _read_built_at_utc(cache_dir),
+        # Gap 4 fix (2026-05-05): non-cache-hit runs write the manifest into
+        # `cache_dir` (see _run_finalize) so the field should point at the
+        # same path a subsequent invocation would probe. Caller passes the
+        # already-computed cache_dir; we skip the leading-empty fallback
+        # only when it's truly unknown (shouldn't happen on _emit_ok).
+        "cache_path": str(cache_dir) if cache_dir is not None else "",
+        "output_json_path": str(data_dir / f"{tree_base}.json"),
+        # summary.md dropped from the output contract.
+        "output_summary_path": "",
+        "node_count": int(tree.get("node_count", 0) or 0),
+        "depth": int(tree.get("depth", 0) or 0),
+        "partial": bool(tree.get("_partial", False)),
+        "partial_reason": tree.get("_partial_reason") or "",
+        "pending_fetches_count": pending_total,
+        "unresolved_count": len(tree.get("_unresolved", []) or []),
+        "available_bots": "",
+        "available_versions": "",
+        # Bug fix (2026-05-05): see _emit_fail note — start_epoch threaded
+        # from pipeline entry so WALL_TIME_SECONDS reflects the full run.
+        "start_epoch": start_epoch if start_epoch is not None else time.time(),
+        "data_dir": str(data_dir),
+        "work_dir": str(work_dir),
+        # architecture-render outcome signals.
+        "architecture_path": architecture_path,
+        "render_failed": render_failed,
+        "render_error_detail": render_error_detail,
+    }
+    (work_dir / ".emit_ctx.json").write_text(json.dumps(ctx, indent=2))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline(args: argparse.Namespace, start_epoch: float) -> int:  # noqa: PLR0911, PLR0915
+    """Execute the 12-phase pipeline. Extracted from `main()` so the
+    top-level entry point can wrap any uncaught exception in a RESULT
+    block .
+
+    Every structured failure path here already routes through
+    `_emit_fail` and returns a non-zero exit code. Exceptions that
+    escape this function are, by definition, bugs we hadn't thought of
+    yet — `main()` catches them so the skill contract (RESULT block on
+    every exit path) holds regardless.
+    """
+    work_dir = Path(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Phase 2 Batch 1: single creds cell shared between provider + refresh.
+    # Refresh mutates the cell; provider reads it on every attempt — this
+    # is the `` refresh contract.
+    #
+    # Wave B fetches run N concurrent Flow.Metadata
+    # calls through parallel_retrieve.fetch_bodies_parallel. `refresh_fn`
+    # serializes behind a lock + 1-second monotonic dedupe window so
+    # concurrent 401s don't each fork their own `sf org display`. See
+    # `_build_creds_plumbing`.
+    try:
+        initial = _resolve_creds(args.org_alias)
+    except (AuthRequired, SfCliError) as e:
+        return _emit_fail(
+            args, None, "AUTH_REQUIRED",
+            error_detail=redact_error(e),
+            start_epoch=start_epoch,
+        )
+
+    creds_provider, refresh_fn, _creds_cell = _build_creds_plumbing(
+        initial,
+        resolve_creds=lambda: _resolve_creds(args.org_alias),
+    )
+
+    # Phase 2.5: derive org_id_15 + org_id_18 + api_version
+    try:
+        org_id_15, org_id_18, api_version = _derive_org_ids(args.org_alias)
+    except (AuthRequired, SfCliError) as e:
+        return _emit_fail(
+            args, None, "AUTH_REQUIRED",
+            error_detail=redact_error(e),
+            start_epoch=start_epoch,
+        )
+
+    # Phase 3: probe channels
+    channels = probe_channels(
+        args.org_alias, org_id_15, api_version,
+        force_refresh=args.reprobe,
+    )
+    if channels.get("status") == "PROBE_FAILED":
+        # Plan suggested STATUS=SCHEMA_DRIFT; emit_result's STATUS enum
+        # doesn't include that value. Mapping to RETRIEVE_FAILED with a
+        # "schema-drift" ERROR_DETAIL preserves the existing enum
+        # contract while surfacing the cause. A future batch may add
+        # SCHEMA_DRIFT to the enum; that change lives in emit_result.
+        missing = [
+            (sobj, e.get("mandatory_missing", []))
+            for sobj, e in (channels.get("channels") or {}).items()
+            if e.get("mandatory_missing")
+        ]
+        return _emit_fail(
+            args, None, "RETRIEVE_FAILED",
+            error_detail=f"schema-drift: mandatory fields missing: {missing[:3]}",
+            start_epoch=start_epoch,
+        )
+
+    # Phase 4: resolve bot + version
+    try:
+        bot_info = _resolve_bot(
+            args.agent_api_name, args.agent_version,
+            creds_provider, refresh_fn,
+            api_version=api_version,
+        )
+    except (RestClientError, SoqlParamError) as e:
+        return _emit_fail(
+            args, None, "AUTH_REQUIRED",
+            error_detail=redact_error(e),
+            start_epoch=start_epoch,
+        )
+
+    if bot_info is None:
+        # AGENT_NOT_FOUND — emit without a list-of-available-bots context.
+        # The unbounded bot-list SELECT was removed (LIMIT-less unfiltered
+        # query on BotDefinition). Operators can run their own SOQL if
+        # they need to enumerate available bots.
+        return _emit_fail(
+            args,
+            {"org_id_15": org_id_15},
+            "AGENT_NOT_FOUND",
+            error_detail=f"BotDefinition.DeveloperName '{args.agent_api_name}' not found",
+            start_epoch=start_epoch,
+        )
+
+    if bot_info.get("_version_not_found"):
+        vers_csv = ",".join(
+            f"{v['version']}({v['status']})" for v in bot_info.get("all_versions", [])
+        )
+        return _emit_fail(
+            args,
+            {"available_versions": vers_csv, "org_id_15": org_id_15},
+            "AGENT_VERSION_NOT_FOUND",
+            error_detail=f"No matching BotVersion (requested: {args.agent_version!r})",
+            start_epoch=start_epoch,
+        )
+
+    # Phase 5: cache check
+    data_dir = build_agent_data_dir(org_id_15, args.agent_api_name, bot_info["version"])
+    cache_dir = build_agent_cache_dir(org_id_15, args.agent_api_name, bot_info["version"])
+    if not args.force_refresh:
+        manifest = _cache_is_fresh(cache_dir)
+        if manifest is not None:
+            return _emit_cache_hit(
+                args, data_dir, cache_dir, manifest,
+                start_epoch=start_epoch,
+                org_id_15=org_id_15,
+                org_id_18=org_id_18,
+            )
+
+    # Phase 6: Wave A — 7 queries, DAG-ordered parallel layers. A1 now
+    # takes (agent_api_name, version) and resolves the canonical planner
+    # DeveloperName from the live chain naming invariant (v1 = <Agent>,
+    # vN = <Agent>...%\_vN); the row's DeveloperName becomes the
+    # authoritative `planner_name` for finalize/render downstream.
+    try:
+        wave_a = _run_wave_a(
+            args.agent_api_name, bot_info["version"],
+            creds_provider, refresh_fn,
+            api_version=api_version,
+            parallelism=args.parallelism,
+        )
+    except (RestClientError, SoqlParamError) as e:
+        return _emit_fail(
+            args, None, "RETRIEVE_FAILED",
+            error_detail=f"wave-a-failed:{redact_error(e)}",
+            start_epoch=start_epoch,
+        )
+
+    if wave_a is None:
+        return _emit_fail(
+            args, {"org_id_15": org_id_15},
+            "AGENT_NOT_FOUND",
+            error_detail=(
+                f"GenAiPlannerDefinition chain not found for "
+                f"agent={args.agent_api_name!r} version={bot_info['version']!r}"
+            ),
+            start_epoch=start_epoch,
+        )
+
+    # Phase 7: join Wave A → bundle-shaped dict
+    bundle_parsed = _join_wave_a_to_bundle(bot_info, wave_a)
+
+    # Phase 8: Wave B — body fetches
+    try:
+        wave_b = _run_wave_b(
+            bundle_parsed,
+            creds_provider, refresh_fn,
+            api_version=api_version,
+            org_alias=args.org_alias,
+            parallelism=args.parallelism,
+        )
+    except (RestClientError, SoqlParamError) as e:
+        return _emit_fail(
+            args, None, "RETRIEVE_FAILED",
+            error_detail=f"wave-b-failed:{redact_error(e)}",
+            start_epoch=start_epoch,
+        )
+
+    # Phase 8.5: iterative Wave B — follow subflow + apex refs from fetched
+    # Flow.Metadata bodies until fixed-point. Without this pass, shared
+    # utility flows (handleFlowFault) and nested subflows ship as empty
+    # leaves even though their bodies are reachable via Tooling API.
+    # Iteration cap safeguards against pathological flow graphs.
+    try:
+        wave_b = _iterate_wave_b(
+            wave_b,
+            creds_provider, refresh_fn,
+            api_version=api_version,
+            org_alias=args.org_alias,
+            parallelism=args.parallelism,
+            max_iterations=5,
+        )
+    except (RestClientError, SoqlParamError) as e:
+        return _emit_fail(
+            args, None, "RETRIEVE_FAILED",
+            error_detail=f"wave-b-iter-failed:{redact_error(e)}",
+            start_epoch=start_epoch,
+        )
+
+    # normalize Flow-ID InvocationTargets → DeveloperName.
+    # Classic ReAct bots occasionally store NGA-style 300Uv-prefix Flow IDs
+    # in GenAiFunctionDefinition.InvocationTarget (observed in one real-org
+    # benchmark run, 6 flows out of 6). Wave B's fetch_flow_definition_by_ids
+    # successfully resolves them, but the resolved DeveloperName never
+    # propagates back into bundle_parsed — so parse_wave sees the raw ID as
+    # the flow's api_name, which never matches visited["FLOW"] (keyed on
+    # DeveloperName), and every such flow ends up in _pending_fetches.
+    # Result: PARTIAL_OK on what should be OK, plus unreadable Flow IDs in
+    # rendered architecture.md.
+    #
+    # Fix: rewrite bundle_parsed's action invocationTarget in-place from
+    # ID → DeveloperName using wave_b["flow_def_rows"] (both the IN-by-names
+    # and the IN-by-ids branches populate it). Unresolved IDs (Flow not
+    # found in the org) stay as-is and will land in _pending_fetches as
+    # intended (they really are unresolved).
+    _normalize_flow_id_targets(bundle_parsed, wave_b["flow_def_rows"])
+
+    # Bug 1 fix (2026-05-05): analogous rewrite for GenAiPromptTemplate Ids.
+    # Wave B's prompt-template Id fetch resolves 0hf-prefix Ids to
+    # DeveloperNames; without this rewrite the bundle would enqueue the
+    # raw Id into _pending_fetches.PROMPT_TEMPLATE and the downstream
+    # Metadata retrieve would never match.
+    _normalize_prompt_template_id_targets(
+        bundle_parsed, wave_b.get("prompt_template_id_rows") or [],
+    )
+
+    # Gap B fix (2026-05-05): analogous rewrite for ApexClass Ids.
+    # Wave B's fetch_apex_bodies_by_ids resolves 01p-prefix Ids to ApexClass
+    # Name; without this rewrite the bundle would enqueue the raw Id into
+    # _pending_fetches.APEX and the tree would render the bare Id instead
+    # of the class name.
+    _normalize_apex_id_targets(
+        bundle_parsed, wave_b.get("apex_rows") or [],
+    )
+
+    # Gap C fix (2026-05-05): retrieve GenAiPromptTemplate bodies.
+    # GenAiPromptTemplate is NOT SOQL-queryable (Tooling or Data API). The
+    # only way to fetch the body is `sf project retrieve start
+    # --metadata GenAiPromptTemplate:<name>,...`. After
+    # _normalize_prompt_template_id_targets has rewritten 0hf-Ids to
+    # DeveloperNames, collect the names and retrieve in a single sf
+    # subprocess call. The resulting bodies get stashed on wave_b so
+    # _run_parse_wave can stamp them onto PROMPT_TEMPLATE leaves (parallel
+    # to the Apex/Flow signature stamping pattern).
+    prompt_template_names = _collect_prompt_template_names(bundle_parsed)
+    prompt_template_bodies: dict[str, dict] = {}
+    if prompt_template_names:
+        try:
+            prompt_template_bodies = retrieve_prompt_templates(
+                args.org_alias,
+                sorted(prompt_template_names),
+                work_dir,
+            )
+        except AuthRequired:
+            raise
+        except SfCliError as e:
+            wave_b.setdefault("unresolved", []).append({
+                "kind": "PROMPT_TEMPLATE",
+                "reason": f"prompt-template-retrieve-failed:{redact_error(e)}",
+            })
+    wave_b["prompt_template_bodies"] = prompt_template_bodies
+
+    # Phase 9: parse_wave -> declared_action_tree.json
+    try:
+        tree = _run_parse_wave(bot_info, bundle_parsed, wave_b, args, work_dir)
+    except (OSError, KeyError) as e:
+        return _emit_fail(
+            args, None, "WRITE_FAILED",
+            error_detail=f"parse-wave-failed:{redact_error(e)}",
+            start_epoch=start_epoch,
+        )
+
+    # Phase 10: render architecture.md — invoked inline from _run_finalize
+    # so the write lands in the same staging dir as the tree JSON and
+    # participates in the atomic _swap_dir_atomic below. See P2.2-1.
+
+    # Flow-nested prompt-template catch-up (2026-05-05). The bundle-scoped
+    # retrieve at step 1 above only covers prompt templates declared as
+    # top-level topic/planner InvocationTargets. Templates referenced from
+    # inside a Flow (via a `generatePromptResponse` actionCall) are
+    # discovered during parse_wave's BFS of flow XML — too late for the
+    # first retrieve. Without this second pass their `_body_available`
+    # stays False and the md renders `_Body not retrieved._` with no
+    # PARTIAL flag (silent content loss). `_stamp_prompt_template_bodies`
+    # is idempotent, so re-stamping already-stamped leaves is safe.
+    flow_nested_names: set[str] = set()
+    _collect_flow_nested_prompt_template_names(
+        tree["root"], prompt_template_bodies, flow_nested_names,
+    )
+    if flow_nested_names:
+        try:
+            more_bodies = retrieve_prompt_templates(
+                args.org_alias,
+                sorted(flow_nested_names),
+                work_dir,
+            )
+        except AuthRequired:
+            raise
+        except SfCliError as e:
+            tree.setdefault("_unresolved", []).append({
+                "kind": "PROMPT_TEMPLATE",
+                "reason": f"prompt-template-retrieve-failed:{redact_error(e)}",
+            })
+        else:
+            prompt_template_bodies.update(more_bodies)
+            _stamp_prompt_template_bodies(tree["root"], prompt_template_bodies)
+            # _kind_counts / _pending_fetches are unchanged: the leaves
+            # already existed and were counted; this pass only attaches
+            # body content to them. No BFS-kind reshuffling needed.
+
+    # Phase 11: finalize. The canonical planner_name now comes from the
+    # resolved planner row (Wave A), which joins into bundle_parsed as
+    # `plannerName`; fall back to the agent api name if the resolver
+    # returned a row without a DeveloperName (shouldn't happen on a
+    # healthy planner but keeps finalize's _partial flag well-defined).
+    planner_name = bundle_parsed.get("plannerName") or args.agent_api_name
+    try:
+        _run_finalize(
+            data_dir, cache_dir, tree, work_dir,
+            args.agent_api_name, bot_info["version"],
+            planner_name,
+        )
+    except OSError as e:
+        return _emit_fail(
+            args, None, "WRITE_FAILED",
+            error_detail=f"finalize-failed:{redact_error(e)}",
+            start_epoch=start_epoch,
+        )
+
+    # Phase 12: emit RESULT
+    return _emit_ok(
+        args, data_dir, tree, bot_info, org_id_15,
+        start_epoch=start_epoch,
+        cache_dir=cache_dir,
+        org_id_18=org_id_18,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point — parses args, runs pipeline, guarantees a RESULT block.
+
+    the skill contract promises that every exit
+    path emits `=== RESULT ===` with a structured STATUS. The prior
+    implementation let any uncaught exception from the pipeline (e.g.
+    the HTTP 405 from , or any future bug we haven't foreseen)
+    propagate to the top of the process — the user saw a Python
+    traceback on stderr and the wrapper skill never got its RESULT
+    block. We now wrap `_run_pipeline` in a broad `except Exception` and
+    funnel uncaught failures through `_emit_fail` with
+    STATUS=RETRIEVE_FAILED + ERROR_DETAIL="uncaught-exception: <redacted
+    message>". `redact_error` keeps tokens / full-URL querystrings out
+    of the ctx file. `SystemExit` + `KeyboardInterrupt` are NOT caught —
+    argparse's `--help` path + Ctrl-C must propagate normally.
+    """
+    args = parse_args(argv)
+    # Bug fix (2026-05-05): capture start_epoch ONCE at real pipeline entry
+    # and thread it through every _emit_* call so WALL_TIME_SECONDS measures
+    # actual pipeline duration, not ctx-write→emit_result drift.
+    start_epoch = time.time()
+    try:
+        return _run_pipeline(args, start_epoch)
+    except Exception as exc:
+        # broad catch — anything that reaches here is a bug
+        # but the skill contract requires a structured exit. redact_error
+        # strips bearer tokens and accessToken values from the message
+        # ; the exception class name leads the detail so triage
+        # can still identify the shape even when the message is terse.
+        redacted = redact_error(exc)
+        return _emit_fail(
+            args,
+            None,
+            "RETRIEVE_FAILED",
+            error_detail=f"uncaught-exception: {redacted}",
+            start_epoch=start_epoch,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/metadata_listing.py
+++ b/skills/investigating-agentforce-architecture/scripts/metadata_listing.py
@@ -1,0 +1,265 @@
+"""Metadata API listMetadata wrappers — for sObjects that are NOT
+exposed via SOQL on Tooling or Data API (e.g. GenAiPromptTemplate).
+
+Wraps the sf CLI `sf org list metadata` recipe. Not a REST client call —
+uses subprocess via sf_cli.run_sf. Failure semantics mirror the rest:
+returns [] on known-missing + surfaces unresolved reasons upstream;
+raises SfCliError / AuthRequired on unknown failures.
+"""
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+from rest_client import redact_error
+from sf_cli import (
+    AuthRequired,
+    _redact_subprocess_stderr,
+    _stderr_matches_auth,
+    run_sf,
+)
+
+
+# Metadata XML default namespace — same as parse_bundle.NS. Duplicated
+# (rather than imported) to keep the "no intra-skill imports" convention
+# documented throughout the pipeline.
+_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+
+
+def list_prompt_template_metadata(org_alias: str) -> List[Dict[str, str]]:
+    """Return every GenAiPromptTemplate metadata component in the org.
+
+    Each row has the shape produced by `sf org list metadata --json`:
+      {"id": "0hfUv...", "fullName": "AGNT_...", "type": "GenAiPromptTemplate",
+       "namespacePrefix": "...", ...}
+
+    Empty list on success with no templates. Raises SfCliError on CLI
+    failure (caller decides whether to treat as fatal).
+    """
+    data = run_sf("list_metadata_genaiprompttemplate", ORG_ALIAS=org_alias)
+    result = data.get("result")
+    if not isinstance(result, list):
+        return []
+    return [r for r in result if isinstance(r, dict)]
+
+
+def _find_text(el: ET.Element | None, path: str) -> str | None:
+    if el is None:
+        return None
+    found = el.find(path, _NS)
+    if found is None:
+        return None
+    return found.text
+
+
+def _parse_prompt_template_xml(xml_bytes: bytes) -> Dict[str, Any] | None:
+    """Parse a single .genAiPromptTemplate XML file into a body dict.
+
+    Returns None on parse failure so the caller can log + skip. The
+    returned dict carries developerName/masterLabel/activeVersionIdentifier/
+    content/inputs — absent optional fields become None or empty lists.
+
+    Version selection: if multiple <templateVersions> elements exist,
+    prefer the one whose `versionIdentifier` matches the template-level
+    `activeVersionIdentifier`; otherwise fall back to the first version.
+    """
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError:
+        return None
+
+    developer_name = _find_text(root, "sf:developerName")
+    master_label = _find_text(root, "sf:masterLabel")
+    active_version = _find_text(root, "sf:activeVersionIdentifier")
+
+    versions = root.findall("sf:templateVersions", _NS)
+    picked: ET.Element | None = None
+    if versions:
+        if active_version:
+            for v in versions:
+                vid = _find_text(v, "sf:versionIdentifier")
+                if vid and vid == active_version:
+                    picked = v
+                    break
+        if picked is None:
+            picked = versions[0]
+
+    content = _find_text(picked, "sf:content") if picked is not None else None
+
+    inputs: List[Dict[str, str]] = []
+    if picked is not None:
+        for inp in picked.findall("sf:inputs", _NS):
+            name = _find_text(inp, "sf:apiName") or _find_text(inp, "sf:name")
+            data_type = _find_text(inp, "sf:dataType")
+            if name is None and data_type is None:
+                continue
+            entry: Dict[str, str] = {}
+            if name is not None:
+                entry["name"] = name
+            if data_type is not None:
+                entry["dataType"] = data_type
+            inputs.append(entry)
+
+    return {
+        "developerName": developer_name,
+        "masterLabel": master_label,
+        "activeVersionIdentifier": active_version,
+        "content": content,
+        "inputs": inputs,
+    }
+
+
+# Timeout for `sf project retrieve start` — matches the prior YAML recipe's
+# `timeout_seconds: 300`. Kept as a module constant (rather than a literal
+# at the call site) so future adjustments have a single home.
+_RETRIEVE_TIMEOUT_SECONDS = 300
+
+# stderr patterns that mean "the CLI ran but there is no authenticated org
+# for this alias" — reraised as AuthRequired. Mirrors the prior recipe's
+# `auth_required_stderr_patterns` field.
+_RETRIEVE_AUTH_PATTERNS = ("NoOrgAuthenticationError", "AuthInfoError")
+
+
+def _run_retrieve(argv: List[str], timeout: int) -> "subprocess.CompletedProcess[str]":
+    """Thin wrapper over `subprocess.run` for the retrieve-start call.
+
+    Exists so tests can mock the subprocess boundary without also mocking
+    the argv-construction logic — see `RetrievePromptTemplatesTests`.
+    """
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def retrieve_prompt_templates(
+    org_alias: str,
+    template_names: List[str],
+    work_dir: Path,
+) -> Dict[str, Dict[str, Any]]:
+    """Retrieve GenAiPromptTemplate bodies via `sf project retrieve start`.
+
+    The sf plugin's `--metadata` flag is REPEATED once per requested
+    template (`--metadata GenAiPromptTemplate:A --metadata
+    GenAiPromptTemplate:B ...`). A comma-joined value is NOT a valid list;
+    the CLI treats the whole comma-joined string as a single malformed
+    member name, silently skips it, and the resulting zip contains only
+    `package.xml` (observed 2026-05-05 against my-org-alias). Hence we
+    bypass the YAML recipe loader here — `run_sf` substitutes
+    `{{METADATA_SPEC}}` single-shot and has no list-expansion primitive.
+
+    The resulting `unpackaged.zip` carries one `.genAiPromptTemplate` XML
+    file per template under `unpackaged/genAiPromptTemplates/`.
+
+    Returns a dict keyed by `developerName`. Templates the retrieve
+    didn't produce a file for are OMITTED (caller handles missing by
+    leaving them in `_pending_fetches`).
+
+    Failure modes:
+      - Empty `template_names` → short-circuits with `{}` and no sf call.
+      - `AuthRequired` (stderr matches auth patterns) → re-raised.
+      - `SfCliError` (any other non-zero exit, timeout, etc) → swallowed;
+        returns `{}`. Caller logs the retrieval-failure reason at the
+        call site.
+      - Zip missing or malformed → returns `{}`.
+      - XML parse failure on a specific file → that file is skipped; the
+        other templates in the same zip still parse and return.
+    """
+    if not template_names:
+        return {}
+
+    retrieve_dir = work_dir / "prompt_template_retrieve"
+    retrieve_dir.mkdir(parents=True, exist_ok=True)
+    # Nuke stale files from a prior invocation so we don't trust an old
+    # unpackaged.zip if this run's sf call fails before writing one.
+    for path in retrieve_dir.iterdir():
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            _rm_tree(path)
+
+    argv: List[str] = [
+        "sf",
+        "project",
+        "retrieve",
+        "start",
+        "--target-org",
+        org_alias,
+        "--target-metadata-dir",
+        str(retrieve_dir),
+        "--json",
+    ]
+    for name in template_names:
+        argv.extend(["--metadata", f"GenAiPromptTemplate:{name}"])
+
+    try:
+        cp = _run_retrieve(argv, _RETRIEVE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as e:
+        # timeout exceptions may carry stderr; route through
+        # redact_error before surfacing — then swallow as non-fatal, same
+        # contract the old run_sf-based path had for SfCliError.
+        _ = redact_error(e)
+        return {}
+    except (OSError, subprocess.SubprocessError) as e:
+        _ = redact_error(e)
+        return {}
+
+    if cp.returncode != 0:
+        # Classify: auth failure re-raises, everything else is non-fatal.
+        if _stderr_matches_auth(cp.stderr, _RETRIEVE_AUTH_PATTERNS):
+            safe_stderr = _redact_subprocess_stderr(cp.stderr)
+            raise AuthRequired(safe_stderr or "auth required")
+        return {}
+
+    zip_path = retrieve_dir / "unpackaged.zip"
+    if not zip_path.exists():
+        return {}
+
+    results: Dict[str, Dict[str, Any]] = {}
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            for info in zf.infolist():
+                name = info.filename
+                if not name.endswith(".genAiPromptTemplate"):
+                    continue
+                if "genAiPromptTemplates/" not in name:
+                    continue
+                try:
+                    xml_bytes = zf.read(info)
+                except (KeyError, zipfile.BadZipFile):
+                    continue
+                body = _parse_prompt_template_xml(xml_bytes)
+                if not body:
+                    continue
+                dev_name = body.get("developerName")
+                if not dev_name:
+                    # Fall back to the file stem if the XML somehow lacks
+                    # a <developerName> element — keeps the caller's
+                    # lookup working.
+                    stem = Path(name).stem
+                    if stem:
+                        body["developerName"] = stem
+                        dev_name = stem
+                if dev_name:
+                    results[dev_name] = body
+    except zipfile.BadZipFile:
+        return {}
+
+    return results
+
+
+def _rm_tree(path: Path) -> None:
+    """Recursively delete a directory tree. stdlib-only, no shutil import
+    at module top to keep the import surface minimal."""
+    for child in path.iterdir():
+        if child.is_dir():
+            _rm_tree(child)
+        else:
+            child.unlink()
+    path.rmdir()

--- a/skills/investigating-agentforce-architecture/scripts/parallel_retrieve.py
+++ b/skills/investigating-agentforce-architecture/scripts/parallel_retrieve.py
@@ -1,0 +1,69 @@
+"""ThreadPoolExecutor orchestrator for Wave B body fetches.
+
+one failure MUST NOT abort the whole run. Callers merge failed kinds
+into `_unresolved[]` with `reason=f'{kind}-fetch-failed:{redact_error(exc)}'`
+and emit STATUS=PARTIAL_OK. We return a mixed list of (ok, result_or_exc)
+tuples instead of raising on the first failure — which is what
+`ThreadPoolExecutor.map` would do (and silently cancel remaining work in
+the process).
+
+Exception identity is preserved on the failure path: callers get the exact
+exception object back so they can run it through `rest_client.redact_error`
+at the point of logging. We intentionally do NOT stringify here — doing so
+would lose structured info (urllib.error.HTTPError.code, etc.) and could
+leak tokens into intermediate strings before redaction runs.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable
+
+
+def fetch_bodies_parallel(
+    tasks: list[Callable[[], object]],
+    *,
+    max_workers: int = 5,
+) -> list[tuple[bool, object]]:
+    """Run zero-arg callables in parallel; return (ok, result_or_exc) per task.
+
+    contract:
+      * Each `task` is a zero-arg callable (use `functools.partial` to bind
+        args at the call site).
+      * On success, `(True, return_value)` is appended.
+      * On any exception, `(False, exc)` is appended — the EXC object itself,
+        not a stringification. Callers run it through `rest_client.redact_error`
+        before logging.
+      * Results are returned in INPUT ORDER, not completion order. Callers
+        frequently zip results back to their input tasks to identify which
+        target failed; completion order would break that contract.
+      * Empty task list returns `[]` without spinning up a pool.
+      * `max_workers=1` serializes — tasks run sequentially but the as_completed
+        path is still used (deterministic ordering preserved via index map).
+      * This function NEVER raises on a task failure. It may propagate
+        programmer errors (e.g., a non-callable in `tasks`) at submit time;
+        that's a bug surface, not a runtime failure mode.
+    """
+    if not tasks:
+        return []
+
+    # Pre-size the results list so we can assign by input index. This keeps
+    # output ordering deterministic and independent of completion timing,
+    # which matters for callers that identify failures positionally.
+    results: list[tuple[bool, object] | None] = [None] * len(tasks)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        future_to_idx = {pool.submit(task): i for i, task in enumerate(tasks)}
+        for fut in as_completed(future_to_idx):
+            idx = future_to_idx[fut]
+            try:
+                results[idx] = (True, fut.result())
+            except Exception as exc:  # noqa: BLE001 — see contract above
+                # Preserve exc identity; do NOT stringify here. Callers run
+                # this through rest_client.redact_error at log time .
+                # We catch Exception (not BaseException) so KeyboardInterrupt
+                # / SystemExit still propagate — those signal shutdown, not a
+                # task failure.
+                results[idx] = (False, exc)
+
+    # All slots filled by construction — futures/indexes are 1:1 with input.
+    return [r for r in results if r is not None]  # type: ignore[return-value]

--- a/skills/investigating-agentforce-architecture/scripts/parse_bundle.py
+++ b/skills/investigating-agentforce-architecture/scripts/parse_bundle.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Parse Bot.bot + GenAiPlannerBundle → _bundle_parsed.json + PLANNER_NAME.
+
+Replaces old agent Phase 2a (Bot.bot planner-name extraction via XPath-ish
+walk) + Phase 2c (bundle XML → topics/plannerActions + generation classifier).
+
+Step 1 — planner name:
+  Read $WORK_DIR/sf_meta/wave1_bot/unpackaged/bots/*.bot XML.
+  Path: /Bot/botVersions[fullName==$AGENT_VERSION]/conversationDefinitionPlanners[0]
+         /genAiPlannerName (fallback: plannerName, fullName)
+
+Step 2 — bundle (only if planner name resolved AND bundle dir exists):
+  Read $WORK_DIR/sf_meta/wave1_bundle/unpackaged/genAiPlannerBundles/<plannerName>/
+       *.genAiPlannerBundle
+  Extract: plannerType, description, masterLabel, localTopics[] with inline
+  localActions[], and (classic-only) plannerActions[].
+  Classify generation:
+    plannerType startswith "AiCopilot__"  → classic
+    plannerType startswith "Atlas__"      → nga
+    else                                   → unknown
+
+Emits:
+  $WORK_DIR/_bundle_parsed.json   (full structured extraction)
+  $WORK_DIR/_agent_generation.txt (generation string, newline-terminated)
+  stdout: `PLANNER_NAME=<shlex-quoted>\nAGENT_GENERATION=<shlex-quoted>`
+          + log lines (topic counts, action counts) for human readability.
+
+If Bot.bot has no <conversationDefinitionPlanners>, prints `PLANNER_NAME=''`
+and exits 0 — caller treats the tree as partial.
+
+Usage:
+    eval "$(python3 parse_bundle.py)"
+
+Inputs (env):
+    WORK_DIR       required
+    AGENT_VERSION  required — used to pin the right <botVersions> element
+
+Outputs:
+    files (above)
+    stdout eval-friendly K=V lines
+    exit 0 always (no recoverable error condition; missing XML → empty planner)
+"""
+import json
+import os
+import pathlib
+import shlex
+import sys
+import xml.etree.ElementTree as ET
+
+
+NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+
+
+def _t(el, p):
+    if el is None:
+        return None
+    x = el.find(p, NS)
+    return x.text if x is not None else None
+
+
+def classify_generation(planner_type: str) -> str:
+    if not planner_type:
+        return "unknown"
+    if planner_type.startswith("AiCopilot__"):
+        return "classic"
+    if planner_type.startswith("Atlas__"):
+        return "nga"
+    return "unknown"
+
+
+def extract_planner_name(work_dir: pathlib.Path, target_ver: str) -> str:
+    bots_dir = work_dir / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+    if not bots_dir.exists():
+        return ""
+    for bot_file in bots_dir.glob("*.bot"):
+        try:
+            root = ET.parse(bot_file).getroot()
+        except ET.ParseError:
+            continue
+        for bv in root.findall("sf:botVersions", NS):
+            full = _t(bv, "sf:fullName") or _t(bv, "sf:developerName")
+            if target_ver and full != target_ver:
+                continue
+            for cdp in bv.findall("sf:conversationDefinitionPlanners", NS):
+                n = (_t(cdp, "sf:genAiPlannerName")
+                     or _t(cdp, "sf:plannerName")
+                     or _t(cdp, "sf:fullName"))
+                if n:
+                    return n
+    return ""
+
+
+def extract_bundle(work_dir: pathlib.Path, planner_name: str) -> dict:
+    bundle = {
+        "plannerType": None,
+        "plannerName": planner_name or None,
+        "generation": "unknown",
+        "description": None,
+        "masterLabel": None,
+        "topics": [],
+        "plannerActions": [],
+    }
+
+    planner_root = work_dir / "sf_meta" / "wave1_bundle" / "unpackaged" / "genAiPlannerBundles"
+    if not planner_root.exists():
+        return bundle
+
+    for bundle_dir in planner_root.iterdir():
+        if not bundle_dir.is_dir():
+            continue
+        bundle_xml = list(bundle_dir.glob("*.genAiPlannerBundle"))
+        if not bundle_xml:
+            continue
+        try:
+            root = ET.parse(bundle_xml[0]).getroot()
+        except ET.ParseError as e:
+            sys.stderr.write(f"parse_bundle.py: XML parse error on {bundle_xml[0]}: {e}\n")
+            continue
+
+        bundle["plannerType"] = _t(root, "sf:plannerType")
+        bundle["generation"] = classify_generation(bundle["plannerType"])
+        bundle["description"] = _t(root, "sf:description")
+        bundle["masterLabel"] = _t(root, "sf:masterLabel")
+
+        for lt in root.findall("sf:localTopics", NS):
+            tname = _t(lt, "sf:developerName") or _t(lt, "sf:fullName")
+            if not tname:
+                continue
+            topic = {
+                "name": tname,
+                "localDeveloperName": _t(lt, "sf:localDeveloperName"),
+                "masterLabel": _t(lt, "sf:masterLabel"),
+                "description": _t(lt, "sf:description"),
+                "canEscalate": (_t(lt, "sf:canEscalate") or "false").lower() == "true",
+                "pluginType": _t(lt, "sf:pluginType"),
+                "actions": [],
+            }
+            for la in lt.findall("sf:localActions", NS):
+                aname = _t(la, "sf:developerName") or _t(la, "sf:fullName")
+                if not aname:
+                    continue
+                topic["actions"].append({
+                    "name": aname,
+                    "localDeveloperName": _t(la, "sf:localDeveloperName"),
+                    "masterLabel": _t(la, "sf:masterLabel"),
+                    "description": _t(la, "sf:description"),
+                    "invocationTarget": _t(la, "sf:invocationTarget"),
+                    "invocationTargetType": (_t(la, "sf:invocationTargetType") or "").strip(),
+                    "source": _t(la, "sf:source"),
+                })
+            bundle["topics"].append(topic)
+
+        for pa in root.findall("sf:plannerActions", NS):
+            aname = _t(pa, "sf:developerName") or _t(pa, "sf:fullName")
+            if not aname:
+                continue
+            bundle["plannerActions"].append({
+                "name": aname,
+                "localDeveloperName": _t(pa, "sf:localDeveloperName"),
+                "masterLabel": _t(pa, "sf:masterLabel"),
+                "description": _t(pa, "sf:description"),
+                "invocationTarget": _t(pa, "sf:invocationTarget"),
+                "invocationTargetType": (_t(pa, "sf:invocationTargetType") or "").strip(),
+                "source": _t(pa, "sf:source"),
+            })
+        break  # first bundle dir is enough
+    return bundle
+
+
+def atomic_write(path: pathlib.Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def main() -> int:
+    try:
+        work_dir = pathlib.Path(os.environ["WORK_DIR"])
+        agent_version = os.environ["AGENT_VERSION"]
+    except KeyError as e:
+        sys.stderr.write(f"parse_bundle.py: missing env {e}\n")
+        return 1
+
+    # Step 1: planner name
+    planner_name = extract_planner_name(work_dir, agent_version)
+
+    # Step 2: bundle (only if planner resolved)
+    bundle = extract_bundle(work_dir, planner_name) if planner_name else {
+        "plannerType": None, "plannerName": None, "generation": "unknown",
+        "description": None, "masterLabel": None, "topics": [], "plannerActions": [],
+    }
+
+    atomic_write(work_dir / "_bundle_parsed.json", json.dumps(bundle, indent=2))
+    atomic_write(work_dir / "_agent_generation.txt", bundle["generation"] + "\n")
+
+    # Log lines (stderr would be lost via eval; use stderr for logs not shell-consumed)
+    total_actions = (
+        sum(len(t["actions"]) for t in bundle["topics"]) + len(bundle["plannerActions"])
+    )
+    sys.stderr.write(
+        f"[parse_bundle] plannerName={planner_name!r} "
+        f"plannerType={bundle['plannerType']!r} generation={bundle['generation']}\n"
+        f"[parse_bundle]   topics={len(bundle['topics'])} "
+        f"topic-scope-actions={sum(len(t['actions']) for t in bundle['topics'])} "
+        f"bundle-scope-actions={len(bundle['plannerActions'])} total={total_actions}\n"
+    )
+
+    # Eval-friendly stdout
+    sys.stdout.write(f"PLANNER_NAME={shlex.quote(planner_name)}\n")
+    sys.stdout.write(f"AGENT_GENERATION={shlex.quote(bundle['generation'])}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/parse_wave.py
+++ b/skills/investigating-agentforce-architecture/scripts/parse_wave.py
@@ -1,0 +1,844 @@
+#!/usr/bin/env python3
+"""Idempotent wave parser — builds `$WORK_DIR/declared_action_tree.json`.
+
+Replaces old agent Phase 4 (wave-2 init) + Phase 5/6 re-parse + MAX_WAVE cap.
+One script, one code path. The "init vs re-parse" distinction is keyed on the
+presence of `declared_action_tree.json` at call time.
+
+Flow:
+  1. Load bundle JSON, bot_definition JSON, existing tree (if any).
+  2. Walk every $WORK_DIR/sf_meta/*/unpackaged/ dir:
+     - flows/*.flow: parse actionCalls → APEX/PROMPT_TEMPLATE/STANDARD_ACTION/
+       UNKNOWN children; subflows → FLOW children. Record flow_children[flow_name].
+       Mark ("FLOW", flow_name) visited.
+     - classes/*.cls-meta.xml: mark ("APEX", name) visited.
+     - genAiPromptTemplates/*.genAiPromptTemplate: mark ("PROMPT_TEMPLATE", name).
+  3. Build tree if missing (Phase-4 init):
+     - agent metadata from bot_definition + bundle
+     - root BOT_DEFINITION node with children = topics[] only
+       (plannerActions[] retained in the bundle shape for back-compat but
+       always empty — a planner never has direct functions, 2026-05-05)
+     - each topic → TOPIC node with GEN_AI_FUNCTION children (from inline actions)
+     - each GEN_AI_FUNCTION → unwraps_to + leaf child (Flow/Apex/Prompt/Std/Unk)
+  4. Inflate every FLOW leaf recursively (depth ≤ 6) with flow_children data.
+  5. Recompute `_pending_fetches` (names not yet in visited set).
+  6. Walk tree for `node_count`, `depth`, `_kind_counts`.
+  7. Atomic write.
+
+With --finalize-cap: after loading tree, move all remaining _pending_fetches
+items to _unresolved[] with reason "max-wave-depth exceeded".
+
+Usage:
+    python3 parse_wave.py                  # init or re-parse
+    python3 parse_wave.py --finalize-cap   # drain _pending_fetches → _unresolved
+
+Inputs (env):
+    WORK_DIR, AGENT_API_NAME, AGENT_VERSION, BOT_ID, BOT_MASTER_LABEL,
+    VERSION_AUTO_PICKED
+
+Outputs:
+    $WORK_DIR/declared_action_tree.json (atomic write)
+    stderr: log lines (node counts, pending counts, etc.)
+    exit 0 on success, 1 on write failure
+"""
+import json
+import os
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+
+
+NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+
+
+def _t(el, p):
+    if el is None:
+        return None
+    x = el.find(p, NS)
+    return x.text if x is not None else None
+
+
+def classify_bundle_action(action: dict) -> dict:
+    """Bundle-action classifier — duplicated in plan_wave.py per 'no
+    intra-skill imports' convention. Matches old agent's Phase 3/4 logic.
+
+    Returns (unwraps_dict, leaf_dict) as in the old agent Phase 4's
+    action_node(). leaf_dict is the child appended under the GEN_AI_FUNCTION
+    node; unwraps_dict is the compact form stored on the function itself.
+    """
+    tgt = action.get("invocationTarget")
+    ttype = (action.get("invocationTargetType") or "").lower()
+    if not tgt:
+        return None, None
+    if ttype == "flow":
+        return ({"kind": "FLOW", "api_name": tgt},
+                {"kind": "FLOW", "api_name": tgt, "children": []})
+    if ttype == "apex":
+        return ({"kind": "APEX", "api_name": tgt},
+                {"kind": "APEX", "api_name": tgt})
+    if ttype == "generatepromptresponse" or ttype.startswith("prompt") or ttype.startswith("genai"):
+        return ({"kind": "PROMPT_TEMPLATE", "api_name": tgt},
+                {"kind": "PROMPT_TEMPLATE", "api_name": tgt})
+    # Canonical field name is `invocation_type` (schema 3.1). Prior
+    # versions wrote `raw_invocation_type` on bundle-sourced nodes and
+    # `raw_action_type` on flow-actionCall-sourced nodes — downstream
+    # readers (render_architecture._display_name, summarize_tree) fall
+    # back to both legacy keys for one release.
+    if ttype == "standardinvocableaction":
+        return ({"kind": "STANDARD_ACTION", "api_name": tgt, "invocation_type": ttype},
+                {"kind": "STANDARD_ACTION", "api_name": tgt, "invocation_type": ttype})
+    return ({"kind": "UNKNOWN", "api_name": tgt, "invocation_type": ttype},
+            {"kind": "UNKNOWN", "api_name": tgt, "invocation_type": ttype})
+
+
+def classify_action_call(at: str, an: str, element_name: str) -> dict:
+    """Flow actionCall classifier (old Phase 4 logic).
+
+    Canonical field name is `invocation_type` (schema 3.1). Legacy readers
+    still fall back to `raw_action_type` for one release.
+    """
+    at = at or ""
+    if at == "apex" and an:
+        return {"kind": "APEX", "element_name": element_name, "api_name": an}
+    if at == "generatePromptResponse" and an:
+        return {"kind": "PROMPT_TEMPLATE", "element_name": element_name, "api_name": an}
+    if at:
+        # Any other non-empty actionType → STANDARD_ACTION; preserve raw.
+        return {"kind": "STANDARD_ACTION", "element_name": element_name,
+                "api_name": an or at, "invocation_type": at}
+    return {"kind": "UNKNOWN", "element_name": element_name,
+            "api_name": an or "?", "invocation_type": at or ""}
+
+
+# ---------------------------------------------------------------------------
+# pure BFS step helper. Visited sets are tuple-keyed on
+# (kind, canonical_name). Pending is a dict-by-kind so cross-kind collisions
+# (Flow Foo vs Apex Foo) stay distinct.
+#
+# this is the single source of truth for wave-level BFS. Both
+# `harvest_waves` and `main()` route through here so the tuple-keyed
+# semantics are active on the production path — not just under unit tests.
+#
+# kind tokens match the runtime tree's `kind` field
+# (FLOW/APEX/PROMPT_TEMPLATE/STANDARD_ACTION). The persisted
+# `_pending_fetches` dict uses the SAME tokens so internal + on-disk
+# conventions don't diverge.
+#
+# promoted from `_BFS_KINDS` → `BFS_KINDS` so
+# cross-module callers (main.py's in-process orchestrator) import a stable
+# public symbol instead of reaching across a leading-underscore boundary.
+# Same pattern as rest_client.redact_text's promotion. The underscore
+# alias below is retained for backwards compatibility and will be removed
+# in the next minor version; new code MUST use `BFS_KINDS`.
+# unified node-truncation annotation. When a node is not fully
+# expanded (either because of a cycle back to an ancestor, or because the
+# MAX_BFS_DEPTH cap tripped), we annotate it with a `_truncated` sub-
+# object of shape `{"reason": <str>, "target": <str>}`. `reason` is one
+# of the values below; `target` is a `"KIND:name"` path pointing at the
+# first encounter (cycle) or the unreached leaf (depth-cap). Downstream
+# consumers check `_truncated["reason"]` once; no per-reason pattern
+# matching.
+#
+# Backcompat: `_cycle_back_to` is emitted alongside `_truncated` for any
+# consumer that hasn't migrated (render_architecture, summarize_tree,
+# third-party tooling). Will be removed in the next minor version.
+TRUNCATION_CYCLE = "cycle"
+TRUNCATION_MAX_DEPTH = "max-depth"
+TRUNCATION_REASONS = frozenset({TRUNCATION_CYCLE, TRUNCATION_MAX_DEPTH})
+
+
+BFS_KINDS = ("FLOW", "APEX", "PROMPT_TEMPLATE", "STANDARD_ACTION")
+
+# STANDARD_ACTION is a Salesforce-owned builtin (e.g.
+# `streamKnowledgeSearch`, `createRecord`, `sendEmail`). These are never
+# fetched — they're declared-only leaves, with the action name carrying
+# all the identity. Keeping STANDARD_ACTION in BFS_KINDS lets the tree's
+# _kind_counts tally include them and visited-bookkeeping dedup against
+# them, but they must never accumulate into `_pending_fetches`. A name
+# like `streamKnowledgeSearch` landing in _pending_fetches.STANDARD_ACTION
+# is pollution — the pipeline isn't "missing" anything; the action is
+# simply declared and never materialized.
+#
+# Callers: when collecting refs into `new_refs`, gate on FETCHABLE_KINDS
+# rather than BFS_KINDS to avoid polluting pending buckets with leaves.
+FETCHABLE_KINDS = ("FLOW", "APEX", "PROMPT_TEMPLATE")
+
+# deprecated alias. Retained so existing tests and any lingering
+# `from parse_wave import _BFS_KINDS` imports keep working. New code MUST
+# use `BFS_KINDS` (public). Planned removal in the next minor version.
+_BFS_KINDS = BFS_KINDS
+
+
+def bfs_step(
+    pending_by_kind: dict[str, set[str]],
+    visited_by_kind: dict[str, set[str]],
+    new_refs_by_kind: dict[str, set[str]],
+) -> tuple[dict[str, set[str]], list[tuple[str, str]]]:
+    """Advance one BFS wave. Returns (new_pending_by_kind, cycles).
+
+    `cycles` is a list of (kind, name) tuples for refs that were already
+    visited on this wave — callers use these to annotate `_cycle_back_to`.
+
+    Self-cycles (a ref pointing at something already visited) are filtered
+    out of pending. Cross-type tuples (Flow Foo + Apex Foo) are distinct —
+    both land in their respective pending buckets.
+
+    unknown kinds RAISE — this is an internal API; a typo in a caller
+    is a programming error, not a recoverable runtime condition. Silent drop
+    produced false confidence (the dropped ref never got fetched and no log
+    ever mentioned it). Callers must filter to `BFS_KINDS` upstream.
+    """
+    new_pending: dict[str, set[str]] = {k: set() for k in BFS_KINDS}
+    cycles: list[tuple[str, str]] = []
+    for kind, refs in new_refs_by_kind.items():
+        if kind not in BFS_KINDS:
+            raise ValueError(
+                f"unknown BFS kind {kind!r}; must be one of {sorted(BFS_KINDS)}"
+            )
+        visited = visited_by_kind.get(kind, set())
+        for name in refs:
+            if name in visited:
+                cycles.append((kind, name))
+                continue
+            # Not yet visited AND not already pending on a prior wave:
+            # OR-in unconditionally — `pending |= (new - visited)` semantics.
+            new_pending[kind].add(name)
+    # Merge with the caller's existing pending. Caller passes the authoritative
+    # pending buckets; we return the delta merged in so they can just replace.
+    merged: dict[str, set[str]] = {k: set(pending_by_kind.get(k, set())) for k in BFS_KINDS}
+    for kind, names in new_pending.items():
+        merged[kind] |= names
+    return merged, cycles
+
+
+def empty_kind_sets() -> dict[str, set[str]]:
+    """Build a fresh {kind: set()} dict covering every BFS_KINDS entry.
+
+    callers use this to seed per-kind visited / pending
+    buckets. Keeping it centralized means new kinds added to BFS_KINDS
+    automatically flow through harvest_waves, bfs_step, and main().
+
+    promoted from `_empty_kind_sets` → public so
+    cross-module callers (main.py) can import a stable name instead of
+    reaching into a private symbol. The underscore alias below is kept
+    for backwards compatibility; it will be removed in the next minor
+    version.
+    """
+    return {k: set() for k in BFS_KINDS}
+
+
+# deprecated alias. Retained for backwards compatibility with any
+# lingering `from parse_wave import _empty_kind_sets` imports; new code
+# MUST use `empty_kind_sets` (public). Planned removal in the next minor
+# version.
+_empty_kind_sets = empty_kind_sets
+
+
+def harvest_waves(
+    work_dir: pathlib.Path,
+) -> tuple[dict[str, list[dict]], dict[str, set[str]], dict[str, set[str]], list[tuple[str, str]]]:
+    """Walk sf_meta/*/unpackaged/ dirs.
+
+    Returns (flow_children, visited_by_kind, pending_by_kind, cycles).
+
+    every ref collected from Flow XML (actionCalls + subflows)
+    is routed through `bfs_step` per-flow. The tuple-keyed visited set is
+    the authoritative record; flat per-name sets have been removed.
+
+    the two dicts are keyed by `BFS_KINDS` tokens
+    (FLOW/APEX/PROMPT_TEMPLATE/STANDARD_ACTION) — matching the runtime
+    tree's `kind` field and the on-disk `_pending_fetches` layout.
+    """
+    flow_children: dict[str, list[dict]] = {}
+    visited_by_kind: dict[str, set[str]] = empty_kind_sets()
+    pending_by_kind: dict[str, set[str]] = empty_kind_sets()
+    cycles: list[tuple[str, str]] = []
+
+    sf_meta = work_dir / "sf_meta"
+    if not sf_meta.exists():
+        return flow_children, visited_by_kind, pending_by_kind, cycles
+
+    all_wave_dirs = sorted(
+        p / "unpackaged" for p in sf_meta.iterdir()
+        if p.is_dir() and (p / "unpackaged").exists()
+    )
+
+    # Pass 1: flows (+ route per-flow refs through bfs_step).
+    for wave_dir in all_wave_dirs:
+        flows_dir = wave_dir / "flows"
+        if not flows_dir.exists():
+            continue
+        for f in sorted(flows_dir.glob("*.flow")):
+            flow_name = f.stem
+            if flow_name in flow_children:
+                continue  # already harvested this wave dir (earlier iter)
+            visited_by_kind["FLOW"].add(flow_name)
+            try:
+                root = ET.parse(f).getroot()
+            except ET.ParseError:
+                flow_children[flow_name] = []
+                continue
+            children: list[dict] = []
+            # Collect per-flow refs into kind-bucketed sets for one bfs_step.
+            new_refs: dict[str, set[str]] = empty_kind_sets()
+            for ac in root.findall("sf:actionCalls", NS):
+                n = _t(ac, "sf:name")
+                at = _t(ac, "sf:actionType") or ""
+                an = _t(ac, "sf:actionName")
+                item = classify_action_call(at, an, n)
+                children.append(item)
+                k = item["kind"]
+                api = item["api_name"]
+                # Only route FETCHABLE kinds into `new_refs` — STANDARD_ACTION
+                # items stay as leaf children with no further fetching implied
+                # . UNKNOWN items are similarly skipped.
+                if k in FETCHABLE_KINDS and api:
+                    new_refs[k].add(api)
+            for sub in root.findall("sf:subflows", NS):
+                n = _t(sub, "sf:name")
+                fn = _t(sub, "sf:flowName")
+                if fn:
+                    children.append({"kind": "FLOW", "element_name": n, "api_name": fn})
+                    new_refs["FLOW"].add(fn)
+            flow_children[flow_name] = children
+            # bfs_step is the canonical merge point.
+            pending_by_kind, step_cycles = bfs_step(
+                pending_by_kind, visited_by_kind, new_refs
+            )
+            cycles.extend(step_cycles)
+
+    # Pass 2: APEX classes (mark visited).
+    for wave_dir in all_wave_dirs:
+        apex_dir = wave_dir / "classes"
+        if apex_dir.exists():
+            for f in sorted(apex_dir.glob("*.cls-meta.xml")):
+                visited_by_kind["APEX"].add(f.name.replace(".cls-meta.xml", ""))
+
+    # Pass 3: Prompt templates (mark visited).
+    for wave_dir in all_wave_dirs:
+        prompt_dir = wave_dir / "genAiPromptTemplates"
+        if prompt_dir.exists():
+            for f in sorted(prompt_dir.glob("*.genAiPromptTemplate")):
+                visited_by_kind["PROMPT_TEMPLATE"].add(f.stem)
+
+    # Passes 2/3 may have added visited entries AFTER pass-1 pending routing;
+    # prune anything that's now visited. This preserves the invariant that
+    # `pending ∩ visited = ∅` without needing a second bfs_step.
+    for kind in BFS_KINDS:
+        pending_by_kind[kind] -= visited_by_kind[kind]
+
+    return flow_children, visited_by_kind, pending_by_kind, cycles
+
+
+def init_tree(work_dir: pathlib.Path, bundle: dict) -> dict:
+    bd_rec = {}
+    bd_file = work_dir / "_bot_definition.json"
+    if bd_file.exists():
+        try:
+            recs = (json.loads(bd_file.read_text()).get("result") or {}).get("records") or []
+            if recs:
+                bd_rec = recs[0]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    tree = {
+        # 3.0 bumps the _pending_fetches key convention from
+        # Metadata-API tokens (Flow/ApexClass/GenAiPromptTemplate) to the
+        # runtime-tree `kind` tokens (FLOW/APEX/PROMPT_TEMPLATE/
+        # STANDARD_ACTION). `cache_check.py`'s schema-version gate busts any
+        # pre-3.0 cache on first run.
+        #
+        # 3.1 (2026-05-05) canonicalizes `invocation_type` on STANDARD_ACTION
+        # nodes (formerly split across `raw_invocation_type` on bundle-
+        # sourced nodes and `raw_action_type` on flow-actionCall-sourced
+        # nodes). Readers fall back to the two legacy keys for one release.
+        "_schema_version": "3.1",
+        "agent": {
+            "api_name": os.environ["AGENT_API_NAME"],
+            "version": os.environ["AGENT_VERSION"],
+            "bot_id": os.environ.get("BOT_ID", ""),
+            "master_label": bd_rec.get("MasterLabel") or os.environ.get("BOT_MASTER_LABEL", ""),
+            "description": bd_rec.get("Description"),
+            "agent_type": bd_rec.get("AgentType"),
+            "type": bd_rec.get("Type"),
+            "agent_template": bd_rec.get("AgentTemplate"),
+            "bot_source": bd_rec.get("BotSource"),
+            "generation": bundle.get("generation", "unknown"),
+            "planner_name": bundle.get("plannerName"),
+            "planner_type": bundle.get("plannerType"),
+            "_version_auto_picked": (os.environ.get("VERSION_AUTO_PICKED", "") == "true"),
+        },
+        "root": {
+            "kind": "BOT_DEFINITION",
+            "api_name": os.environ["AGENT_API_NAME"],
+            "children": [],
+        },
+        "node_count": 0,
+        "depth": 0,
+        # `_partial` + `_partial_reason` propagate from parse_wave's
+        # depth-cap detection through to emit_result's PARTIAL_OK status.
+        # `_partial_reason` values: "max-depth-cap" | "pending-refs" | null.
+        "_partial": True,
+        "_partial_reason": None,
+        "_pending_fetches": {k: [] for k in BFS_KINDS},
+        "_unresolved": [],
+        "_visited": [],
+    }
+    return tree
+
+
+def build_root_children(
+    bundle: dict,
+    visited_by_kind: dict[str, set[str]],
+    aux_visited: set[tuple[str, str]],
+) -> tuple[list[dict], dict[str, set[str]]]:
+    """Build the root's topic / plannerAction children.
+
+    bundle-scoped FLOW/APEX/PROMPT_TEMPLATE refs are collected
+    into a kind-keyed `new_refs` dict and returned to the caller, which runs
+    them through `bfs_step` for uniform pending-merge + cycle tracking.
+    This used to directly mutate three flat sets — split out so the tuple-
+    keyed semantics apply to bundle-derived refs too, not just wave-derived
+    ones.
+
+    `aux_visited` tracks non-BFS node identity (GEN_AI_FUNCTION / TOPIC) so
+    the persisted `_visited` list still represents every node the walker
+    has laid hands on. It is NOT consulted by bfs_step.
+    """
+    children: list[dict] = []
+    new_refs: dict[str, set[str]] = empty_kind_sets()
+
+    def action_node(action: dict) -> dict:
+        unwraps, leaf = classify_bundle_action(action)
+        aux_visited.add(("GEN_AI_FUNCTION", action["name"]))
+        node = {
+            "kind": "GEN_AI_FUNCTION",
+            "api_name": action["name"],
+            "unwraps_to": unwraps,
+            "children": [leaf] if leaf else [],
+        }
+        if unwraps:
+            tgt = unwraps.get("api_name")
+            kind = unwraps.get("kind")
+            # STANDARD_ACTION is declared-only, never
+            # fetched; routing it into `new_refs` would pollute
+            # `_pending_fetches.STANDARD_ACTION`. Gate on FETCHABLE_KINDS.
+            if kind in FETCHABLE_KINDS and tgt and tgt not in visited_by_kind[kind]:
+                new_refs[kind].add(tgt)
+        return node
+
+    for topic in bundle.get("topics", []) or []:
+        aux_visited.add(("TOPIC", topic["name"]))
+        children.append({
+            "kind": "TOPIC",
+            "api_name": topic["name"],
+            "children": [action_node(a) for a in topic.get("actions", []) or []],
+        })
+
+    # bundle["plannerActions"] is always [] now (a planner never has
+    # direct functions — 2026-05-05). The key stays in the bundle dict
+    # for back-compat with consumers that still call `.get("plannerActions")`.
+
+    return children, new_refs
+
+
+# ---------------------------------------------------------------------------
+# cycle-safe inflate with (kind, canonical_name) tuple-keyed tracking.
+#
+# Visited tracking uses tuple keys so a Flow `Foo` and an Apex `Foo` are
+# distinct nodes — a flat name-only set would silently drop the second one.
+# Flow→subflow cycles (direct or cross-type A→B→A) are annotated with
+# `_cycle_back_to` on the repeat node and recursion terminates immediately.
+#
+# , revised 2026-05-03: `MAX_BFS_DEPTH` is a DEFENSIVE termination
+# guard, not a functional constraint on chain depth. Must stay in sync
+# with `scripts/config.py::MAX_BFS_DEPTH` — duplicated (rather than
+# imported) because this module runs as a standalone subprocess under
+# `python3 parse_wave.py` (see `main()`) and the module has a long-standing
+# "no intra-skill imports" convention (search `no intra-skill imports'
+# convention`).
+#
+# Real cycle detection is per-branch via `visited_in_path`: a flow that
+# appears on sibling branches is NOT a cycle (e.g. `handleFlowFault`,
+# invoked from many parents), but the same flow recurring along its own
+# ancestor chain IS. Textbook DFS cycle detection.
+#
+# Before the revision this was `5` and the cap itself tripped on shared
+# utility flows (`handleFlowFault`, logging subflows) — those landed in
+# `_pending_fetches["FLOW"]` and the user saw `PARTIAL_REASON=max-depth-cap`
+# on trees that were in fact fully knowable. Bumping to 20 keeps a safety
+# net for pathological graphs while letting per-branch cycle detection do
+# the real work. On every real bot tree observed to date, the per-branch
+# check terminates well below depth 20.
+#
+# When this cap *does* trip (truly exceptional), the unreached FLOW lands
+# in `pending_out["FLOW"]` and the leaf is annotated `_truncated =
+# {reason: "max-depth", target: "FLOW:<name>"}`, exactly as before.
+MAX_BFS_DEPTH = 20
+
+# Retained alias so the `MAX_INFLATE_DEPTH` symbol (referenced in older
+# agent notes / docs) still resolves. Tracks `MAX_BFS_DEPTH` exactly; the
+# 2026-05-03 revision reinterpreted this as a defensive guard rather than
+# a functional cap, but the alias semantics are unchanged.
+MAX_INFLATE_DEPTH = MAX_BFS_DEPTH
+_FLOW_CYCLE_KINDS = frozenset({"FLOW"})  # the only kind that recurses here
+
+
+def _cycle_key(node: dict) -> tuple[str, str]:
+    """Tuple key for visited / cycle detection. Flows use canonical api_name.
+
+    keying on `(kind, api_name)` — NOT just name — so cross-kind
+    collisions (Flow Foo + Apex Foo) stay distinct.
+    """
+    return (node.get("kind") or "", node.get("api_name") or "")
+
+
+def inflate_flow_leaf(
+    leaf: dict,
+    flow_children: dict,
+    depth: int = 0,
+    visited_in_path: frozenset[tuple[str, str]] | None = None,
+    pending_out: dict[str, set[str]] | None = None,
+) -> None:
+    """Recursively expand a FLOW leaf's subflow tree.
+
+    `visited_in_path` is threaded through the recursion as an
+    IMMUTABLE frozenset — siblings at the same depth must NOT observe
+    each other's descent. Mutating a shared set would cause the second
+    sibling to be pruned as a false cycle.
+
+    `pending_out` is an OPTIONAL mutable accumulator keyed by
+    `BFS_KINDS` tokens. When the depth cap trips (`depth >= MAX_BFS_DEPTH`)
+    and the current leaf still has subflow children we'd normally expand,
+    those unreached targets are added to `pending_out[kind]` so a caller
+    can surface them as `_pending_fetches` on the tree with
+    `_partial=True` + `_partial_reason="max-depth-cap"`. When `pending_out`
+    is None (legacy callers), the cap behaves as before — silently skip.
+    """
+    # depth-cap check. We use `>=` (not `>`) so the cap matches
+    # `MAX_BFS_DEPTH` exactly — at depth 5 we do NOT expand the current
+    # leaf, and the leaf's own (kind, api_name) is recorded in
+    # `pending_out` as "unreached". Rationale: this node was supposed
+    # to be fully explored but we hit the cap on the way in. Naming
+    # the leaf itself (not its kids) is what downstream callers need
+    # to surface as `_pending_fetches["FLOW"] = [<unreached>]`.
+    if depth >= MAX_BFS_DEPTH:
+        if leaf.get("kind") == "FLOW":
+            flow_name = leaf.get("api_name")
+            if flow_name:
+                if pending_out is not None:
+                    pending_out.setdefault("FLOW", set()).add(flow_name)
+                # annotate the truncated leaf with the unified
+                # `_truncated` sub-object so rendered tree views can
+                # mark depth-capped nodes alongside cycle nodes using
+                # one predicate. The target points at the leaf itself
+                # (it was supposed to be fully explored but the cap
+                # tripped on the way in).
+                leaf["_truncated"] = {
+                    "reason": TRUNCATION_MAX_DEPTH,
+                    "target": f"FLOW:{flow_name}",
+                }
+        return
+    if leaf.get("kind") != "FLOW":
+        return
+    flow_name = leaf.get("api_name")
+    if not flow_name:
+        return
+    kids = flow_children.get(flow_name)
+    if not kids:
+        return  # no data this wave; preserve any existing children
+
+    # Extend the path-visited set with this node. Frozenset keeps sibling
+    # branches independent — mutation would cross-contaminate.
+    leaf_key = _cycle_key(leaf)
+    path_set = (visited_in_path or frozenset()) | {leaf_key}
+
+    new_children: list[dict] = []
+    for k in kids:
+        item = {"kind": k["kind"], "element_name": k.get("element_name"), "api_name": k["api_name"]}
+        # Carry the STANDARD_ACTION / UNKNOWN invocation-type qualifier
+        # through to the expanded child. Canonical key is `invocation_type`
+        # (schema 3.1); legacy `raw_action_type` kept for one release so
+        # caches built by an older parse_wave still render cleanly.
+        if "invocation_type" in k:
+            item["invocation_type"] = k["invocation_type"]
+        if "raw_action_type" in k:
+            item["raw_action_type"] = k["raw_action_type"]
+        if k["kind"] == "FLOW":
+            item["children"] = []
+            child_key = _cycle_key(item)
+            if child_key in path_set:
+                # cycle detected — annotate and do NOT recurse.
+                # Path format: "<KIND>:<name>" of the first encounter.
+                # unified `_truncated` sub-object + legacy
+                # `_cycle_back_to` for backcompat.
+                target_path = f"{child_key[0]}:{child_key[1]}"
+                item["_truncated"] = {
+                    "reason": TRUNCATION_CYCLE,
+                    "target": target_path,
+                }
+                item["_cycle_back_to"] = target_path  # deprecated alias
+                new_children.append(item)
+                continue
+            new_children.append(item)
+            inflate_flow_leaf(item, flow_children, depth + 1, path_set, pending_out)
+        else:
+            new_children.append(item)
+    leaf["children"] = new_children
+
+
+def walk_and_inflate(
+    node: dict,
+    flow_children: dict,
+    depth: int = 0,
+    pending_out: dict[str, set[str]] | None = None,
+) -> None:
+    """Walk the tree and inflate every FLOW leaf we encounter.
+
+    Each inflate call starts with an empty path-visited set — tree-walk
+    descent is not itself a Flow recursion, so ancestor GEN_AI_FUNCTION
+    or TOPIC nodes don't count toward cycle detection.
+
+    `pending_out` (optional) is threaded into every `inflate_flow_leaf`
+    call so depth-cap truncations accumulate into a single shared dict,
+    which `main()` merges into `tree["_pending_fetches"]` + flips
+    `tree["_partial"]` with reason `max-depth-cap`.
+    """
+    if node.get("kind") == "GEN_AI_FUNCTION":
+        for child in node.get("children", []) or []:
+            if child.get("kind") == "FLOW":
+                inflate_flow_leaf(child, flow_children, depth, pending_out=pending_out)
+    elif node.get("kind") == "FLOW":
+        inflate_flow_leaf(node, flow_children, depth, pending_out=pending_out)
+    for c in node.get("children", []) or []:
+        walk_and_inflate(c, flow_children, depth + 1, pending_out)
+
+
+def compute_stats(root: dict) -> tuple[int, int, dict]:
+    counts: Counter = Counter()
+
+    def walk(node: dict, d: int = 0) -> int:
+        k = node.get("kind")
+        if k:
+            counts[k] += 1
+        max_d = d
+        for c in node.get("children", []) or []:
+            max_d = max(max_d, walk(c, d + 1))
+        return max_d
+
+    depth = walk(root)
+    return sum(counts.values()), depth, dict(counts)
+
+
+def atomic_write_json(path: pathlib.Path, obj: dict) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2))
+    os.replace(tmp, path)
+
+
+def finalize_cap(tree: dict) -> dict:
+    """Move remaining _pending_fetches items to _unresolved[].
+
+    pending and unresolved both use the same kind tokens now
+    (FLOW/APEX/PROMPT_TEMPLATE/STANDARD_ACTION) — matching the runtime
+    tree's `kind` field.
+
+    depth-cap truncation writes `_partial=True` +
+    `_partial_reason="max-depth-cap"` earlier in the pipeline. Finalize
+    preserves those signals when it drains pending → unresolved so the
+    downstream emit_result.py can still surface PARTIAL_OK with the
+    correct reason. If BOTH the depth cap AND finalize-cap fire on the
+    same run, depth-cap wins priority (set first, not overwritten).
+    """
+    pending = tree.get("_pending_fetches") or {}
+    unresolved = tree.setdefault("_unresolved", [])
+    drained_any = False
+    for kind, items in pending.items():
+        for n in items:
+            drained_any = True
+            unresolved.append({
+                "kind": kind,
+                "api_name": n,
+                "reason": "max-wave-depth exceeded",
+            })
+    tree["_pending_fetches"] = {k: [] for k in BFS_KINDS}
+
+    # if pending was drained but no `_partial_reason` is set yet,
+    # mark it as wave-depth exhaustion. DO NOT overwrite an existing
+    # `max-depth-cap` reason — the depth-cap trigger is strictly earlier
+    # and more specific.
+    if drained_any:
+        tree["_partial"] = True
+        if not tree.get("_partial_reason"):
+            tree["_partial_reason"] = "max-wave-depth"
+    return tree
+
+
+def main() -> int:
+    finalize_cap_mode = "--finalize-cap" in sys.argv
+
+    try:
+        work_dir = pathlib.Path(os.environ["WORK_DIR"])
+    except KeyError as e:
+        sys.stderr.write(f"parse_wave.py: missing env {e}\n")
+        return 1
+
+    tree_path = work_dir / "declared_action_tree.json"
+
+    # --finalize-cap: trivial; just drain pending → unresolved on existing tree
+    if finalize_cap_mode:
+        if not tree_path.is_file():
+            sys.stderr.write("parse_wave.py: --finalize-cap with no tree file; noop\n")
+            return 0
+        try:
+            tree = json.loads(tree_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            sys.stderr.write(f"parse_wave.py: cannot read tree: {e}\n")
+            return 1
+        tree = finalize_cap(tree)
+        try:
+            atomic_write_json(tree_path, tree)
+        except OSError as e:
+            sys.stderr.write(f"parse_wave.py: write failed: {e}\n")
+            return 1
+        sys.stderr.write(
+            f"[parse_wave] finalize-cap: {len(tree.get('_unresolved', []))} nodes unresolved\n"
+        )
+        return 0
+
+    # Standard init-or-reparse path
+    bundle_path = work_dir / "_bundle_parsed.json"
+    if not bundle_path.is_file():
+        sys.stderr.write(f"parse_wave.py: missing {bundle_path}\n")
+        return 1
+    try:
+        bundle = json.loads(bundle_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"parse_wave.py: bundle parse error: {e}\n")
+        return 1
+
+    # Harvest wave dirs. Returns kind-keyed visited + pending dicts plus
+    # the list of (kind, name) cycles detected during per-flow BFS merges.
+    flow_children, wave_visited_by_kind, pending_by_kind, _wave_cycles = harvest_waves(work_dir)
+
+    # Load-or-init tree
+    if tree_path.is_file():
+        try:
+            tree = json.loads(tree_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            sys.stderr.write(f"parse_wave.py: cannot re-parse; reinitializing ({e})\n")
+            tree = init_tree(work_dir, bundle)
+    else:
+        tree = init_tree(work_dir, bundle)
+
+    # Rehydrate tuple-keyed visited from the persisted _visited list and
+    # union with wave-derived visited. Non-BFS kinds (TOPIC/GEN_AI_FUNCTION)
+    # live in `aux_visited` — they're persisted in _visited but do NOT
+    # participate in BFS routing.
+    visited_by_kind: dict[str, set[str]] = empty_kind_sets()
+    for kind, names in wave_visited_by_kind.items():
+        visited_by_kind[kind] |= names
+    aux_visited: set[tuple[str, str]] = set()
+    for pair in (tree.get("_visited") or []):
+        if not pair or len(pair) != 2:
+            continue
+        k, n = pair[0], pair[1]
+        if k in BFS_KINDS:
+            visited_by_kind[k].add(n)
+        else:
+            aux_visited.add((k, n))
+
+    # If the tree was just initialized, populate root children (only once).
+    # bundle-derived refs now flow through bfs_step via
+    # build_root_children's new_refs return value — same code path as
+    # wave-derived refs.
+    is_fresh = not (tree.get("root", {}).get("children"))
+    if is_fresh:
+        children, bundle_new_refs = build_root_children(
+            bundle, visited_by_kind, aux_visited
+        )
+        tree["root"]["children"] = children
+        pending_by_kind, _bundle_cycles = bfs_step(
+            pending_by_kind, visited_by_kind, bundle_new_refs
+        )
+
+    # Inflate Flow leaves wherever possible.
+    # `depth_cap_pending` captures subflow refs we skipped because
+    # the depth cap tripped — these get merged into `_pending_fetches`
+    # below so downstream emit_result.py can surface `PARTIAL_OK`.
+    depth_cap_pending: dict[str, set[str]] = empty_kind_sets()
+    walk_and_inflate(tree["root"], flow_children, pending_out=depth_cap_pending)
+
+    # Merge depth-cap-suppressed refs back into pending_by_kind so they
+    # land in `_pending_fetches`. Preserve any existing (already-visited)
+    # exclusion semantics — refs already fetched this run MUST NOT be
+    # re-reported as pending.
+    for kind in BFS_KINDS:
+        pending_by_kind[kind] |= depth_cap_pending.get(kind, set())
+
+    depth_cap_tripped = any(depth_cap_pending[k] for k in BFS_KINDS)
+
+    # Recompute pending (exclude anything now visited). the
+    # persisted dict uses the same `BFS_KINDS` tokens as the runtime tree
+    # and the in-memory buckets — no more Metadata-API-style aliasing.
+    tree["_pending_fetches"] = {
+        k: sorted(pending_by_kind.get(k, set()) - visited_by_kind.get(k, set()))
+        for k in BFS_KINDS
+    }
+
+    # surface a `_partial` signal when:
+    # (a) depth-cap-pending refs exist (we suppressed deep subflows), OR
+    # (b) any `_pending_fetches` bucket is non-empty at write time.
+    # `_partial_reason` identifies which of the two tripped — `max-depth-cap`
+    # takes priority when depth_cap_pending is non-empty, since the cap is
+    # the reason pending refs weren't drained to `_unresolved` yet.
+    any_pending = any(tree["_pending_fetches"][k] for k in BFS_KINDS)
+    if depth_cap_tripped:
+        tree["_partial"] = True
+        tree["_partial_reason"] = "max-depth-cap"
+    elif any_pending:
+        # Still incomplete but NOT because of the depth cap. Leave any
+        # existing reason intact if prior run set it; default to a neutral
+        # marker so emit_result.py can still flip to PARTIAL_OK.
+        tree["_partial"] = True
+        tree.setdefault("_partial_reason", "pending-refs")
+    else:
+        tree["_partial"] = False
+        tree["_partial_reason"] = None
+
+    # Recompute node_count + depth + kind_counts
+    node_count, depth, kind_counts = compute_stats(tree["root"])
+    tree["node_count"] = node_count
+    tree["depth"] = depth
+    tree["_kind_counts"] = kind_counts
+
+    # Persist visited as sorted list of [kind, name] pairs. Includes aux
+    # kinds (TOPIC/GEN_AI_FUNCTION) so the replay surface is complete.
+    all_visited: set[tuple[str, str]] = set(aux_visited)
+    for kind, names in visited_by_kind.items():
+        for n in names:
+            all_visited.add((kind, n))
+    tree["_visited"] = [list(v) for v in sorted(all_visited)]
+
+    try:
+        atomic_write_json(tree_path, tree)
+    except OSError as e:
+        sys.stderr.write(f"parse_wave.py: write failed: {e}\n")
+        return 1
+
+    # log line mirrors the persisted dict's kind tokens.
+    pending_total = sum(len(v) for v in tree["_pending_fetches"].values())
+    sys.stderr.write(
+        f"[parse_wave] parsed: {node_count} nodes, depth {depth}, counts={kind_counts}, "
+        f"pending={pending_total} "
+        f"(flow={len(tree['_pending_fetches']['FLOW'])} "
+        f"apex={len(tree['_pending_fetches']['APEX'])} "
+        f"prompt_template={len(tree['_pending_fetches']['PROMPT_TEMPLATE'])} "
+        f"standard_action={len(tree['_pending_fetches']['STANDARD_ACTION'])})\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/probe_channels.py
+++ b/skills/investigating-agentforce-architecture/scripts/probe_channels.py
@@ -1,0 +1,302 @@
+"""Channel probe — one-shot sf sobject describe per target type, cached 7 days.
+
+channel probe with TTL (7d), mandatory-field gate, runtime
+INVALID_FIELD re-probe, and a `--reprobe` CLI flag.
+
+Rationale: Salesforce ships quarterly releases that can rename / deprecate
+Tooling sObject fields. A long-lived cache would mask a schema drift for
+weeks. A 7-day TTL bounds the exposure; the `invalidate_and_reprobe` hook
+is the runtime escape valve when a SOQL returns `INVALID_FIELD` mid-run.
+
+Security:
+  * Cache dir comes ONLY from `config.build_probe_cache_dir` (validated
+    path; no attacker-controlled segments).
+  * Cache file is written 0o600 — owner read-write only.
+  * No raw sObject describe REST calls here; we go through `sf_cli.run_sf`
+    which already enforces  (yaml.safe_load) +  (redacted stderr).
+
+Mandatory vs optional fields: we ship a MANDATORY_FIELDS map of the fields
+the skill's SOQL assets can't function without. A probe that sees ANY
+mandatory field missing flags `status: "PROBE_FAILED"` so the caller can
+surface a clean error instead of producing a subtly-wrong tree.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+# Local imports — sf_cli handles the actual describe calls + redaction.
+from config import PROBE_TTL_DAYS, build_probe_cache_dir
+from sf_cli import SfCliError, run_sf
+
+
+# -----------------------------------------------------------------------------
+# critical sObjects the skill depends on.
+# -----------------------------------------------------------------------------
+# `api_kind`: which describe recipe we route the call through. BotDefinition
+# / BotVersion are reachable via the Data API; the GenAi* sObjects are
+# Tooling-API-only. The two recipes share the same shape (sObject name in,
+# queryable fields list out) so downstream handling is uniform.
+
+_DATA_API_SOBJECTS = ("BotDefinition", "BotVersion")
+_TOOLING_API_SOBJECTS = (
+    "ApexClass",
+    "Flow",
+    "FlowDefinition",
+    "GenAiPlannerDefinition",
+    "GenAiPluginDefinition",
+    "GenAiFunctionDefinition",
+    "GenAiPlannerAttrDefinition",
+)
+
+ALL_SOBJECTS: tuple[str, ...] = _DATA_API_SOBJECTS + _TOOLING_API_SOBJECTS
+
+
+# mandatory fields. These are the minimum set of fields the skill's
+# SOQL assets reference by name. If a probe sees ANY of these missing, the
+# probe status flips to PROBE_FAILED — we'd rather abort cleanly than
+# produce a tree with silent holes from missing columns.
+#
+# Keep this list conservative — "mandatory" means "every code path needs
+# it". Fields that only some branches use go in the queryable set without
+# being gated.
+MANDATORY_FIELDS: Dict[str, set[str]] = {
+    "BotDefinition": {"Id", "DeveloperName"},
+    "BotVersion": {"Id", "BotDefinitionId"},
+    "ApexClass": {"Id", "Name"},
+    "Flow": {"Id", "MasterLabel", "DefinitionId"},
+    "FlowDefinition": {"Id", "DeveloperName"},
+    "GenAiPlannerDefinition": {"Id", "DeveloperName", "PlannerType"},
+    "GenAiPluginDefinition": {"Id", "DeveloperName"},
+    "GenAiFunctionDefinition": {"Id", "DeveloperName", "InvocationTarget"},
+    "GenAiPlannerAttrDefinition": {"Id"},
+}
+
+
+class ProbeError(RuntimeError):
+    """Probe could not complete — surfaced to caller, redaction already applied."""
+
+
+def _describe_sobject(org_alias: str, sobject: str, is_tooling: bool) -> dict:
+    """Describe a single sObject via `sf_cli.run_sf`.
+
+    Expected recipes (to be added alongside this module): `describe_sobject`
+    for the Data API and `describe_tooling_sobject` for Tooling. Both are
+    expected to return a dict of shape `{"status":0,"result":{"fields":
+    [{"name":"X","queryable":true}, ...]}}`.
+
+    We keep this helper tiny so tests can mock `run_sf` without touching
+    the wire. The recipes themselves are author-controlled YAML loaded
+    through `sf_cli` (yaml.safe_load).
+
+    NOTE: the recipes don't exist on disk yet — they land in the Batch-4
+    integration pass. This function is called only via `probe_channels`,
+    which every test mocks. The production path stays inert until the
+    recipes ship.
+    """
+    recipe = "describe_tooling_sobject" if is_tooling else "describe_sobject"
+    try:
+        data = run_sf(recipe, ORG_ALIAS=org_alias, SOBJECT=sobject)
+    except SfCliError as e:
+        raise ProbeError(f"describe failed for {sobject}: {e}") from None
+    return data.get("result") or {}
+
+
+def _extract_queryable_fields(describe_result: dict) -> list[str]:
+    """Pull queryable field names from a describe result.
+
+    Tolerant of both the shape `{"fields":[{"name":"X","queryable":true}]}`
+    and the bare `{"fields":[{"name":"X"}]}` (some endpoints omit the
+    queryable flag; we default to queryable=True when absent).
+    """
+    fields = describe_result.get("fields") or []
+    out: list[str] = []
+    for f in fields:
+        if not isinstance(f, dict):
+            continue
+        name = f.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        queryable = f.get("queryable", True)
+        if queryable:
+            out.append(name)
+    return sorted(out)
+
+
+def _is_cache_fresh(path: Path, ttl_days: int) -> bool:
+    """Return True if the cached channels.json is present and not stale.
+
+    Staleness is derived from the embedded `_built_at_utc` timestamp, NOT
+    filesystem mtime — mtime can be skewed by backup / restore / rsync.
+
+    reject future timestamps (`age_seconds < 0`) as stale. A
+    `_built_at_utc` in the future means clock-skew or tampering; either
+    way we can't trust the cache. The bound `0 <= age < ttl` is the
+    honest freshness predicate.
+    """
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    built_at = data.get("_built_at_utc")
+    if not isinstance(built_at, (int, float)):
+        return False
+    age_seconds = time.time() - float(built_at)
+    # future timestamps (age < 0) are not fresh.
+    return 0 <= age_seconds < (ttl_days * 86400)
+
+
+def _write_cache(path: Path, payload: dict) -> None:
+    """Write the probe payload atomically with 0o600 permissions.
+
+    adjacency: the path itself is built via `build_probe_cache_dir`
+    upstream, so every segment is regex-validated. Here we just enforce
+    owner-only read/write and atomic rename.
+
+    concurrent-safe tmp filename. `path.with_suffix(...+".tmp")`
+    produces the same deterministic name for every concurrent caller —
+    a second writer would either race on the final rename or clobber
+    the first writer's in-flight bytes. `tempfile.mkstemp(dir=...)`
+    returns a unique pathname per call, eliminating the collision.
+
+    normalize parent-dir perms to 0o700 after mkdir. Even if the
+    parent existed with looser permissions (umask or operator lapse),
+    the probe cache directory is a per-user-per-org artifact that
+    should not be world-readable.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # normalize even if the dir pre-existed.
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        # Best-effort: on an exotic filesystem (e.g. FAT) chmod may fail.
+        # Don't block the cache write on it.
+        pass
+
+    # unique tmp name per call, in the same directory as the final
+    # path so `os.replace` stays atomic (same-filesystem rename).
+    fd, tmp_str = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".channels.", suffix=".tmp",
+    )
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(payload, indent=2, sort_keys=True))
+        os.chmod(tmp, 0o600)  # owner RW only
+        os.replace(tmp, path)
+    except Exception:
+        # Clean up the tmp file on error — mkstemp leaves it behind.
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def probe_channels(
+    org_alias: str,
+    org_id_15: str,
+    api_version: str,
+    *,
+    force_refresh: bool = False,
+) -> dict:
+    """Run (or return cached) describes for every sObject the skill touches.
+
+    caller passes `force_refresh=True` via the `--reprobe` CLI flag
+    or via `invalidate_and_reprobe` when a runtime SOQL surfaces
+    `INVALID_FIELD`. Default behavior: return cached payload if present
+    AND younger than `PROBE_TTL_DAYS`.
+
+    Returns a dict of shape:
+      {
+        "_schema": "channels/1",
+        "_built_at_utc": <epoch>,
+        "status": "OK" | "PROBE_FAILED",
+        "channels": {
+          "BotDefinition": {
+            "queryable_fields": [...],
+            "mandatory_missing": [...],
+            "describe_error": None | "<redacted error>"
+          },
+          ...
+        }
+      }
+    """
+    cache_dir = build_probe_cache_dir(org_id_15, api_version)
+    cache_file = cache_dir / "channels.json"
+
+    if not force_refresh and _is_cache_fresh(cache_file, PROBE_TTL_DAYS):
+        return json.loads(cache_file.read_text())
+
+    channels: Dict[str, dict] = {}
+    any_mandatory_missing = False
+
+    for sobject in ALL_SOBJECTS:
+        is_tooling = sobject in _TOOLING_API_SOBJECTS
+        entry: Dict[str, Any] = {
+            "queryable_fields": [],
+            "mandatory_missing": [],
+            "describe_error": None,
+        }
+        try:
+            result = _describe_sobject(org_alias, sobject, is_tooling)
+        except ProbeError as e:
+            # Redaction already applied by sf_cli.run_sf; we're just
+            # passing the message along.
+            entry["describe_error"] = str(e)
+            channels[sobject] = entry
+            # A describe failure is treated as "all mandatory missing"
+            # for this sObject — the skill can't function against it.
+            entry["mandatory_missing"] = sorted(MANDATORY_FIELDS.get(sobject, set()))
+            if entry["mandatory_missing"]:
+                any_mandatory_missing = True
+            continue
+
+        queryable = _extract_queryable_fields(result)
+        entry["queryable_fields"] = queryable
+        mandatory = MANDATORY_FIELDS.get(sobject, set())
+        missing = sorted(mandatory - set(queryable))
+        entry["mandatory_missing"] = missing
+        if missing:
+            any_mandatory_missing = True
+
+        channels[sobject] = entry
+
+    payload = {
+        "_schema": "channels/1",
+        "_built_at_utc": time.time(),
+        "status": "PROBE_FAILED" if any_mandatory_missing else "OK",
+        "channels": channels,
+    }
+    _write_cache(cache_file, payload)
+    return payload
+
+
+def invalidate_and_reprobe(
+    org_alias: str,
+    org_id_15: str,
+    api_version: str,
+) -> dict:
+    """Delete the cached channels.json and re-run the probe.
+
+    called when a runtime SOQL returns `INVALID_FIELD`. The cached
+    schema is stale (SF release renamed / removed a field); we can't trust
+    any of it, so unlink + re-probe.
+
+    Returns the fresh payload. On a subsequent INVALID_FIELD from the
+    re-probed schema, the caller should surface PROBE_FAILED rather than
+    re-enter this function — one reprobe per run, not a retry loop.
+    """
+    cache_dir = build_probe_cache_dir(org_id_15, api_version)
+    cache_file = cache_dir / "channels.json"
+    try:
+        cache_file.unlink()
+    except FileNotFoundError:
+        pass
+    return probe_channels(org_alias, org_id_15, api_version, force_refresh=True)

--- a/skills/investigating-agentforce-architecture/scripts/render_architecture.py
+++ b/skills/investigating-agentforce-architecture/scripts/render_architecture.py
@@ -1,0 +1,1043 @@
+"""Render architecture.md from metadata_tree.json.
+
+Phase 2 Batch 2.2: 8-section architecture document with up to 3 Mermaid
+diagrams (2 core + 1 conditional dependency graph). Generation-aware:
+classic/ReAct, classic/SequentialPlannerIntentClassifier, NGA/
+ConcurrentMultiAgentOrchestration, search/BYOP all produce distinct
+structural output on the same fixture schema.
+
+Consumers
+---------
+- `main.py` phase 10 — called with the finalized tree_path + a target
+  out_path under the agent data_dir.
+- Tests — `scripts/tests/test_render_architecture.py` exercises every
+  per-generation branch and the cap/partial/cycle edge cases.
+
+Template loader
+---------------
+`load_mermaid(name, **params)` mirrors `soql_loader.load_soql`'s
+substitution shape (single-pass `str.replace` on `{{KEY}}` tokens) but
+deliberately does NOT run `fs_guard.validate_api_name` on the values.
+Mermaid strings are not SQL, not a filesystem path, and not a shell
+argument — there is no injection surface downstream. We only guard
+against a *substituted* value itself containing `{{` / `}}`, which would
+confuse readers of the rendered diff if it silently chained into a
+second substitution pass; the loader logs a warning and proceeds.
+Template filenames are validated — they flow into a `Path.is_file()`
+check on disk, same traversal surface as `load_soql`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from config import MERMAID_DIR, SKILL_ROOT, fs_guard  # fs_guard re-exported by config.py from _shared/
+
+logger = logging.getLogger(__name__)
+
+# P2.2-1: per-diagram-type node caps. Above cap -> summary placeholder.
+DEFAULT_MAX_MERMAID_NODES: Dict[str, int] = {
+    "flowchart": 200,
+    "stateDiagram": 40,
+    "sequenceDiagram": 60,
+    "graph": 100,
+}
+
+
+def _display_name(node: Dict[str, Any]) -> str:
+    """Return the node's rendered label.
+
+    For STANDARD_ACTION nodes, append the invocation-type qualifier
+    (e.g. `streamKnowledgeSearch (standardinvocableaction)`) so the
+    rendered tree distinguishes a real Salesforce-owned builtin from
+    a flow-element STANDARD_ACTION whose action-name equals its
+    invocation-target. Canonical key is `invocation_type` (schema
+    3.1); legacy `raw_invocation_type` / `raw_action_type` fall
+    back for caches built by an older parse_wave.
+    """
+    name = node.get("api_name") or node.get("element_name") or "?"
+    if node.get("kind") == "STANDARD_ACTION":
+        inv = (
+            node.get("invocation_type")
+            or node.get("raw_invocation_type")
+            or node.get("raw_action_type")
+        )
+        if inv:
+            return f"{name} ({inv})"
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Template loader
+# ---------------------------------------------------------------------------
+
+
+def load_mermaid(name: str, **params: str) -> str:
+    """Read assets/mermaid/<name>.mmd and substitute {{PARAM}} values.
+
+    P2.2-1: template name is regex-validated BEFORE any filesystem access.
+    Traversal via `../../etc/...` is blocked by `fs_guard.validate_api_name`.
+    Param *values* are NOT validated — mermaid strings don't flow into
+    SOQL, REST, or filesystem paths and carry no injection surface.
+    We DO check for nested `{{`/`}}` in substituted values and log a
+    warning (the first-pass substitute call won't re-trigger, but a
+    stray `{{OTHER}}` inside a value makes the rendered markdown
+    confusing to diff). Raises `FileNotFoundError` with the template
+    name (no absolute-path leak) when the template file is missing.
+    """
+    try:
+        fs_guard.validate_api_name(name, label="mermaid_template_name")
+    except fs_guard.ValidationError as e:
+        # Template name is attacker-controlled in theory (a caller could
+        # source it from a config file). Don't leak the full SKILL_ROOT
+        # via the default FileNotFoundError message.
+        raise FileNotFoundError(
+            f"Mermaid template name rejected: {e.reason}"
+        ) from None
+
+    path = MERMAID_DIR / f"{name}.mmd"
+    if not path.is_file():
+        # Match soql_loader's SoqlTemplateNotFound hygiene — carry only
+        # the template *name*, not the absolute MERMAID_DIR path, so
+        # error text surfacing in logs doesn't disclose filesystem layout.
+        raise FileNotFoundError(f"Mermaid template not found: {name}")
+
+    template = path.read_text()
+    # the `%%` header-comment block in each template is kept
+    # verbatim in the rendered output. Mermaid treats `%%` lines as
+    # comments and ignores them at render time, and keeping them aids
+    # debuggability (rendered diff still carries the author's contract
+    # notes). Templates MUST document placeholder names as bare tokens
+    # (e.g. `NODES placeholder:`) rather than `{{NODES}}` — otherwise
+    # the single-pass `str.replace` below would substitute the comment's
+    # placeholder reference and corrupt the header.
+
+    for key, value in params.items():
+        if not isinstance(value, str):
+            # Fail loud rather than produce a literal 'None' or '[<Node>...]'
+            # in the rendered markdown.
+            raise TypeError(
+                f"Mermaid param {key!r} must be str, got {type(value).__name__}"
+            )
+        if "{{" in value or "}}" in value:
+            # Defensive log; single-pass `str.replace` still renders safely.
+            logger.warning(
+                "load_mermaid(%s): param %r contains nested placeholder tokens; "
+                "rendered output may be confusing",
+                name, key,
+            )
+        template = template.replace(f"{{{{{key}}}}}", value)
+    return template.strip()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def render(
+    tree_path: Path,
+    out_path: Path,
+    *,
+    max_mermaid_nodes: Optional[Dict[str, int]] = None,
+) -> None:
+    """Read metadata_tree.json and write architecture.md to out_path.
+
+    The renderer walks the tree once to collect catalog data (topics,
+    actions, flows, apex, prompts, unresolved refs, cycles) then emits
+    8 sections in document order. Generation-aware branches live at the
+    section-level helpers below.
+
+    Note: `_render_invocation_sequence` and `_render_planner_state`
+    remain defined and tested but are no longer part of the default
+    pipeline (heuristics distrusted by reviewers as of 2026-05).
+    Uncomment the relevant `parts.append` calls below to re-enable.
+    """
+    caps = dict(DEFAULT_MAX_MERMAID_NODES)
+    if max_mermaid_nodes:
+        caps.update(max_mermaid_nodes)
+
+    tree = json.loads(Path(tree_path).read_text())
+    agent = tree.get("agent") or {}
+    generation = (agent.get("generation") or "classic").lower()
+
+    walker = _TreeWalker(tree)
+    walker.walk()
+
+    parts: List[str] = []
+    parts.append(_render_header(tree, agent))
+    parts.append(_render_anatomy_summary(tree, walker))
+    # parts.append(_render_invocation_sequence(tree, agent, walker, caps))
+    # ^ Disabled 2026-05: heuristic over-simplified real orchestration
+    # paths. Function + template retained; re-enable by uncommenting.
+    parts.append(_render_action_tree(tree, walker, caps))
+    parts.append(_render_topic_anatomy(walker))
+    parts.append(_render_action_catalog(walker))
+    # parts.append(_render_planner_state(agent, generation, caps))
+    # ^ Disabled 2026-05: generation-specific state diagram added more
+    # noise than signal in review. Function + template retained; re-enable
+    # by uncommenting.
+    parts.append(_render_data_flow(tree, walker, caps))
+    parts.append(_render_artifact_catalogs(walker))
+    parts.append(_render_unresolved(tree, walker))
+
+    # Conditional dependency-graph section — emitted only if there are
+    # unresolved refs or cycles detected. Not counted as one of the 9.
+    if tree.get("_unresolved") or walker.cycles:
+        parts.append(_render_dependency_graph(tree, walker, caps))
+
+    Path(out_path).write_text("\n\n".join(parts).rstrip() + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Tree walker — single pass over the tree to collect catalog data
+# ---------------------------------------------------------------------------
+
+
+class _TreeWalker:
+    """Collects nodes, edges, topics, cycles in a single depth-first pass.
+
+    P2.2-1: BFS-equivalent visit budget already enforced by parse_wave
+    (MAX_BFS_DEPTH=5), so we don't need a depth cap here — the tree is
+    already bounded. We DO guard against a malformed tree with a
+    self-referential `children` ring by tracking id()'s.
+    """
+
+    def __init__(self, tree: Dict[str, Any]) -> None:
+        self.tree = tree
+        self.topics: List[Dict[str, Any]] = []
+        # actions = top-level children of each topic plus planner-level actions
+        self.actions: List[Dict[str, Any]] = []
+        self.flows: Dict[str, Dict[str, Any]] = {}
+        self.apex: Dict[str, Dict[str, Any]] = {}
+        self.prompts: Dict[str, Dict[str, Any]] = {}
+        self.standard_actions: Dict[str, Dict[str, Any]] = {}
+        # tree edges: parent api_name -> list of child api_name
+        self.edges: List[Tuple[str, str, str]] = []  # (parent, child, kind)
+        # fan-out map for summary-placeholder top-5
+        self.fanout: Dict[str, int] = {}
+        # cycle-back annotations: list of (node_label, cycle_back_to)
+        self.cycles: List[Tuple[str, str]] = []
+        # depth-cap truncations (subset of self.cycles surfaced by
+        # the unified _truncated annotation with reason="max-depth").
+        # Kept separate so downstream renderers can distinguish the two
+        # truncation classes without re-walking the tree.
+        self.depth_capped: List[Tuple[str, str]] = []
+        self._seen_py_ids: set[int] = set()
+
+    def walk(self) -> None:
+        root = self.tree.get("root") or {}
+        for child in root.get("children") or []:
+            self._visit(child, parent_label=root.get("api_name") or "ROOT",
+                        topic=None)
+
+    def _visit(
+        self,
+        node: Dict[str, Any],
+        *,
+        parent_label: str,
+        topic: Optional[Dict[str, Any]],
+    ) -> None:
+        if not isinstance(node, dict):
+            return
+        nid = id(node)
+        if nid in self._seen_py_ids:
+            return
+        self._seen_py_ids.add(nid)
+
+        kind = node.get("kind") or "UNKNOWN"
+        api_name = node.get("api_name") or node.get("element_name") or ""
+
+        # Top-level children of a BOT_DEFINITION with kind TOPIC feed the
+        # topic list. Non-topic top-level children (planner-level actions)
+        # attach to a synthetic `_plannerActions` bucket.
+        if kind == "TOPIC" and topic is None:
+            topic_rec = {
+                "api_name": api_name,
+                "label": node.get("master_label") or api_name,
+                "actions": [],
+                "raw": node,
+            }
+            self.topics.append(topic_rec)
+            topic = topic_rec
+        elif topic is None and kind == "GEN_AI_FUNCTION":
+            # plannerAction (classic Sequential / NGA) — no parent topic.
+            self.actions.append({
+                "kind": kind,
+                "api_name": api_name,
+                "topic": None,
+                "raw": node,
+            })
+        elif topic is not None and kind == "GEN_AI_FUNCTION":
+            action_rec = {
+                "kind": kind,
+                "api_name": api_name,
+                "topic": topic["api_name"],
+                "raw": node,
+            }
+            topic["actions"].append(action_rec)
+            self.actions.append(action_rec)
+
+        # Per-kind catalog buckets. We key on api_name; dupes collapse.
+        if kind == "FLOW" and api_name:
+            self.flows.setdefault(api_name, node)
+        elif kind == "APEX" and api_name:
+            self.apex.setdefault(api_name, node)
+        elif kind == "PROMPT_TEMPLATE" and api_name:
+            self.prompts.setdefault(api_name, node)
+        elif kind == "STANDARD_ACTION" and api_name:
+            self.standard_actions.setdefault(api_name, node)
+
+        # per-node truncation annotation (cycle OR depth-cap).
+        # Prefer the unified `_truncated` sub-object; fall back to the
+        # deprecated `_cycle_back_to` string for trees produced by
+        # older parse_wave versions.
+        trunc = node.get("_truncated") or {}
+        cycle_to = trunc.get("target") or node.get("_cycle_back_to")
+        reason = trunc.get("reason") or ("cycle" if cycle_to else None)
+        if cycle_to:
+            self.cycles.append((api_name or parent_label, str(cycle_to)))
+            # Optional: downstream renderers may want to distinguish
+            # the two truncation classes. We keep that open by stashing
+            # `reason` when present.
+            if reason and reason != "cycle":
+                self.depth_capped.append((api_name or parent_label, str(cycle_to)))
+
+        # Edge + fanout bookkeeping
+        children = node.get("children") or []
+        if api_name and parent_label and parent_label != api_name:
+            self.edges.append((parent_label, api_name, kind))
+            self.fanout[parent_label] = self.fanout.get(parent_label, 0) + 1
+
+        for child in children:
+            self._visit(child, parent_label=api_name or parent_label,
+                        topic=topic)
+
+    # ---- helpers -----------------------------------------------------
+
+    def total_nodes(self) -> int:
+        counts = self.tree.get("_kind_counts") or {}
+        return sum(counts.values()) or self.tree.get("node_count", 0)
+
+    def top_fanout(self, n: int = 5) -> List[Tuple[str, int]]:
+        return sorted(self.fanout.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+
+
+def _md_escape(value: Any) -> str:
+    if value is None:
+        return "-"
+    s = str(value)
+    # Escape the two characters that break markdown tables.
+    return s.replace("|", r"\|").replace("\n", " ")
+
+
+def _render_header(tree: Dict[str, Any], agent: Dict[str, Any]) -> str:
+    # P2.2-1: section 1 — kv table. No input is trusted (agent fields
+    # come from SOQL + metadata retrieve), but we escape pipes anyway.
+    lines = ["# Architecture — `{}` `{}`".format(
+        _md_escape(agent.get("api_name") or "?"),
+        _md_escape(agent.get("version") or "?"),
+    )]
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    rows = [
+        ("Master label", agent.get("master_label")),
+        ("Description", agent.get("description")),
+        ("Agent type", agent.get("agent_type")),
+        ("Type", agent.get("type")),
+        ("Template", agent.get("agent_template")),
+        ("Bot source", agent.get("bot_source")),
+        ("Generation", agent.get("generation")),
+        ("Planner name", agent.get("planner_name")),
+        ("Planner type", agent.get("planner_type")),
+        ("Bot id", agent.get("bot_id")),
+        ("Schema version", tree.get("_schema_version")),
+    ]
+    for label, value in rows:
+        lines.append(f"| {label} | {_md_escape(value)} |")
+    return "\n".join(lines)
+
+
+def _render_anatomy_summary(tree: Dict[str, Any], walker: _TreeWalker) -> str:
+    # P2.2-1: section 2 renders health callout when _partial=true.
+    kc = tree.get("_kind_counts") or {}
+    lines = ["## 2. Anatomy summary", ""]
+    topic_count = kc.get("TOPIC", len(walker.topics))
+    action_count = kc.get("GEN_AI_FUNCTION", len(walker.actions))
+    flow_count = kc.get("FLOW", len(walker.flows))
+    apex_count = kc.get("APEX", len(walker.apex))
+    prompt_count = kc.get("PROMPT_TEMPLATE", len(walker.prompts))
+    stdaction_count = kc.get("STANDARD_ACTION", len(walker.standard_actions))
+
+    lines.append(
+        "Agent exposes **{} topics** and **{} declared actions** "
+        "spanning **{} flows**, **{} apex classes**, **{} prompt templates**, "
+        "and **{} standard actions**. Tree depth is {} across {} total nodes.".format(
+            topic_count, action_count, flow_count, apex_count,
+            prompt_count, stdaction_count,
+            tree.get("depth", "?"), walker.total_nodes(),
+        )
+    )
+
+    if tree.get("_partial"):
+        pending = tree.get("_pending_fetches") or {}
+        pending_count = sum(len(v) for v in pending.values())
+        reason = tree.get("_partial_reason") or "unspecified"
+        lines.append("")
+        lines.append("> **Health: PARTIAL.** The tree did not fully converge.")
+        lines.append(f"> - Reason: `{_md_escape(reason)}`")
+        lines.append(f"> - Pending fetches: {pending_count}")
+        if pending:
+            for key, items in pending.items():
+                if items:
+                    lines.append(
+                        f">   - `{_md_escape(key)}`: {len(items)} outstanding"
+                    )
+
+    # P2.2-1: health callout when planner_name is missing.
+    agent = tree.get("agent") or {}
+    if not agent.get("planner_name"):
+        lines.append("")
+        lines.append(
+            "> **Health: WARN.** `planner_name` missing from agent metadata — "
+            "downstream sections render best-effort from tree shape alone."
+        )
+
+    if tree.get("_unresolved"):
+        lines.append("")
+        lines.append(
+            "> **Health: WARN.** {} unresolved references — see section 8.".format(
+                len(tree["_unresolved"])
+            )
+        )
+
+    return "\n".join(lines)
+
+
+def _render_invocation_sequence(
+    tree: Dict[str, Any],
+    agent: Dict[str, Any],
+    walker: _TreeWalker,
+    caps: Dict[str, int],
+) -> str:
+    # P2.2-1: section 3 — sequenceDiagram with cap check.
+    lines = ["## 3. Invocation sequence", ""]
+    generation = (agent.get("generation") or "classic").lower()
+
+    participants = ["participant User", "    participant Planner"]
+    if generation == "nga":
+        participants.append("    participant Orchestrator")
+        participants.append("    participant SubAgent")
+    else:
+        participants.append("    participant TopicClassifier")
+    participants.append("    participant ActionExecutor")
+
+    messages: List[str] = []
+    messages.append("    User->>+Planner: utterance")
+    if generation == "nga":
+        messages.append("    Planner->>+Orchestrator: plan")
+        messages.append("    Orchestrator->>+SubAgent: dispatch (par/and)")
+        messages.append("    SubAgent->>+ActionExecutor: invoke action")
+        messages.append("    ActionExecutor-->>-SubAgent: result")
+        messages.append("    SubAgent-->>-Orchestrator: subresult")
+        messages.append("    Orchestrator-->>-Planner: aggregated")
+    elif (agent.get("planner_type") or "").endswith("SequentialPlannerIntentClassifier"):
+        messages.append("    Planner->>+ActionExecutor: direct intent->action")
+        messages.append("    ActionExecutor-->>-Planner: result")
+    else:
+        # Classic ReAct — one round-trip per topic (sampled at :5 for
+        # readability). The cap check below counts the ACTUAL rendered
+        # messages, so a 30-topic bot whose ReAct branch only emits 12
+        # lines is correctly NOT truncated.
+        for topic in walker.topics[:5]:  # sample for readability
+            label = _md_escape(topic["api_name"])
+            messages.append(f"    Planner->>+TopicClassifier: classify → {label}")
+            messages.append(f"    TopicClassifier-->>-Planner: topic={label}")
+        messages.append("    Planner->>+ActionExecutor: invoke action")
+        messages.append("    ActionExecutor-->>-Planner: result")
+
+    messages.append("    Planner-->>-User: response")
+
+    # cap against ACTUAL rendered message count, not a
+    # potential / over-estimated figure. The prior implementation used
+    # `2 * len(walker.topics) + len(walker.actions) + 2`, which false-
+    # tripped on large bots because the ReAct branch only emits
+    # `2 * min(len(walker.topics), 5) + 2` lines (topics[:5] sampling).
+    # The rendered-list length is the single source of truth.
+    msg_count = len(messages)
+    if msg_count > caps.get("sequenceDiagram", 60):
+        lines.append(_truncation_placeholder(
+            kind="sequenceDiagram", total=msg_count,
+            cap=caps["sequenceDiagram"],
+            top_fanout=walker.top_fanout(5),
+            catalog_pointer="section 5 (action catalog)",
+        ))
+        return "\n".join(lines)
+
+    rendered = load_mermaid(
+        "invocation_sequence",
+        PARTICIPANTS="\n".join(participants).lstrip(),
+        MESSAGES="\n".join(messages).lstrip(),
+    )
+    lines.append("```mermaid")
+    lines.append(rendered)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _render_action_tree(
+    tree: Dict[str, Any],
+    walker: _TreeWalker,
+    caps: Dict[str, int],
+) -> str:
+    # P2.2-1: section 3 — flowchart + subgraphs per topic; cycle back-edges.
+    lines = ["## 3. Action tree", ""]
+    total_nodes = walker.total_nodes()
+    if total_nodes > caps.get("flowchart", 200):
+        lines.append(_truncation_placeholder(
+            kind="flowchart", total=total_nodes,
+            cap=caps["flowchart"],
+            top_fanout=walker.top_fanout(5),
+            catalog_pointer="section 5 (action catalog) and section 7 (artifact catalogs)",
+        ))
+        lines.append("")
+        lines.append(_render_action_tree_ascii(walker))
+        return "\n".join(lines)
+
+    # Build subgraphs and edges
+    subgraphs: List[str] = []
+    for topic in walker.topics:
+        sg_id = _safe_id(topic["api_name"])
+        sg_lines = [f"    subgraph {sg_id}[\"{_md_escape(topic['label'])}\"]"]
+        for action in topic["actions"]:
+            node_id = _safe_id(action["api_name"])
+            label = _display_name(action.get("raw") or action)
+            sg_lines.append(f"        {node_id}[\"{_md_escape(label)}\"]")
+        sg_lines.append("    end")
+        subgraphs.append("\n".join(sg_lines))
+
+    # Planner-level actions (no topic)
+    planner_actions = [a for a in walker.actions if a.get("topic") is None]
+    if planner_actions:
+        sg_lines = ["    subgraph _plannerActions[\"(plannerActions)\"]"]
+        for action in planner_actions:
+            node_id = _safe_id(action["api_name"])
+            label = _display_name(action.get("raw") or action)
+            sg_lines.append(f"        {node_id}[\"{_md_escape(label)}\"]")
+        sg_lines.append("    end")
+        subgraphs.append("\n".join(sg_lines))
+
+    edges: List[str] = []
+    for parent, child, kind in walker.edges:
+        pid = _safe_id(parent)
+        cid = _safe_id(child)
+        edges.append(f"    {pid} --> {cid}")
+
+    # Cycle back-edges (dotted)
+    for node_label, cycle_to in walker.cycles:
+        nid = _safe_id(node_label)
+        tid = _safe_id(cycle_to)
+        edges.append(f"    {nid} -.->|cycle_back_to: {_md_escape(cycle_to)}| {tid}")
+
+    rendered = load_mermaid(
+        "action_tree",
+        SUBGRAPHS="\n\n".join(subgraphs).lstrip() if subgraphs else "%% no topics",
+        EDGES="\n".join(edges).lstrip() if edges else "%% no edges",
+    )
+    lines.append("```mermaid")
+    lines.append(rendered)
+    lines.append("```")
+    lines.append("")
+    lines.append("**ASCII appendix**")
+    lines.append("")
+    lines.append("```")
+    lines.append(_render_action_tree_ascii(walker))
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _render_action_tree_ascii(walker: _TreeWalker) -> str:
+    out: List[str] = []
+    root = walker.tree.get("root") or {}
+    out.append(f"{root.get('api_name', 'ROOT')} ({root.get('kind', 'BOT_DEFINITION')})")
+    _ascii_recurse(root.get("children") or [], out, depth=1, seen=set())
+    return "\n".join(out)
+
+
+def _ascii_recurse(
+    children: List[Dict[str, Any]],
+    out: List[str],
+    depth: int,
+    seen: set[int],
+) -> None:
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        nid = id(child)
+        if nid in seen:
+            continue
+        seen.add(nid)
+        name = _display_name(child)
+        kind = child.get("kind") or "?"
+        # surface BOTH cycle AND max-depth truncation in the ASCII
+        # tree view. Prefer `_truncated["reason"]`; fall back to the
+        # legacy `_cycle_back_to` string (older parse_wave output).
+        trunc = child.get("_truncated") or {}
+        if trunc.get("reason") == "max-depth":
+            marker = " [depth-capped]"
+        elif trunc.get("reason") == "cycle" or child.get("_cycle_back_to"):
+            marker = " [cycle]"
+        else:
+            marker = ""
+        out.append(f"{'  ' * depth}├── [{kind}] {name}{marker}")
+        grand = child.get("children") or []
+        if grand:
+            _ascii_recurse(grand, out, depth + 1, seen)
+
+
+def _render_topic_anatomy(walker: _TreeWalker) -> str:
+    # P2.2-1: section 4 — H3 per topic + kv list. Empty-case: 0 topics is
+    # valid for SequentialPlannerIntentClassifier.
+    lines = ["## 4. Topic anatomy", ""]
+    if not walker.topics:
+        lines.append("_No topics defined (planner exposes actions directly)._")
+        return "\n".join(lines)
+    for topic in walker.topics:
+        lines.append(f"### `{_md_escape(topic['api_name'])}`")
+        lines.append("")
+        lines.append(f"- Label: {_md_escape(topic['label'])}")
+        lines.append(f"- Action count: {len(topic['actions'])}")
+        if topic["actions"]:
+            lines.append("- Actions:")
+            for action in topic["actions"]:
+                label = _display_name(action.get("raw") or action)
+                lines.append(f"  - `{_md_escape(label)}`")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _render_action_catalog(walker: _TreeWalker) -> str:
+    # P2.2-1: section 5 — markdown table of actions.
+    lines = ["## 5. Action catalog", ""]
+    if not walker.actions:
+        lines.append("_No actions declared._")
+        return "\n".join(lines)
+    lines.append("| Action | Topic | Unwraps to |")
+    lines.append("|---|---|---|")
+    for action in walker.actions:
+        raw = action.get("raw") or {}
+        unwrap = raw.get("unwraps_to") or {}
+        unwrap_str = "-"
+        if unwrap:
+            unwrap_str = "{} `{}`".format(
+                unwrap.get("kind", "?"),
+                _display_name(unwrap),
+            )
+        lines.append("| `{}` | {} | {} |".format(
+            _md_escape(action["api_name"]),
+            _md_escape(action.get("topic") or "(plannerAction)"),
+            _md_escape(unwrap_str),
+        ))
+    return "\n".join(lines)
+
+
+def _planner_state_for_generation(
+    agent: Dict[str, Any], generation: str,
+) -> Tuple[List[str], List[str]]:
+    """Return (states, transitions) for the planner state machine."""
+    planner_type = (agent.get("planner_type") or "").lower()
+    if generation == "nga":
+        states = [
+            "[*] --> Planning",
+            "    state Planning",
+            "    state Orchestration {",
+            "        direction LR",
+            "        [*] --> Dispatch",
+            "        Dispatch --> SubAgentA",
+            "        Dispatch --> SubAgentB",
+            "        --",
+            "        SubAgentA --> Aggregate",
+            "        SubAgentB --> Aggregate",
+            "    }",
+            "    state Respond",
+        ]
+        transitions = [
+            "    Planning --> Orchestration: par/and dispatch",
+            "    Orchestration --> Respond: aggregated",
+            "    Respond --> [*]",
+        ]
+        return states, transitions
+    if planner_type.endswith("sequentialplannerintentclassifier"):
+        states = [
+            "[*] --> Classify",
+            "    state Classify",
+            "    state Execute",
+            "    state Respond",
+        ]
+        transitions = [
+            "    Classify --> Execute: intent",
+            "    Execute --> Respond: result",
+            "    Respond --> [*]",
+        ]
+        return states, transitions
+    # Default: classic ReAct
+    states = [
+        "[*] --> Thought",
+        "    state Thought",
+        "    state Action",
+        "    state Observation",
+        "    state Respond",
+    ]
+    transitions = [
+        "    Thought --> Action: pick tool",
+        "    Action --> Observation: tool result",
+        "    Observation --> Thought: more reasoning",
+        "    Observation --> Respond: done",
+        "    Respond --> [*]",
+    ]
+    return states, transitions
+
+
+def _render_planner_state(
+    agent: Dict[str, Any],
+    generation: str,
+    caps: Dict[str, int],
+) -> str:
+    # P2.2-1: section 6 — stateDiagram-v2 with generation-aware branches.
+    lines = ["## 6. Planner state machine", ""]
+
+    if generation in ("search", "byop"):
+        lines.append(
+            "_Custom planner — structure depends on the planner's Apex class_ "
+            f"(`{_md_escape(agent.get('planner_type') or '?')}`). State "
+            "diagram skipped; see section 7 for the backing Apex class body."
+        )
+        return "\n".join(lines)
+
+    states, transitions = _planner_state_for_generation(agent, generation)
+    total = len(states) + len(transitions)
+    if total > caps.get("stateDiagram", 40):
+        lines.append(_truncation_placeholder(
+            kind="stateDiagram", total=total,
+            cap=caps["stateDiagram"],
+            top_fanout=[],
+            catalog_pointer="section 7 (artifact catalogs)",
+        ))
+        return "\n".join(lines)
+
+    rendered = load_mermaid(
+        "planner_state",
+        STATES="\n".join(states).lstrip(),
+        TRANSITIONS="\n".join(transitions).lstrip(),
+    )
+    lines.append("```mermaid")
+    lines.append(rendered)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _render_data_flow(
+    tree: Dict[str, Any],
+    walker: _TreeWalker,
+    caps: Dict[str, int],
+) -> str:
+    # P2.2-1: section 6 — flowchart LR with labeled param edges.
+    lines = ["## 6. Data flow / context propagation", ""]
+
+    # Build node list — User, Planner, each topic, each action.
+    nodes: List[str] = ["    User([User utterance])", "    Planner[Planner]"]
+    for topic in walker.topics:
+        nodes.append(f"    {_safe_id(topic['api_name'])}[Topic: {_md_escape(topic['api_name'])}]")
+
+    edges: List[str] = ["    User --> Planner"]
+    for topic in walker.topics:
+        edges.append(f"    Planner --> {_safe_id(topic['api_name'])}")
+        for action in topic["actions"]:
+            label = _display_name(action.get("raw") or action)
+            nodes.append(
+                f"    {_safe_id(action['api_name'])}[[Action: {_md_escape(label)}]]"
+            )
+            # Labeled edge when the planner attr metadata declares a
+            # parameter hand-off; fall back to a bare edge otherwise.
+            attr = (action.get("raw") or {}).get("planner_attr") or {}
+            var_name = attr.get("variable_name") or attr.get("name")
+            var_type = attr.get("data_type") or attr.get("type")
+            if var_name:
+                label = _md_escape(var_name)
+                if var_type:
+                    label = f"{label}: {_md_escape(var_type)}"
+                edges.append(
+                    f"    {_safe_id(topic['api_name'])} -->|{label}| "
+                    f"{_safe_id(action['api_name'])}"
+                )
+            else:
+                edges.append(
+                    f"    {_safe_id(topic['api_name'])} --> "
+                    f"{_safe_id(action['api_name'])}"
+                )
+
+    total = len(nodes) + len(edges)
+    if total > caps.get("flowchart", 200):
+        lines.append(_truncation_placeholder(
+            kind="flowchart", total=total,
+            cap=caps["flowchart"],
+            top_fanout=walker.top_fanout(5),
+            catalog_pointer="section 7 (artifact catalogs)",
+        ))
+        return "\n".join(lines)
+
+    rendered = load_mermaid(
+        "data_flow",
+        NODES="\n".join(nodes).lstrip(),
+        EDGES="\n".join(edges).lstrip(),
+    )
+    lines.append("```mermaid")
+    lines.append(rendered)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _render_artifact_catalogs(walker: _TreeWalker) -> str:
+    # P2.2-1: section 7 — H3 per flow / apex / prompt + signature.
+    lines = ["## 7. Flow / Apex / Prompt catalogs", ""]
+
+    if walker.flows:
+        lines.append("### Flows")
+        lines.append("")
+        for name in sorted(walker.flows):
+            node = walker.flows[name]
+            sig = node.get("signature") or node.get("_signature")
+            # Gap 2 fix (2026-05-05): main._stamp_signatures stamps
+            # `_signature_reason` on flows whose body we can't retrieve
+            # (managed package, no active version, metadata fetch miss).
+            # Surface the reason so the rendered markdown distinguishes
+            # a known limitation from a silent hole.
+            reason = node.get("_signature_reason")
+            lines.append(f"#### `{_md_escape(name)}`")
+            lines.append("")
+            if sig:
+                lines.append("```")
+                lines.append(str(sig))
+                lines.append("```")
+            elif reason:
+                lines.append(f"_Signature not captured — {_md_escape(reason)}._")
+            else:
+                lines.append("_Signature not captured._")
+            lines.append("")
+
+    if walker.apex:
+        lines.append("### Apex classes")
+        lines.append("")
+        for name in sorted(walker.apex):
+            node = walker.apex[name]
+            sig = node.get("signature") or node.get("_signature")
+            lines.append(f"#### `{_md_escape(name)}`")
+            lines.append("")
+            if sig:
+                lines.append("```")
+                lines.append(str(sig))
+                lines.append("```")
+            else:
+                lines.append("_Signature not captured._")
+            lines.append("")
+
+    if walker.prompts:
+        lines.append("### Prompt templates")
+        lines.append("")
+        for name in sorted(walker.prompts):
+            node = walker.prompts[name]
+            sig = node.get("signature") or node.get("_signature")
+            prompt_type = node.get("prompt_type")
+            # Gap C (2026-05-05): retrieve_prompt_templates stamps
+            # master_label / content / inputs / _body_available onto
+            # each PROMPT_TEMPLATE leaf. Emit the real body when
+            # available; fall back to the stub only when `_body_available`
+            # is explicitly False (retrieve failed / not requested) AND
+            # there's no signature/type to show.
+            master_label = node.get("master_label")
+            content = node.get("content")
+            inputs = node.get("inputs") or []
+            body_available = node.get("_body_available")
+            lines.append(f"#### `{_md_escape(name)}`")
+            lines.append("")
+            if master_label:
+                lines.append(f"_Label: {_md_escape(master_label)}_")
+                lines.append("")
+            if prompt_type:
+                lines.append(f"- Type: `{_md_escape(prompt_type)}`")
+            if inputs:
+                lines.append("**Inputs**:")
+                for inp in inputs:
+                    if not isinstance(inp, dict):
+                        continue
+                    iname = inp.get("name") or "?"
+                    itype = inp.get("dataType")
+                    if itype:
+                        lines.append(
+                            f"- `{_md_escape(iname)}`: "
+                            f"`{_md_escape(itype)}`"
+                        )
+                    else:
+                        lines.append(f"- `{_md_escape(iname)}`")
+                lines.append("")
+            if content:
+                lines.append("```text")
+                lines.append(str(content))
+                lines.append("```")
+            elif sig:
+                lines.append("```")
+                lines.append(str(sig))
+                lines.append("```")
+            if (
+                not content and not sig and not prompt_type
+                and not master_label and not inputs
+            ):
+                if body_available is False:
+                    lines.append("_Body not retrieved._")
+                else:
+                    lines.append("_Details not captured._")
+            lines.append("")
+
+    if not (walker.flows or walker.apex or walker.prompts):
+        lines.append("_No backing artifacts in tree._")
+
+    return "\n".join(lines).rstrip()
+
+
+def _render_unresolved(tree: Dict[str, Any], walker: _TreeWalker) -> str:
+    # P2.2-1: section 8 — unresolved refs + artifact pointers.
+    lines = ["## 8. Unresolved refs + artifact pointers", ""]
+    unresolved = tree.get("_unresolved") or []
+    if unresolved:
+        lines.append("> **{} unresolved refs.**".format(len(unresolved)))
+        lines.append("")
+        lines.append("| Kind | Api name | Reason |")
+        lines.append("|---|---|---|")
+        for ref in unresolved:
+            lines.append("| {} | `{}` | {} |".format(
+                _md_escape(ref.get("kind") or "?"),
+                _md_escape(ref.get("api_name") or "?"),
+                _md_escape(ref.get("reason") or "?"),
+            ))
+    else:
+        lines.append("_No unresolved references._")
+    lines.append("")
+    lines.append("### Artifact pointers")
+    lines.append("")
+    lines.append(
+        "- Full tree JSON: same directory as this file (`metadata_tree.json`)"
+    )
+    lines.append("- Build manifest: cache dir / `manifest.json`")
+    return "\n".join(lines)
+
+
+def _render_dependency_graph(
+    tree: Dict[str, Any],
+    walker: _TreeWalker,
+    caps: Dict[str, int],
+) -> str:
+    # P2.2-1: conditional — render only on unresolved or cycles.
+    lines = ["## Dependency graph (conditional)", ""]
+    unresolved = tree.get("_unresolved") or []
+
+    nodes: List[str] = []
+    edges: List[str] = []
+    seen: set[str] = set()
+
+    def add_node(label: str, unresolved_flag: bool) -> None:
+        nid = _safe_id(label)
+        if nid in seen:
+            return
+        seen.add(nid)
+        suffix = ":::unresolved" if unresolved_flag else ""
+        nodes.append(f"    {nid}[{_md_escape(label)}]{suffix}")
+
+    for parent, child, _ in walker.edges:
+        add_node(parent, False)
+        add_node(child, False)
+        edges.append(f"    {_safe_id(parent)} --> {_safe_id(child)}")
+
+    for ref in unresolved:
+        name = ref.get("api_name") or "?"
+        add_node(name, True)
+
+    for node_label, cycle_to in walker.cycles:
+        add_node(node_label, False)
+        add_node(cycle_to, False)
+        edges.append(
+            f"    {_safe_id(node_label)} -.->|cycle| {_safe_id(cycle_to)}"
+        )
+
+    total = len(nodes)
+    if total > caps.get("graph", 100):
+        lines.append(_truncation_placeholder(
+            kind="graph", total=total,
+            cap=caps["graph"],
+            top_fanout=walker.top_fanout(5),
+            catalog_pointer="section 8 (unresolved refs)",
+        ))
+        return "\n".join(lines)
+
+    rendered = load_mermaid(
+        "dependency_graph",
+        NODES="\n".join(nodes).lstrip() if nodes else "%% no nodes",
+        EDGES="\n".join(edges).lstrip() if edges else "%% no edges",
+    )
+    lines.append("```mermaid")
+    lines.append(rendered)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncation_placeholder(
+    *,
+    kind: str,
+    total: int,
+    cap: int,
+    top_fanout: List[Tuple[str, int]],
+    catalog_pointer: str,
+) -> str:
+    # P2.2-1: explicit visual placeholder. Mentions the diagram kind, the
+    # over-cap count, and points at the catalog section.
+    lines = [
+        f"> **[diagram truncated: {kind} — {total} elements exceed cap of {cap}]**",
+    ]
+    if top_fanout:
+        lines.append(">")
+        lines.append("> Top 5 nodes by fan-out:")
+        for name, count in top_fanout:
+            lines.append(f"> - `{_md_escape(name)}` ({count})")
+    lines.append(">")
+    lines.append(f"> See {catalog_pointer} for the full listing.")
+    return "\n".join(lines)
+
+
+def _safe_id(value: str) -> str:
+    """Return a mermaid-safe identifier. Mermaid node ids must be
+    alphanumeric + underscore; anything else breaks the parser."""
+    if not value:
+        return "n_empty"
+    out = []
+    for ch in str(value):
+        if ch.isalnum() or ch == "_":
+            out.append(ch)
+        else:
+            out.append("_")
+    # Prefix digit-leading ids so they don't collide with mermaid syntax.
+    result = "".join(out)
+    if result and result[0].isdigit():
+        result = f"n_{result}"
+    return result or "n_empty"

--- a/skills/investigating-agentforce-architecture/scripts/resolve_bot.py
+++ b/skills/investigating-agentforce-architecture/scripts/resolve_bot.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Bot + version resolution via two sf data query calls.
+
+Replaces the old agent's Phase 0b–0e (bot/version SOQL, natural-key sort,
+error-block assembly) + Phase 1's parallel BotDefinition SOQL. One process,
+one RESULT-block emission point.
+
+Flow:
+  1. `sf data query` for BotVersion WHERE BotDefinition.DeveloperName=$AGENT_API_NAME.
+  2. If 0 rows → follow-up query for AVAILABLE_BOTS, emit STATUS=AGENT_NOT_FOUND.
+  3. Natural-key sort versions (v10 > v9 > v2 > v1); pick explicit match or
+     Active highest-numbered auto-pick.
+  4. If no match → emit STATUS=AGENT_VERSION_NOT_FOUND with AVAILABLE_VERSIONS
+     in `v5(Active),v4(Inactive),...` form.
+  5. Run a second `sf data query` for BotDefinition (MasterLabel, Description,
+     AgentType, Type, AgentTemplate, BotSource) and write `_bot_definition.json`
+     for parse_wave.py.
+
+On success, prints eval-friendly KV lines to stdout:
+    BOT_FOUND=true
+    BOT_ID=<18-char>
+    BOT_MASTER_LABEL=<shlex-quoted>
+    AGENT_VERSION=<resolved version>
+    VERSION_AUTO_PICKED=true|false
+
+Also writes `$WORK_DIR/_bot_versions.json` + `$WORK_DIR/_bot_definition.json`
+as raw sidecars (archived into the cache by finalize.py).
+
+Usage:
+    eval "$(python3 resolve_bot.py)"
+
+Inputs (env):
+    ORG_ALIAS         required — sf CLI target org alias
+    AGENT_API_NAME    required — BotDefinition.DeveloperName
+    AGENT_VERSION     optional — explicit BotVersion.DeveloperName (if empty, auto-pick)
+    WORK_DIR          required — sidecar JSON landing area
+    ORG_ID_15         optional — used for error-block context
+    ORG_ID_18         optional — used for error-block context
+    ERROR_TEE         optional — tee path for error RESULT blocks
+
+Outputs:
+    stdout on success: eval-able KV lines (above)
+    stdout on error:   full STATUS=AGENT_NOT_FOUND|AGENT_VERSION_NOT_FOUND block
+    files: $WORK_DIR/_bot_versions.json, _bot_definition.json, _all_bots.json (on miss)
+    exit 0 on success, 1 on any failure branch
+"""
+import json
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+
+
+def scrub(s) -> str:
+    if not isinstance(s, str):
+        s = "" if s is None else str(s)
+    bad = set("`$\"\\\r\t\0\n")
+    return "".join(c for c in s if c not in bad)
+
+
+def emit_error_block(status: str, error_detail: str, extras: dict) -> None:
+    """Write a terminal RESULT block to stdout + $ERROR_TEE, then exit 1."""
+    lines = [
+        "=== RESULT ===",
+        f"STATUS={status}",
+        f"ERROR_DETAIL={scrub(error_detail)}",
+        f"AGENT_API_NAME={scrub(os.environ.get('AGENT_API_NAME', ''))}",
+        f"ORG_ID_15={scrub(os.environ.get('ORG_ID_15', ''))}",
+        f"ORG_ID_18={scrub(os.environ.get('ORG_ID_18', ''))}",
+    ]
+    for k, v in extras.items():
+        lines.append(f"{k}={scrub(v)}")
+    block = "\n".join(lines) + "\n"
+
+    tee_path = os.environ.get("ERROR_TEE")
+    if tee_path:
+        try:
+            p = pathlib.Path(tee_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            tmp = p.with_suffix(p.suffix + ".tmp")
+            tmp.write_text(block)
+            os.replace(tmp, p)
+        except OSError:
+            pass
+
+    sys.stdout.write(block)
+    sys.exit(1)
+
+
+def run_sf_query(query: str, out_path: pathlib.Path, org_alias: str) -> dict:
+    """Run `sf data query --json` and return parsed JSON (or {} on failure)."""
+    try:
+        result = subprocess.run(
+            ["sf", "data", "query",
+             "--target-org", org_alias,
+             "--json",
+             "--query", query],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        emit_error_block(
+            "AUTH_REQUIRED",
+            f"sf data query failed ({type(e).__name__}: {e}) — check sf CLI install + auth",
+            {},
+        )
+        return {}  # unreachable
+    if result.returncode != 0:
+        # Print stderr to help user debug, then bail as AUTH_REQUIRED (most
+        # common cause is the target-org alias not being logged in)
+        emit_error_block(
+            "AUTH_REQUIRED",
+            f"sf data query returned rc={result.returncode}: {result.stderr[:200]}",
+            {},
+        )
+    try:
+        out_path.write_text(result.stdout)
+        return json.loads(result.stdout)
+    except (OSError, json.JSONDecodeError) as e:
+        emit_error_block(
+            "AUTH_REQUIRED",
+            f"sf data query JSON parse error: {e}",
+            {},
+        )
+        return {}  # unreachable
+
+
+def natural_key(v: str):
+    return [int(p) if p.isdigit() else p for p in re.split(r"(\d+)", v or "")]
+
+
+def main() -> int:
+    try:
+        org_alias = os.environ["ORG_ALIAS"]
+        agent_api_name = os.environ["AGENT_API_NAME"]
+        work_dir = pathlib.Path(os.environ["WORK_DIR"])
+    except KeyError as e:
+        sys.stderr.write(f"resolve_bot.py: missing env {e}\n")
+        return 1
+
+    explicit_version = os.environ.get("AGENT_VERSION", "").strip()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Step 1: BotVersion query (with BotDefinition join) ---
+    q_versions = (
+        "SELECT Id, DeveloperName, Status, BotDefinitionId, "
+        "BotDefinition.DeveloperName, BotDefinition.MasterLabel "
+        f"FROM BotVersion WHERE BotDefinition.DeveloperName='{agent_api_name}'"
+    )
+    versions_json = run_sf_query(q_versions, work_dir / "_bot_versions.json", org_alias)
+    records = (versions_json.get("result") or {}).get("records") or []
+
+    # --- Step 2: AGENT_NOT_FOUND branch ---
+    if not records:
+        q_all = "SELECT DeveloperName FROM BotDefinition ORDER BY DeveloperName"
+        all_bots = run_sf_query(q_all, work_dir / "_all_bots.json", org_alias)
+        bots_csv = ",".join(
+            r.get("DeveloperName", "")
+            for r in ((all_bots.get("result") or {}).get("records") or [])
+            if r.get("DeveloperName")
+        )
+        emit_error_block(
+            "AGENT_NOT_FOUND",
+            f"BotDefinition.DeveloperName '{agent_api_name}' not found in org {org_alias}",
+            {"AVAILABLE_BOTS": bots_csv},
+        )
+        return 1  # unreachable
+
+    # --- Step 3: sort (natural-key, DESC) + pick ---
+    records.sort(key=lambda r: natural_key(r.get("DeveloperName") or ""), reverse=True)
+    picked = None
+    if explicit_version:
+        for v in records:
+            if v.get("DeveloperName") == explicit_version:
+                picked = v
+                break
+        version_auto_picked = False
+    else:
+        for v in records:
+            if v.get("Status") == "Active":
+                picked = v
+                break
+        version_auto_picked = True
+
+    # --- Step 4: AGENT_VERSION_NOT_FOUND branch ---
+    if not picked:
+        vers_csv = ",".join(
+            f"{v.get('DeveloperName', '?')}({v.get('Status', '?')})"
+            for v in records
+        )
+        requested = explicit_version or "<auto-pick>"
+        emit_error_block(
+            "AGENT_VERSION_NOT_FOUND",
+            f"No matching BotVersion under BotDefinition {agent_api_name} (requested: '{requested}')",
+            {
+                "AVAILABLE_VERSIONS": vers_csv,
+                "BOT_ID": picked.get("BotDefinitionId") if picked else (records[0].get("BotDefinitionId") or ""),
+            },
+        )
+        return 1  # unreachable
+
+    bot_id = picked.get("BotDefinitionId") or ""
+    bd_node = picked.get("BotDefinition") or {}
+    bot_master_label = bd_node.get("MasterLabel") or ""
+    chosen_version = picked.get("DeveloperName") or ""
+
+    # --- Step 5: BotDefinition metadata (for parse_wave.py enrichment) ---
+    q_def = (
+        "SELECT DeveloperName, MasterLabel, Description, AgentType, Type, "
+        "AgentTemplate, BotSource FROM BotDefinition "
+        f"WHERE DeveloperName='{agent_api_name}' LIMIT 1"
+    )
+    try:
+        result = subprocess.run(
+            ["sf", "data", "query",
+             "--target-org", org_alias,
+             "--json",
+             "--query", q_def],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            (work_dir / "_bot_definition.json").write_text(result.stdout)
+        else:
+            # Non-fatal; parse_wave.py tolerates an empty bot_definition.json
+            (work_dir / "_bot_definition.json").write_text('{"result":{"records":[]}}')
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        (work_dir / "_bot_definition.json").write_text('{"result":{"records":[]}}')
+
+    # --- Success: emit eval-friendly lines ---
+    out_lines = [
+        "BOT_FOUND=true",
+        f"BOT_ID={shlex.quote(bot_id)}",
+        f"BOT_MASTER_LABEL={shlex.quote(bot_master_label)}",
+        f"AGENT_VERSION={shlex.quote(chosen_version)}",
+        f"VERSION_AUTO_PICKED={'true' if version_auto_picked else 'false'}",
+    ]
+    sys.stdout.write("\n".join(out_lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/resolve_invocation_target.py
+++ b/skills/investigating-agentforce-architecture/scripts/resolve_invocation_target.py
@@ -1,0 +1,130 @@
+"""NGA InvocationTarget ID-prefix router.
+
+NGA bots store Salesforce Ids in GenAiFunctionDefinition.InvocationTarget,
+not DeveloperNames. This module resolves the kind by the 3-char key prefix.
+
+unknown prefixes MUST NEVER raise — Salesforce is free to introduce
+new NGA target types (e.g., a hypothetical `0aN...` AgentCapability) and
+the skill must degrade gracefully. Callers use `resolve_or_unresolved` to
+append a `_unresolved[]` entry with a diagnostic reason and get back
+`("unknown", "skip")` so the wave orchestrator can keep parsing.
+
+Invariants:
+  * Only the 3-char prefix is consulted for Id-based routing — 15-char
+    and 18-char Ids both map the same way.
+  * `standard_action` kind is selected by caller context (bundle's
+    `invocationTargetType == "standardInvocableAction"`), not by prefix —
+    standard actions have no Id. Its presence in the Kind union is
+    scaffolding for call-site type-checking.
+  * `REGISTERED_PREFIXES` exposes the known prefix set as a frozenset for
+    tests and probe-channel validation.
+"""
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+Kind = Literal[
+    "apex",
+    "flow_definition",
+    "flow_version",
+    "prompt_template",
+    "standard_action",
+    "unknown",
+]
+Channel = Literal[
+    "tooling_soql",
+    "retrieve_required",
+    "skip",
+]
+
+_PREFIX_MAP: dict[str, tuple[Kind, Channel]] = {
+    "01p": ("apex", "tooling_soql"),
+    "300": ("flow_definition", "tooling_soql"),
+    "301": ("flow_version", "tooling_soql"),
+    "0hf": ("prompt_template", "retrieve_required"),
+}
+
+# public reverse-lookup set. `frozenset` (not set) so callers can't
+# mutate the authoritative table by accident.
+REGISTERED_PREFIXES: frozenset[str] = frozenset(_PREFIX_MAP.keys())
+
+# Salesforce Ids are 15 or 18 chars, alphanumeric only. This is the gate
+# between "could be a real Id with an unknown prefix" (treat as an NGA
+# addition we don't know about yet) and "garbage input" (empty, wrong
+# length, bad characters — treat as invalid format).
+_SF_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
+_SF_ID_LENGTHS = frozenset({15, 18})
+
+
+def looks_like_sf_id(id_str: object) -> bool:
+    """True iff `id_str` is a 15- or 18-char alphanumeric string.
+
+    promoted from module-private `_looks_like_sf_id`
+    so `main._route` can gate calls to `resolve_or_unresolved` on the
+    Id shape without reaching into a leading-underscore symbol (same
+    surface). Underscore form retained as a deprecated alias.
+    """
+    if not isinstance(id_str, str):
+        return False
+    if len(id_str) not in _SF_ID_LENGTHS:
+        return False
+    return bool(_SF_ID_RE.match(id_str))
+
+
+# backcompat alias — deprecated; use `looks_like_sf_id`.
+_looks_like_sf_id = looks_like_sf_id
+
+
+def resolve_target_id(id_str: str) -> tuple[Kind, Channel]:
+    """Return (kind, resolvable_via) for a Salesforce Id.
+
+    unknown prefixes NEVER raise — callers observing ("unknown", "skip")
+    are expected to route through `resolve_or_unresolved` (or equivalent)
+    to append an `_unresolved[]` entry. This function stays pure — it does
+    not mutate any caller state, does not log.
+    """
+    if not id_str or not isinstance(id_str, str) or len(id_str) < 3:
+        return ("unknown", "skip")
+    prefix = id_str[:3]
+    return _PREFIX_MAP.get(prefix, ("unknown", "skip"))
+
+
+def resolve_or_unresolved(
+    id_str: object,
+    unresolved: list[dict],
+) -> tuple[Kind, Channel]:
+    """Like `resolve_target_id` but records failures into `unresolved`.
+
+    semantics:
+      * Valid Salesforce Id (15 or 18 alphanumeric chars) with known prefix:
+        route as usual. `unresolved` untouched.
+      * Valid Id shape, unknown prefix: append
+        `{"id": <id>, "reason": f"unknown-id-prefix:{id[:3]}"}` and
+        return ("unknown", "skip"). This is the "NGA shipped a new type"
+        path — the wave orchestrator keeps running.
+      * Not an Id shape (empty/None/wrong length/bad chars): append
+        `{"id": str(id_str), "reason": "invalid-id-format"}` and return
+        ("unknown", "skip"). Distinct reason so triage can tell "NGA
+        added something new" apart from "caller passed us garbage."
+
+    `unresolved` is mutated in place — same contract as `_unresolved[]`
+    throughout the skill. Caller owns the list.
+    """
+    if _looks_like_sf_id(id_str):
+        kind, channel = resolve_target_id(id_str)  # type: ignore[arg-type]
+        if kind == "unknown":
+            # Real Id shape, prefix we don't recognize — record the prefix
+            # so triage can add it to _PREFIX_MAP.
+            unresolved.append({
+                "id": id_str,
+                "reason": f"unknown-id-prefix:{id_str[:3]}",  # type: ignore[index]
+            })
+        return (kind, channel)
+
+    # Not a valid Id shape — empty, None, wrong length, or bad chars.
+    unresolved.append({
+        "id": str(id_str),
+        "reason": "invalid-id-format",
+    })
+    return ("unknown", "skip")

--- a/skills/investigating-agentforce-architecture/scripts/rest_client.py
+++ b/skills/investigating-agentforce-architecture/scripts/rest_client.py
@@ -1,0 +1,763 @@
+"""Tooling + Data REST client scaffolding with security-critical primitives.
+
+This module ships the HTTP primitives used by every REST-path caller in the
+skill. Two security invariants are enforced here and must not be bypassed:
+
+the Authorization header is STRIPPED from any cross-host redirect.
+Python's default HTTPRedirectHandler blindly forwards all request headers
+(including Authorization) to the redirect target. A compromised or
+attacker-controlled edge that returns a 302 to an arbitrary host would
+otherwise receive the bearer token. We subclass HTTPRedirectHandler to
+strip Authorization whenever the redirect target hostname differs from
+the original. Callers MUST use `build_opener()` — never `urllib.request.
+urlopen` directly, which wires the default redirect handler.
+
+access tokens MUST NEVER appear in exception strings, tracebacks,
+or logged output. `redact_error(exc)` returns a safe string representation
+with `Authorization: Bearer ...` scrubbed. Every `except` that surfaces
+HTTP / subprocess error text runs the text through `redact_error` first.
+Never call `log.exception()` on an object that carries request headers.
+"""
+from __future__ import annotations
+
+import email.utils
+import functools
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Tuple
+
+
+# stdlib logger for transient-HTTP backoff breadcrumbs. The skill has
+# no global logging config — we emit at DEBUG and leave handler/level wiring
+# to callers. Absent any config, Python's "last-resort" handler suppresses
+# DEBUG records, so this is a no-op in production until someone enables it.
+logger = logging.getLogger(__name__)
+
+
+class RestClientError(RuntimeError):
+    """REST request failed — always constructed with a redacted message."""
+
+
+# -----------------------------------------------------------------------------
+# error redaction
+# -----------------------------------------------------------------------------
+# Three patterns cover the bulk of token-leakage surfaces:
+# 1. `Authorization: Bearer <token>` in any string context (header echo,
+# exception repr, stringified HTTP error).
+# 2. `accessToken=<token>` / `access_token=<token>` in URL-encoded bodies
+# or query strings (`sf org display` errors sometimes echo these).
+# 3. `"accessToken":"<token>"` or `"access_token":"<token>"` in JSON
+# payload echoes.
+#
+# Regexes are intentionally permissive on the token character class
+# (anything non-whitespace, non-quote, non-ampersand) — we'd rather
+# over-redact than miss a token with an unexpected encoding.
+
+_AUTH_HEADER_RE = re.compile(
+    r"(Authorization\s*:\s*Bearer\s+)\S+",
+    flags=re.IGNORECASE,
+)
+# Matches access[_]?Token=<value> in url-encoded form; stops at & or whitespace.
+_ACCESS_TOKEN_QS_RE = re.compile(
+    r"(access[_]?token\s*=\s*)[^&\s\"']+",
+    flags=re.IGNORECASE,
+)
+# Matches "access[_]?Token":"<value>" in JSON; stops at closing quote.
+_ACCESS_TOKEN_JSON_RE = re.compile(
+    r"(\"access[_]?token\"\s*:\s*\")[^\"]*",
+    flags=re.IGNORECASE,
+)
+
+
+def redact_text(text: str) -> str:
+    """Scrub bearer tokens and accessToken values from arbitrary text.
+
+    Pure function; no side effects. Used by `redact_error` and available
+    for use on any raw response body / stderr string before it reaches
+    a log or exception message.
+
+    renamed from `_redact_text` to a public symbol so
+    cross-module callers (sf_cli._redact_subprocess_stderr) import a stable
+    name instead of reaching into a module-private. The `_redact_text`
+    alias below is retained for backwards compatibility with any caller
+    that still imports the underscore-prefixed form; it will be removed
+    in a future batch once all callers migrate.
+    """
+    if not text:
+        return text
+    text = _AUTH_HEADER_RE.sub(r"\1<redacted>", text)
+    text = _ACCESS_TOKEN_QS_RE.sub(r"\1<redacted>", text)
+    text = _ACCESS_TOKEN_JSON_RE.sub(r'\1<redacted>', text)
+    return text
+
+
+# deprecated alias. Retained so existing tests and any lingering
+# `from rest_client import _redact_text` imports keep working. New code
+# MUST use `redact_text` (public). Planned removal in a follow-up batch
+# once the codebase is clean.
+_redact_text = redact_text
+
+
+def redact_error(exc: BaseException) -> str:
+    """Return a safe string representation of `exc`.
+
+    guaranteed to:
+      * include the exception type name (for triage)
+      * include the exception message WITH bearer tokens scrubbed
+      * NEVER include raw header collections, even if the exception carries them
+
+    For HTTPError specifically, we do NOT call `exc.read()` — the caller is
+    responsible for reading the body once (reading twice is usually a no-op
+    but we avoid the extra I/O and any token embedded in the body is scrubbed
+    at the caller via `redact_text` when it surfaces in the error message).
+    """
+    exc_type = type(exc).__name__
+    try:
+        raw = str(exc)
+    except Exception:
+        raw = "<unreprable>"
+    return f"{exc_type}: {redact_text(raw)}"
+
+
+# -----------------------------------------------------------------------------
+# cross-host redirect strips Authorization
+# -----------------------------------------------------------------------------
+
+
+class StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+    """Strip Authorization header on any cross-host redirect.
+
+    Python's default HTTPRedirectHandler preserves request headers across
+    301/302/303/307/308. When `instanceUrl` is the trusted origin and a
+    redirect points at ANY other hostname, we treat the Authorization
+    header as tainted and drop it before the follow-up request goes out.
+
+    Hostname comparison is case-insensitive (DNS is case-insensitive).
+    We compare `urlparse(...).hostname` — which strips port and userinfo
+    — because a port change on the same host is NOT a credential-leak
+    vector, but treating it as cross-host would break legitimate
+    `:443` → bare-host redirects.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        orig_host = urllib.parse.urlparse(req.full_url).hostname
+        new_host = urllib.parse.urlparse(newurl).hostname
+        # Normalize for case-insensitive comparison. `None == None` is safe
+        # (both malformed URLs treated as "same host" — urllib would fail
+        # the follow-up anyway).
+        same_host = (orig_host or "").lower() == (new_host or "").lower()
+
+        if same_host:
+            # Default behavior: preserve Authorization (same-host redirect is
+            # standard practice; stripping would break legitimate OAuth flows).
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+        # cross-host redirect — build a NEW Request without any
+        # Authorization header. We cannot mutate `req` in place because
+        # urllib's default handler reuses it; callers that retain a reference
+        # would observe the mutation.
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        # Authorization may have been set via add_header (lowercased internal
+        # storage as "Authorization") or via unredirected_hdrs. Remove both.
+        # Note: `Request.headers` stores header names in the form produced by
+        # `.capitalize()` (so "Authorization" lands as "Authorization" since
+        # .capitalize() leaves single-word strings unchanged at the first
+        # letter — but we defensively pop both casings).
+        for hdr_name in list(new_req.headers.keys()):
+            if hdr_name.lower() == "authorization":
+                new_req.headers.pop(hdr_name, None)
+        for hdr_name in list(new_req.unredirected_hdrs.keys()):
+            if hdr_name.lower() == "authorization":
+                new_req.unredirected_hdrs.pop(hdr_name, None)
+        return new_req
+
+
+def build_opener() -> urllib.request.OpenerDirector:
+    """Return an OpenerDirector wired with StripAuthOnCrossHostRedirect.
+
+    every REST call in this module must go through an opener built
+    here. Direct use of `urllib.request.urlopen(...)` bypasses the redirect
+    handler and reintroduces the cross-host-token-leak vulnerability.
+    """
+    return urllib.request.build_opener(StripAuthOnCrossHostRedirect())
+
+
+# -----------------------------------------------------------------------------
+# 401 token refresh decorator + tooling/data query helpers
+# -----------------------------------------------------------------------------
+# Motivation: `sf org display` returns an access token with a short TTL
+# (typically 15min–2h). A pipeline run with many Flow / Tooling fetches can
+# exceed TTL. Without a refresh path the pipeline fails mid-run with a raw
+# 401 and the user has to re-run from scratch.
+#
+# Design: `retry_on_401` is a decorator-factory that takes a `refresh_fn`
+# closure. On 401 (HTTP status OR body contains INVALID_SESSION_ID) it
+# invokes `refresh_fn()`, retries the wrapped call ONCE, and surfaces the
+# original error if the retry also 401s. The refresh closure is passed
+# per-call rather than stored globally so the client stays stateless and
+# testable — each caller wires its own `lambda: run_sf("org_display", ...)`.
+#
+# Redaction: any error text that surfaces from this decorator runs through
+# `redact_error` / `redact_text` . The 401 body is read once and
+# scrubbed before being used for INVALID_SESSION_ID detection — we never
+# log or re-raise raw bytes from the wire.
+
+_INVALID_SESSION_MARKER = "INVALID_SESSION_ID"
+
+
+_ERROR_ENVELOPE_KEYS = ("errors", "error", "errorDetails", "messages")
+
+
+def _body_indicates_invalid_session(body: Any) -> bool:
+    """detect `INVALID_SESSION_ID` in a parsed or raw response body.
+
+    Some SF endpoints (notably a few Tooling paths) return HTTP 200 with an
+    error body rather than 401. The documented SF error shape is a list of
+    `{"errorCode": "INVALID_SESSION_ID", "message": "..."}` dicts at the
+    body root.
+
+    BUGFIX (2026-05-03): the prior implementation recursed into ALL
+    `dict.values()` and fell back to substring-matching the stringified
+    form. Tooling Query responses for ApexClass include a `records` list
+    whose `Body` field is the raw Apex source — which can legitimately
+    contain the literal string `INVALID_SESSION_ID` (as an errorCode
+    constant referenced by catch/rethrow code, e.g. `XCSF_FlowFaultMessage`
+    and `SkillRulesMatchAction` in the real-org fixture). That tripped the
+    value-walk and the substring fallback, misclassifying a 200 OK success
+    response as an auth failure and forcing a spurious
+    `INVALID_SESSION_ID after refresh` envelope into Wave B's `_unresolved`.
+
+    The tightened rules:
+      1. Top-level list/tuple: the SF error envelope — recurse (one level
+         is enough in practice, but recursion is safe because list items
+         are error dicts, not data rows with Apex bodies).
+      2. Dict: a positive match requires `errorCode == INVALID_SESSION_ID`
+         at THIS level, OR recursion into a well-known error-envelope key
+         (`errors`, `error`, `errorDetails`, `messages`). Data keys like
+         `records`, `Body`, `attributes` are NEVER walked — that was the
+         bug. Typos / shape variants still surface through the
+         error-envelope keys, which is the real world observed-shape set.
+      3. Top-level raw str/bytes: an unparsed error body. A substring
+         match here is still safe because this helper is only called on
+         the TOP-LEVEL parsed response (never on a field inside a success
+         dict), so a raw-string body means SF literally returned text
+         rather than JSON — in which case substring match is the best
+         we can do.
+      4. Anything else (int, float, None, other types): not an error
+         shape. Return False.
+    """
+    if body is None:
+        return False
+    if isinstance(body, (list, tuple)):
+        return any(_body_indicates_invalid_session(item) for item in body)
+    if isinstance(body, dict):
+        code = body.get("errorCode") or body.get("error_code")
+        if isinstance(code, str) and _INVALID_SESSION_MARKER in code:
+            return True
+        # Only recurse into known error-envelope keys. Walking arbitrary
+        # values misclassifies legitimate success payloads whose data
+        # fields (e.g. ApexClass.Body) happen to contain the string
+        # `INVALID_SESSION_ID`.
+        for key in _ERROR_ENVELOPE_KEYS:
+            if key in body and _body_indicates_invalid_session(body[key]):
+                return True
+        return False
+    if isinstance(body, (str, bytes)):
+        text = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else body
+        return _INVALID_SESSION_MARKER in text
+    return False
+
+
+class _InvalidSessionSignal(Exception):
+    """Internal-only: tunnel INVALID_SESSION_ID-in-200-body through retry_on_401.
+
+    Never escapes this module — the decorator catches it, refreshes, retries,
+    and on a second failure surfaces a RestClientError (redacted).
+    """
+
+
+def _is_invalid_session_403(exc: urllib.error.HTTPError) -> bool:
+    """detect HTTP 403 + `INVALID_SESSION_ID` in body.
+
+    Some SF endpoints respond to an expired session with `403 Forbidden`
+    (body: `{"errorCode": "INVALID_SESSION_ID"}`) instead of 401. We treat
+    that shape as auth-refresh-triggering just like 401. Any OTHER 403
+    (permission denied, IP restriction, etc.) propagates unchanged — we
+    don't burn a refresh on a non-auth 403.
+
+    Reading `.read()` on an HTTPError is a one-shot — callers that surface
+    this exception must not re-read the body. For our retry path this is
+    fine: the decorator consumes the body once to decide, then discards
+    the exception after retry.
+    """
+    if exc.code != 403:
+        return False
+    try:
+        body = exc.read()
+    except Exception:
+        return False
+    if not body:
+        return False
+    try:
+        text = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else str(body)
+    except Exception:
+        return False
+    return _INVALID_SESSION_MARKER in text
+
+
+def retry_on_401(
+    refresh_fn: Callable[[], Tuple[str, str]],
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator: retry a REST call ONCE after refreshing the session token.
+
+    detects three auth-failure shapes:
+      1. `urllib.error.HTTPError` with `code == 401`
+      2. `urllib.error.HTTPError` with `code == 403` AND body contains
+         `INVALID_SESSION_ID` (some SF endpoints return 403 for
+         expired sessions; non-auth 403 is NOT treated as refreshable).
+      3. HTTP 200 with response body containing `INVALID_SESSION_ID` —
+         callers signal this by raising `_InvalidSessionSignal`; the
+         helpers below do the body inspection before returning.
+
+     (REMEDIATE): the retry contract is documented and enforced here:
+    `refresh_fn()` returns `(instance_url, access_token)` and the caller
+    MUST thread those fresh credentials into the NEXT invocation of the
+    wrapped callable. See `tooling_query` / `data_query`, which implement
+    this via the `creds_provider` closure pattern (Option A). The previous
+    design captured credentials in a closure at call time — refresh
+    returned fresh creds, the wrapped closure kept using stale ones, and
+    the retry 401'd again. That's the defect. `retry_on_401` itself
+    is still credential-agnostic; the invariant lives in the caller.
+
+    If the retry ALSO fails (401 / 403+INVALID_SESSION_ID / INVALID_SESSION_ID),
+    the ORIGINAL error is re-raised (wrapped as `RestClientError` with a
+    redacted message) — not the retry's error. Rationale: the user sees
+    the first-attempt context (what call failed) rather than a downstream
+    artefact of the retry path.
+
+    Non-auth errors (500, 403 without INVALID_SESSION_ID, network timeout,
+    etc.) propagate unchanged — refresh is NOT attempted.
+    """
+
+    def _is_auth_http_error(exc: urllib.error.HTTPError) -> bool:
+        # 401 is the classic shape; 403+INVALID_SESSION_ID is a
+        # variant observed on some SF endpoints. All other 4xx/5xx
+        # propagate without refresh.
+        if exc.code == 401:
+            return True
+        if _is_invalid_session_403(exc):
+            return True
+        return False
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return fn(*args, **kwargs)
+            except urllib.error.HTTPError as first_exc:
+                if not _is_auth_http_error(first_exc):
+                    raise
+                # auth-failure path — refresh and retry once.
+                try:
+                    refresh_fn()
+                except Exception as refresh_exc:
+                    # Refresh itself failed — surface the REFRESH error so
+                    # the user knows they need to re-auth, but keep token
+                    # redaction on the message.
+                    raise RestClientError(
+                        f"token refresh failed after auth error: {redact_error(refresh_exc)}"
+                    ) from None
+                try:
+                    return fn(*args, **kwargs)
+                except urllib.error.HTTPError as retry_exc:
+                    if _is_auth_http_error(retry_exc):
+                        raise RestClientError(
+                            f"auth error after refresh (original): {redact_error(first_exc)}"
+                        ) from None
+                    raise
+                except _InvalidSessionSignal:
+                    raise RestClientError(
+                        f"INVALID_SESSION_ID after refresh (original): "
+                        f"{redact_error(first_exc)}"
+                    ) from None
+            except _InvalidSessionSignal as first_sig:
+                # body-path INVALID_SESSION_ID — refresh and retry once.
+                try:
+                    refresh_fn()
+                except Exception as refresh_exc:
+                    raise RestClientError(
+                        f"token refresh failed after INVALID_SESSION_ID: "
+                        f"{redact_error(refresh_exc)}"
+                    ) from None
+                try:
+                    return fn(*args, **kwargs)
+                except urllib.error.HTTPError as retry_exc:
+                    if _is_auth_http_error(retry_exc):
+                        raise RestClientError(
+                            f"auth error after refresh (original INVALID_SESSION_ID): "
+                            f"{redact_error(first_sig)}"
+                        ) from None
+                    raise
+                except _InvalidSessionSignal:
+                    raise RestClientError(
+                        f"INVALID_SESSION_ID after refresh: {redact_error(first_sig)}"
+                    ) from None
+
+        return wrapper
+
+    return decorator
+
+
+# -----------------------------------------------------------------------------
+# transient HTTP (429/503) exponential backoff
+# -----------------------------------------------------------------------------
+# Motivation: SF REST endpoints occasionally return 429 (rate-limited) or
+# 503 (service unavailable) during API-limit windows, planned maintenance,
+# or transient edge hiccups. Without a retry the pipeline fails mid-run on
+# what is almost always a recoverable condition. Three attempts with
+# exponential backoff (1s → 2s → 4s, roughly — `base_delay * 2**attempt`)
+# resolve the vast majority of transient blips without meaningfully
+# extending happy-path latency.
+#
+# Scope (what this decorator does NOT do):
+# * Not a 401 refresher — that's `retry_on_401`. The layering is:
+# retry_on_401( retry_on_transient_http()( _query_once ) )
+# so 429s retry first (inner), and a 401 surfacing through that layer
+# triggers the outer refresh. The two concerns stay independent.
+# * No jitter. Bounded to 3 attempts + short delays; adding jitter here
+# would only matter if many callers burst-retried against the same
+# endpoint, which is not the shape of this skill's traffic.
+# * No retry on 5xx generally. Only 503 is retried because 500/502/504
+# often indicate deterministic server-side failures where retrying
+# won't help and we'd prefer to surface fast.
+#
+# Retry-After handling:
+# * If the header is present and parses as a non-negative number of
+# seconds OR an HTTP-date, we honor it — bounded below by base_delay *
+# 2**attempt so a "Retry-After: 0" doesn't disarm the backoff.
+# * Negative / malformed values fall back to the exponential schedule.
+#
+# Redaction: any HTTPError surfaced from the final failure goes through
+# `redact_error` at the caller's message site (see `_query_once`'s wrapper
+# chain). We do NOT stringify headers here — no `str(exc.headers)` or
+# `resp.read()` debug dumps on retry. URL logging strips the query string.
+
+
+def _parse_retry_after(raw: str | None) -> float | None:
+    """Parse a Retry-After header value to seconds.
+
+    Per RFC 9110 the value is either `delta-seconds` (non-negative int) or
+    an HTTP-date. We accept floats too — some clients emit decimal seconds
+    and the spec-strict int parse would silently lose them.
+
+    Returns None for missing / malformed input; caller falls back to the
+    exponential schedule.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        secs = float(raw)
+        if secs < 0:
+            return None
+        return secs
+    except ValueError:
+        pass
+    # HTTP-date form. `parsedate_to_datetime` raises on malformed input on
+    # 3.10+; wrap defensively.
+    try:
+        target = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if target is None:
+        return None
+    # Header expresses an absolute time; convert to a delta from now.
+    now = time.time()
+    delta = target.timestamp() - now
+    if delta < 0:
+        return 0.0
+    return delta
+
+
+def retry_on_transient_http(
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator: retry on HTTP 429/503 up to `max_retries` times.
+
+    on `urllib.error.HTTPError` with code in {429, 503}, sleep and
+    retry. Any other exception (including 401 — let `retry_on_401`
+    handle that, and any 5xx besides 503) propagates immediately.
+
+    Retry semantics:
+      * max_retries: number of retries AFTER the first attempt (default 3).
+      * Total attempts = 1 + max_retries (default 4: 1 original + 3 retries).
+      * Final attempt's exception propagates; no further retry.
+
+    Delay per attempt = max(Retry-After-seconds, base_delay * 2**attempt).
+    If Retry-After is absent or malformed, falls back to the exponential
+    schedule. `attempt` is 0-indexed for the first retry (so the first
+    sleep is base_delay * 1 = base_delay).
+
+    Logs a DEBUG breadcrumb per retry via the module-level `logger`. No
+    header values are logged — only the HTTP code + computed delay +
+    attempt counter.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Total attempts = 1 original + max_retries retries. `attempt`
+            # below is 0-indexed over the retry slots, which matches the
+            # exponential formula base_delay * 2**attempt starting at
+            # base_delay for attempt=0.
+            for attempt in range(max_retries):
+                try:
+                    return fn(*args, **kwargs)
+                except urllib.error.HTTPError as exc:
+                    if exc.code not in (429, 503):
+                        # Any other HTTP status (including 401) — out of
+                        # scope for this decorator. Propagate so outer
+                        # layers (retry_on_401) can handle it.
+                        raise
+                    retry_after_raw = None
+                    try:
+                        # `exc.headers` is a Message-like; .get tolerates
+                        # the case where headers are absent on some
+                        # synthesized HTTPErrors.
+                        retry_after_raw = exc.headers.get("Retry-After") if exc.headers else None
+                    except Exception:
+                        retry_after_raw = None
+                    hinted = _parse_retry_after(retry_after_raw)
+                    expo = base_delay * (2 ** attempt)
+                    delay = max(hinted, expo) if hinted is not None else expo
+                    logger.debug(
+                        "retry_on_transient_http: HTTP %d, sleeping %.2fs (attempt %d/%d)",
+                        exc.code, delay, attempt + 1, max_retries,
+                    )
+                    time.sleep(delay)
+                    continue
+            # Final attempt — let any exception propagate directly. If
+            # this attempt raises 429/503 the caller gets the HTTPError
+            # unchanged (redaction happens at the wrapping call site).
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _query_once(
+    instance_url: str,
+    token: str,
+    path: str,
+    soql: str,
+) -> dict:
+    """Single SOQL GET — reads body, checks for INVALID_SESSION_ID.
+
+    the Salesforce REST Query + Tooling Query
+    endpoints are GET-only with the SOQL passed as a urlencoded `q=`
+    querystring. The prior POST-with-JSON-body shape returned HTTP 405
+    ("Method Not Allowed") on every real-org run — confirmed by curl
+    against a real org:
+
+        GET  /services/data/v60.0/query/?q=<soql>  -> 200 OK
+        POST /services/data/v60.0/query/           -> 405 Method Not Allowed
+
+    We urlencode the SOQL (via `urllib.parse.urlencode({"q": soql})`)
+    rather than string-concatenating so spaces, single quotes, commas,
+    and parentheses in the query — all legal inside SOQL string
+    literals — travel through the wire correctly. The JSON body and
+    `Content-Type: application/json` header are dropped (GET carries
+    no body; Content-Type with a bodyless GET is technically legal but
+    meaningless and some edge proxies get irritated by it).
+
+    uses `build_opener()` so cross-host redirects strip Authorization.
+    any exception is surfaced with `redact_error`; raw body is run
+    through `redact_text` before it reaches an exception message.
+    signals `_InvalidSessionSignal` on 200-body-error so
+    `retry_on_401` can refresh + retry.
+    sets `Accept-Encoding: identity` to opt out of gzip. The
+    responses here are small JSON payloads — gzip would add handling
+    complexity (Content-Encoding detection + decompression) for zero
+    measurable benefit. Explicit `identity` keeps the body-inspection
+    path (INVALID_SESSION_ID detection) straightforward and testable.
+    """
+    # urlencode handles all SOQL-legal characters — spaces,
+    # single quotes inside string literals, commas, parentheses. Hand-
+    # rolled concatenation would have to escape each class separately.
+    qs = urllib.parse.urlencode({"q": soql})
+    url = f"{instance_url.rstrip('/')}{path}?{qs}"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/json")
+    # force identity encoding — no gzip.
+    req.add_header("Accept-Encoding", "identity")
+
+    opener = build_opener()
+    try:
+        with opener.open(req) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        # Bug D.1 fix: HTTPError.read() is one-shot. The default
+        # `redact_error()` path stringifies just `HTTP Error 4xx: <reason>`
+        # which loses the Salesforce error body — and that body is what
+        # tells the operator WHY (e.g. INVALID_FIELD, MALFORMED_QUERY,
+        # name-too-long, or a specific bad identifier). Pull the body
+        # ONCE here, scrub it via redact_text, attach it to the exception
+        # as `_response_body_preview`, and re-raise. Downstream callers
+        # that surface `redact_error(exc)` keep their existing string
+        # output; callers that want the body read it from the attribute.
+        try:
+            body = exc.read()
+        except Exception:
+            body = b""
+        try:
+            body_text = body.decode("utf-8", errors="replace")
+        except Exception:
+            body_text = ""
+        # Cap at 500 chars — enough to carry a Salesforce error array
+        # element with the offending name in it; small enough that
+        # downstream contexts don't bloat. redact_text strips bearer
+        # tokens defensively (body shouldn't contain one but cheaper to
+        # always scrub than reason about it).
+        exc._response_body_preview = redact_text(body_text)[:500]  # type: ignore[attr-defined]
+        raise
+
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise RestClientError(
+            f"malformed query response: {redact_error(e)}"
+        ) from None
+
+    # HTTP 200 + INVALID_SESSION_ID in body → tunnel up to the
+    # decorator so it can refresh + retry.
+    if _body_indicates_invalid_session(parsed):
+        raise _InvalidSessionSignal(
+            redact_text(json.dumps(parsed)[:500])
+        )
+    return parsed
+
+
+# (REMEDIATE): credentials flow through a provider closure, not
+# through function arguments that are captured once at decoration time.
+#
+# The previous design had a fatal defect:
+#
+# def tooling_query(instance_url, token, soql, *, on_401_refresh):
+# @retry_on_401(on_401_refresh)
+# def _call():
+# return _query_once(instance_url, token, ...) # stale closure
+# return _call()
+#
+# `refresh_fn()` returned `(new_url, new_token)` but those values were
+# thrown away — the decorator only called `refresh_fn()` for its side
+# effects, then re-invoked the same closure holding the ORIGINAL stale
+# `instance_url` / `token`. Retry 401'd again. Feature was dead.
+#
+# Option A (taken): `tooling_query` / `data_query` accept a
+# `creds_provider: Callable[[], Tuple[str, str]]` that is called EACH
+# attempt. `refresh_fn` is responsible for mutating whatever state the
+# provider reads from — typically a simple closure over a list. This
+# keeps `retry_on_401` credential-agnostic and makes the contract
+# ("refresh updates the source that `creds_provider` reads from")
+# explicit at the caller site instead of implicit in the helper.
+#
+# Test: `RetryOn401CredentialRefreshIntegrationTests` in
+# test_rest_client.py verifies that a real refresh carries fresh
+# credentials into the retry call; the prior design fails that test.
+
+
+def tooling_query(
+    creds_provider: Callable[[], Tuple[str, str]],
+    soql: str,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> dict:
+    """GET a SOQL query against the Tooling API.
+
+    `creds_provider()` is invoked on EACH attempt. `on_401_refresh`
+    is responsible for updating whatever state the provider reads from
+    before it returns — otherwise the retry would hit the same stale
+    credentials and 401 again.
+
+    `api_version` is a REQUIRED keyword-only arg.
+    The prior hardcoded `v60.0` was the source of — real orgs
+    run on v66 and expose fields v60 does not (confirmed empirically:
+    `BotDefinition.Description` exists on v66, `INVALID_FIELD` on v60).
+    Callers thread the version through from `main._derive_org_ids`, which
+    reads it once from `sf org display --json`. Making the param REQUIRED
+    (no default) surfaces a missed call-site as a TypeError at call time
+    rather than a silent regression back to a stale pinned version.
+    Shape is already enforced by `fs_guard.validate_api_version`
+    (`^v[0-9]+\\.[0-9]+$`) at the caller.
+
+    Stateless: both closures are passed per-call. Each caller owns the
+    storage the refresh writes to (typically a small `list[tuple[str, str]]`
+    cell).
+    """
+    path = f"/services/data/{api_version}/tooling/query/"
+
+    # retry_on_transient_http is the INNER layer — 429/503 retries
+    # happen first, and any 401 bubbling through triggers retry_on_401's
+    # refresh path at the outer layer. Ordering matters: if transient
+    # retry were outer, a 429 during a refresh retry would be mis-handled.
+    @retry_on_401(on_401_refresh)
+    @retry_on_transient_http()
+    def _call() -> dict:
+        # re-read creds on every attempt so refresh actually lands.
+        instance_url, token = creds_provider()
+        return _query_once(instance_url, token, path, soql)
+
+    return _call()
+
+
+def data_query(
+    creds_provider: Callable[[], Tuple[str, str]],
+    soql: str,
+    *,
+    api_version: str,
+    on_401_refresh: Callable[[], Tuple[str, str]],
+) -> dict:
+    """GET a SOQL query against the Data API (non-Tooling).
+
+    identical retry wiring to `tooling_query`, different URL path.
+    `creds_provider` is invoked on every attempt so a refresh actually
+    propagates fresh credentials into the retry.
+
+    `api_version` is a REQUIRED keyword-only arg;
+    see `tooling_query` for the rationale.
+    """
+    path = f"/services/data/{api_version}/query/"
+
+    # see `tooling_query` for the decorator-ordering rationale.
+    @retry_on_401(on_401_refresh)
+    @retry_on_transient_http()
+    def _call() -> dict:
+        # re-read creds on every attempt so refresh actually lands.
+        instance_url, token = creds_provider()
+        return _query_once(instance_url, token, path, soql)
+
+    return _call()
+
+
+def static_creds(instance_url: str, token: str) -> Callable[[], Tuple[str, str]]:
+    """Build a zero-state creds_provider that always returns the same pair.
+
+    Convenience for callers that don't wire a refresh path — tests,
+    single-shot scripts where a 401 is terminal. If the call 401s, the
+    retry sees the same creds and fails again; this is correct behavior
+    for an unrefreshable context (no point claiming otherwise).
+    """
+    def _provider() -> Tuple[str, str]:
+        return instance_url, token
+    return _provider

--- a/skills/investigating-agentforce-architecture/scripts/retrieve_planner.py
+++ b/skills/investigating-agentforce-architecture/scripts/retrieve_planner.py
@@ -1,0 +1,13 @@
+"""BFS graph builder — walks the cross-type reference graph.
+
+ (visited keys = (kind, canonical_name) tuples) +  (MAX_DEPTH=5 cap
+→ _partial + PARTIAL_OK) land in Batches 2 and 3.
+"""
+from __future__ import annotations
+
+
+def build_fetch_graph() -> dict:
+    """TODO  + BFS with per-kind visited tuples, cycle-safe,
+    MAX_DEPTH cap surfaces as _partial=true in the tree.
+    """
+    raise NotImplementedError("build_fetch_graph implements in P0 Batches 2+3")

--- a/skills/investigating-agentforce-architecture/scripts/sf_cli.py
+++ b/skills/investigating-agentforce-architecture/scripts/sf_cli.py
@@ -1,0 +1,242 @@
+"""sf CLI recipe loader — reads assets/cli/*.yaml, runs argv via subprocess.
+
+Security: YAML recipes are loaded via yaml.safe_load only; yaml.load is banned.
+PyYAML's `yaml.load` deserializes arbitrary Python objects (including
+constructor-injected code in some tags) and must never run on attacker-reachable
+YAML. The recipes live inside this repo and are author-controlled, but we
+still use `safe_load` as defence in depth — a compromised dist/ or a botched
+copy-paste can't escalate to code execution.
+
+the `_SAFE_LOADER` module-level binding is THE loader used everywhere
+in this module; tests assert its identity against `yaml.safe_load`.
+
+every stringification of a subprocess.CalledProcessError or related
+exception is routed through `rest_client.redact_error` so stderr containing
+an access token (rare but observed on some `sf` failure paths) cannot leak
+into logs or RESULT blocks.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from config import CLI_DIR
+# hoisted `redact_text` to module-top alongside
+# `redact_error`. Previously `_redact_subprocess_stderr` performed a lazy
+# import of the module-private `_redact_text` on every call, which (a)
+# tied this module to a name that could be renamed silently and (b) meant
+# an ImportError from rest_client would surface only at redaction time —
+# possibly in a frame whose locals held the raw, un-redacted stderr.
+# Hoisting is safe: rest_client does not import sf_cli (no cycle).
+from rest_client import redact_error, redact_text
+
+# the ONE allowed loader for this module. Test asserts identity.
+# NEVER change this to yaml.load (which can construct arbitrary Python
+# objects via tag hooks).
+_SAFE_LOADER = yaml.safe_load
+
+
+class AuthRequired(RuntimeError):
+    """sf CLI returned a known auth-failure pattern.
+
+    Carries a redacted stderr snippet — any bearer token in stderr is scrubbed
+    via redact_error before reaching this message.
+    """
+
+
+class SfCliError(RuntimeError):
+    """sf CLI returned non-zero exit or JSON status != 0.
+
+    Message is redacted  before construction.
+    """
+
+
+def _load_recipe(name: str) -> Dict[str, Any]:
+    """Read and parse a CLI recipe file with yaml.safe_load.
+
+    _SAFE_LOADER is bound to yaml.safe_load at module top; using it
+    here (instead of `yaml.safe_load` directly) makes the identity testable
+    and gives a single point to review if the loader ever changes.
+    """
+    path = CLI_DIR / f"{name}.yaml"
+    with path.open("r", encoding="utf-8") as fh:
+        recipe = _SAFE_LOADER(fh)
+    if not isinstance(recipe, dict):
+        raise SfCliError(
+            f"recipe {name!r} did not parse to a mapping (got {type(recipe).__name__})"
+        )
+    return recipe
+
+
+def _sub(arg: str, params: Dict[str, str]) -> str:
+    """Substitute {{KEY}} placeholders in a single argv element.
+
+    Input validation: `params` values are expected to be already-validated
+    strings (SKILL.md phase 1 runs fs_guard on every user-supplied input).
+    We do not revalidate here because argv substitution is shell-escape-safe
+    by construction — subprocess.run with a list argv never invokes a shell.
+    """
+    out = arg
+    for key, value in params.items():
+        out = out.replace(f"{{{{{key}}}}}", value)
+    return out
+
+
+def _parse_stdout_json(stdout: str) -> Dict[str, Any]:
+    """Parse sf CLI's --json stdout.
+
+    sf CLI emits `{"status": 0, "result": {...}}` on success; malformed
+    stdout (e.g. when the CLI crashes before JSON serialization) raises
+    SfCliError with a redacted message.
+    """
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        # stdout could in theory contain a token on some crash paths;
+        # redact before surfacing.
+        raise SfCliError(
+            f"sf CLI stdout is not JSON: {redact_error(e)}"
+        ) from None
+
+
+_AUTH_LINE_PREFIX_RE = re.compile(r"^(?:Error|Warning):\s")  # @rule-suppress starter-sec-002 — re.compile, not python compile()
+
+
+def _stderr_matches_auth(stderr: str, patterns) -> bool:
+    """Check if any auth-failure pattern appears on an Error:/Warning: line.
+
+    previously a substring scan across the entire stderr, which
+    false-positived on Node ESM warnings ("Warning: @gthoppae/sf-cli-
+    plugin-data360 is a linked ESM module") if they happened to echo an
+    auth pattern substring. Now we only match on lines starting with
+    `Error:` or `Warning:` followed by whitespace. This keeps every
+    true-positive we care about (real sf auth errors always surface as
+    `Error: NoOrgAuthenticationError ...`) while pruning the noise.
+
+    Matching rules:
+      * Line starts with `Error:<ws>` or `Warning:<ws>` (anchored at
+        start-of-line, so embedded-in-prose mentions don't match).
+      * Pattern is a substring of the REST of that line (after the
+        prefix). We strip only the prefix — we do not re-scope to word
+        boundaries, since sf auth tokens like `NoOrgAuthenticationError`
+        are always well-formed identifiers without adjacent alphanum.
+      * Empty stderr / empty patterns → no match.
+    """
+    if not stderr or not patterns:
+        return False
+    for line in stderr.splitlines():
+        m = _AUTH_LINE_PREFIX_RE.match(line)
+        if not m:
+            continue
+        tail = line[m.end():]
+        if any(p in tail for p in patterns):
+            return True
+    return False
+
+
+def run_sf(name: str, **params: str) -> Dict[str, Any]:
+    """Execute a recipe-defined sf CLI command and return parsed stdout.
+
+    Steps:
+      1. Load recipe (yaml.safe_load).
+      2. Enforce required_params.
+      3. Substitute {{KEY}} into argv.
+      4. subprocess.run with list argv (no shell, no bash -c).
+      5. Parse stdout JSON; check `status == 0`.
+      6. On failure: classify as AuthRequired (stderr pattern match) or
+         SfCliError; every message is redacted via redact_error .
+
+    Exception semantics:
+      * AuthRequired — user needs to `sf org login`
+      * SfCliError   — anything else (timeout, non-zero exit, JSON parse,
+        status != 0)
+
+    NEVER uses shell=True. NEVER calls log.exception(). NEVER echoes raw
+    stderr without redaction .
+    """
+    recipe = _load_recipe(name)
+
+    required = set(recipe.get("required_params") or [])
+    missing = required - params.keys()
+    if missing:
+        raise SfCliError(f"missing required params for {name!r}: {sorted(missing)}")
+
+    argv_template = recipe.get("argv") or []
+    if not isinstance(argv_template, list):
+        raise SfCliError(f"recipe {name!r} argv must be a list")
+
+    argv = [_sub(str(e), params) for e in argv_template]
+    timeout = int(recipe.get("timeout_seconds", 60))
+    auth_patterns = recipe.get("auth_required_stderr_patterns") or []
+
+    # SF_TEMP_SHOW_SECRETS=true is required for `sf org display --verbose
+    # --json` to emit `accessToken` instead of the literal redaction string
+    # `"[REDACTED] Use 'sf org auth show-access-token' to view"` introduced
+    # in sf CLI v2. Without it, downstream callers receive the redaction
+    # string as the bearer token and every Tooling/REST call returns
+    # INVALID_AUTH_HEADER 401. Set on every recipe — recipes that don't
+    # touch tokens are unaffected.
+    env = {**os.environ, "SF_TEMP_SHOW_SECRETS": "true"}
+    try:
+        cp = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as e:
+        # timeout exceptions carry stderr via e.stderr — redact.
+        raise SfCliError(
+            f"sf CLI {name!r} timed out after {timeout}s: {redact_error(e)}"
+        ) from None
+    except (OSError, subprocess.SubprocessError) as e:
+        # any subprocess-layer error gets redacted.
+        raise SfCliError(
+            f"sf CLI {name!r} invocation failed: {redact_error(e)}"
+        ) from None
+
+    # Even on nonzero exit sf CLI usually still emits JSON on stdout; try
+    # to parse before deciding failure mode.
+    try:
+        data = _parse_stdout_json(cp.stdout) if cp.stdout else {}
+    except SfCliError:
+        data = {}
+
+    status_field = data.get("status", 0) if isinstance(data, dict) else 1
+    if cp.returncode != 0 or status_field != 0:
+        # stderr could contain a token on some failure paths; redact
+        # the ENTIRE string before deciding how to classify or what to show.
+        safe_stderr = _redact_subprocess_stderr(cp.stderr)
+        if _stderr_matches_auth(cp.stderr, auth_patterns):
+            raise AuthRequired(safe_stderr or "auth required")
+        # Include exit code + JSON status in the message (both are
+        # numeric/well-known, no token risk) plus the redacted stderr tail.
+        raise SfCliError(
+            f"sf CLI {name!r} failed "
+            f"(exit={cp.returncode}, json_status={status_field}): {safe_stderr}"
+        )
+
+    return data
+
+
+def _redact_subprocess_stderr(stderr: str) -> str:
+    """run stderr text through the rest_client redaction regexes.
+
+    stderr may contain `Authorization: Bearer ...` or `accessToken=...` if
+    the sf CLI echoes a failing request; scrub before surfacing.
+
+    calls the public `redact_text` (imported at module
+    top). Previously imported the module-private `_redact_text` lazily on
+    every call — a rename could have silently broken redaction, and an
+    ImportError would have propagated through `run_sf` with the raw stderr
+    still live in the traceback's frame locals.
+    """
+    return redact_text(stderr or "")

--- a/skills/investigating-agentforce-architecture/scripts/soql_loader.py
+++ b/skills/investigating-agentforce-architecture/scripts/soql_loader.py
@@ -1,0 +1,253 @@
+"""SOQL template loader — reads assets/soql/*.soql and substitutes {{PARAM}} values.
+
+every value passed in via **params is regex-revalidated at the
+substitution boundary via `fs_guard.validate_api_name`. This is defence
+in depth — callers (SKILL.md phase 1, parse_bundle.extract_planner_name,
+parse_wave.discovered_names) already validate at their own boundaries, but
+centralizing the gate here guarantees that any future caller can't bypass
+it by forgetting to validate first.
+
+Why no escape function: `validate_api_name` restricts every substituted
+string to `^[A-Za-z0-9_]+$` — the legal character set for Salesforce
+DeveloperName / API-name identifiers. No quote, apostrophe, semicolon,
+parenthesis, or whitespace can ever reach the SOQL builder, so there is
+nothing to escape. Adding an escape step would be both dead code and a
+false reassurance that unvalidated input is somehow safe.
+
+`load_soql_in` adds support for `WHERE X IN (...)`
+list placeholders. The BFS fan-out passes across Apex/Flow/Plugin/Function
+discovery each need to batch-query by a list of ids or names; forcing
+one SOQL call per element would blow up both the query-count budget and
+the request-latency floor. The new function shares the `load_soql`
+validation path (every element goes through `fs_guard.validate_api_name`)
+so list inputs cannot widen the SOQL-injection surface — `'`, `;`, `--`,
+whitespace, and every other SOQL metachar remain unreachable. The
+existing `load_soql` signature is unchanged.
+
+SOQL-string-substitution loader with validation at the substitution
+boundary. Every value substituted into a `{{token}}` placeholder is
+regex-validated before insertion.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from config import SOQL_DIR, fs_guard  # fs_guard re-exported by config.py from _shared/
+
+
+class SoqlParamError(ValueError):
+    """Raised when a parameter value fails revalidation at the substitution site.
+
+    Carries the failing key + a 20-char preview of the rejected value. Callers
+    (parse_bundle, parse_wave, main.py) catch this and add the key to
+    `_unresolved[]` with `reason=invalid-soql-param:<key>` so the pipeline
+    continues with `STATUS=PARTIAL_OK` rather than aborting on a single
+    malformed name.
+    """
+
+    def __init__(self, key: str, value, reason: str) -> None:
+        self.key = key
+        self.reason = reason
+        # Preview is bounded to 20 chars to avoid echoing arbitrarily-long
+        # attacker-controlled strings into logs.
+        try:
+            preview = str(value)[:20]
+        except Exception:
+            preview = "<unreprable>"
+        self.preview = preview
+        super().__init__(
+            f"SOQL param {key!r} rejected: {reason} (preview={preview!r})"
+        )
+
+
+class SoqlTemplateNotFound(LookupError):
+    """Raised when `load_soql(name)` cannot locate a matching template file.
+
+    the message deliberately carries ONLY the requested
+    template name — never the absolute SOQL_DIR path. This prevents leaking
+    the filesystem layout of the skill install (which the attacker does not
+    otherwise need to know) via error messages that bubble up to logs or
+    RESULT blocks.
+
+    Distinct from `FileNotFoundError` so callers can tell "template missing"
+    apart from "filesystem I/O error" (permission denied, etc.) at the
+    except-clause layer.
+    """
+
+    def __init__(self, name: str) -> None:
+        # Preview bounds the echoed name at 60 chars. The validator forbids
+        # traversal characters anyway, but defence in depth against an
+        # arbitrarily-long attacker-controlled name ever reaching logs.
+        try:
+            preview = str(name)[:60]
+        except Exception:
+            preview = "<unreprable>"
+        self.name = preview
+        super().__init__(f"SOQL template not found: {preview!r}")
+
+
+def load_soql(name: str, **params) -> str:
+    """Read assets/soql/<name>.soql and substitute {{PARAM}} placeholders.
+
+    every value in `params` is revalidated via
+    `fs_guard.validate_api_name` before being substituted. Invalid values
+    (non-string, empty, or containing any character outside [A-Za-z0-9_])
+    raise `SoqlParamError`.
+
+    `name` itself is validated via the same
+    `fs_guard.validate_api_name` regex BEFORE any filesystem access.
+    Without this, a caller that sources `name` from data (config file,
+    user argument, etc.) could read `SOQL_DIR/../../../tmp/pwn.soql` via
+    traversal. All SOQL template filenames in this skill match
+    `^[A-Za-z0-9_]+$` (e.g. `bot_version_lookup`, `plugins_by_planner`),
+    so the regex is the correct gate.
+
+    Substitution is single-pass: `str.replace` does not re-scan the output,
+    so a value that contains `{{OTHER}}` cannot re-trigger substitution of
+    a different key. This is verified by test_soql_loader.
+    """
+    # validate the template name BEFORE touching the filesystem.
+    # A raw `../../../etc/passwd` would otherwise resolve via read_text().
+    try:
+        fs_guard.validate_api_name(name, label="soql_template_name")
+    except fs_guard.ValidationError as e:
+        raise SoqlParamError("soql_template_name", name, e.reason) from None
+
+    # revalidate every SOQL param before substitution. No exceptions,
+    # no "this caller already validated" shortcuts. Defence in depth.
+    for key, value in params.items():
+        try:
+            fs_guard.validate_api_name(value, label=key)
+        except fs_guard.ValidationError as e:
+            raise SoqlParamError(key, value, e.reason) from None
+
+    # translate FileNotFoundError into SoqlTemplateNotFound so the
+    # absolute SOQL_DIR path never bleeds into caller-visible error text.
+    # We intentionally do NOT chain the original exception (`from None`) —
+    # the original carries the full path in `filename`/`strerror`.
+    try:
+        soql = (SOQL_DIR / f"{name}.soql").read_text()
+    except FileNotFoundError:
+        raise SoqlTemplateNotFound(name) from None
+
+    for key, value in params.items():
+        # Plain str.replace: single-pass by construction. No re-substitution
+        # of placeholders that appear inside a substituted value (see test).
+        soql = soql.replace(f"{{{{{key}}}}}", value)
+    return soql.strip()
+
+
+def load_soql_in(
+    name: str,
+    *,
+    string_params: Optional[Dict[str, str]] = None,
+    list_params: Dict[str, List[str]],
+) -> str:
+    """Read assets/soql/<name>.soql and substitute both scalar and list placeholders.
+
+    the BFS fan-out builds `WHERE X IN (:list)` queries
+    (apex_class_bodies_by_names, flow_definition_by_ids, plugin_functions_
+    by_plugin_ids, etc.). The existing `load_soql` only handles scalar
+    string substitution; this sibling covers the list case without
+    touching that signature.
+
+    Parameters
+    ----------
+    name:
+        Template filename (without `.soql`). Validated via
+        `fs_guard.validate_api_name` BEFORE any filesystem access — same
+        defence-in-depth gate as `load_soql` .
+    string_params:
+        Optional scalar {{KEY}} → value map. Values revalidated through
+        `fs_guard.validate_api_name` — identical path to `load_soql`.
+        Useful for templates that mix a single scalar value with a list
+        in the same query. No active callers at present (retired with
+        `flow_definition_ids_by_name_with_ns.soql` on 2026-05-05); kept
+        on the signature as a stable extension point.
+    list_params:
+        Required. {{KEY}} → list-of-strings map. Each element is
+        revalidated through `fs_guard.validate_api_name`; any failure
+        aborts the whole call with `SoqlParamError(key=<list-key>, ...)`.
+        Empty lists raise — SOQL `WHERE X IN ()` is a syntax error in
+        Salesforce, fail fast rather than let the CLI surface an opaque
+        500.
+
+    Rendering
+    ---------
+    Lists render as `','.join(f"'{v}'" for v in sorted(set(list_value)))`:
+    single-quoted, comma-separated, no surrounding parens. The `.soql`
+    template supplies the parens around the `{{PLACEHOLDER}}` so the
+    result reads `WHERE Id IN ('A','B','C')`.
+
+    Deduplication is load-bearing: SOQL tolerates dupes but they waste
+    the 100k-char query-length budget. Sort is for deterministic order —
+    stable cache keys and diffable test output.
+
+    Returns
+    -------
+    Substituted, `.strip()`-ed SOQL string.
+    """
+    # validate template name BEFORE touching the filesystem.
+    try:
+        fs_guard.validate_api_name(name, label="soql_template_name")
+    except fs_guard.ValidationError as e:
+        raise SoqlParamError("soql_template_name", name, e.reason) from None
+
+    string_params = string_params or {}
+
+    # / revalidate scalar params — same path as `load_soql`.
+    for key, value in string_params.items():
+        try:
+            fs_guard.validate_api_name(value, label=key)
+        except fs_guard.ValidationError as e:
+            raise SoqlParamError(key, value, e.reason) from None
+
+    # validate list params first (deterministic failure order — we
+    # want the first bad element, not a partially-rendered string).
+    rendered_lists: Dict[str, str] = {}
+    for key, list_value in list_params.items():
+        if not isinstance(list_value, list):
+            raise SoqlParamError(
+                key,
+                list_value,
+                f"list_params[{key}] must be a list, got {type(list_value).__name__}",
+            )
+        if not list_value:
+            # Salesforce `WHERE X IN ()` is a hard syntax error — fail fast
+            # at the loader, not at the CLI. Callers should branch on the
+            # empty-list case upstream (e.g. skip the whole SOQL) rather
+            # than rely on an empty-clause fallback.
+            raise SoqlParamError(
+                key, "[]", "empty-list-would-produce-invalid-soql",
+            )
+        # Dedupe + sort: cache-key stable, query-length budget sparing.
+        # `sorted(set(...))` raises TypeError on non-hashable elements;
+        # validate_api_name below will surface the real cause for
+        # non-strings, so gate on type FIRST.
+        for element in list_value:
+            try:
+                fs_guard.validate_api_name(element, label=key)
+            except fs_guard.ValidationError as e:
+                raise SoqlParamError(key, element, e.reason) from None
+        unique_sorted = sorted(set(list_value))
+        # Single-quote each element, comma-join. The `.soql` template
+        # supplies the surrounding parens around `{{KEY}}`.
+        rendered_lists[key] = ",".join(f"'{v}'" for v in unique_sorted)
+
+    # translate FileNotFoundError into SoqlTemplateNotFound. Same
+    # hygiene contract as `load_soql` — the absolute SOQL_DIR path must
+    # not bleed into caller-visible error text.
+    try:
+        soql = (SOQL_DIR / f"{name}.soql").read_text()
+    except FileNotFoundError:
+        raise SoqlTemplateNotFound(name) from None
+
+    # Single-pass substitution, same semantics as `load_soql`. Scalars
+    # first, lists second — the order is only relevant if a scalar value
+    # could contain a list-placeholder token, which `validate_api_name`
+    # forbids (no `{` or `}` in `[A-Za-z0-9_]+`).
+    for key, value in string_params.items():
+        soql = soql.replace(f"{{{{{key}}}}}", value)
+    for key, rendered in rendered_lists.items():
+        soql = soql.replace(f"{{{{{key}}}}}", rendered)
+    return soql.strip()

--- a/skills/investigating-agentforce-architecture/scripts/summarize_tree.py
+++ b/skills/investigating-agentforce-architecture/scripts/summarize_tree.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Render the declared action tree as a box-drawing summary.md.
+
+Called by finalize.py (cold path) and cache_check.py (hit path when the
+cached summary is missing). Mirrors the old agent Phase 7 render_tree()
+logic verbatim.
+
+Usage:
+    python3 summarize_tree.py <tree_json_path> <out_md_path> <built_at_utc>
+
+Inputs:
+    argv[1]   absolute path to declared_action_tree.json (or similar)
+    argv[2]   output .summary.md path (overwritten atomically)
+    argv[3]   ISO-8601 UTC built-at timestamp (e.g. 2026-04-25T14:00:00Z)
+
+Outputs:
+    argv[2]   rendered markdown
+    exit 0    success
+    exit 1    missing args, read failure, write failure
+"""
+import json
+import os
+import pathlib
+import sys
+
+KC_ORDER = [
+    "BOT_DEFINITION", "TOPIC", "GEN_AI_FUNCTION",
+    "FLOW", "APEX", "PROMPT_TEMPLATE",
+    "STANDARD_ACTION", "UNKNOWN",
+]
+
+
+def render_tree(node, prefix="", is_last=True, lines=None, agent_=None):
+    if lines is None:
+        lines = []
+    connector = "└── " if is_last else "├── "
+    kind = node.get("kind", "?")
+    api = node.get("api_name", "?")
+    elem = node.get("element_name")
+    if kind == "BOT_DEFINITION":
+        v = (agent_ or {}).get("version") or ""
+        label = f"[{kind}] {api}" + (f" ({v})" if v else "")
+    elif kind == "GEN_AI_FUNCTION":
+        unwraps = node.get("unwraps_to") or {}
+        uk = unwraps.get("kind")
+        un = unwraps.get("api_name")
+        arrow = f" → {uk}:{un}" if uk and un else ""
+        label = f"[{kind}] {api}{arrow}"
+    elif kind in ("STANDARD_ACTION", "UNKNOWN"):
+        # Canonical key is `invocation_type` (schema 3.1+); fall back to
+        # the two legacy keys so caches built by an older parse_wave still
+        # render the qualifier.
+        raw = (
+            node.get("invocation_type")
+            or node.get("raw_invocation_type")
+            or node.get("raw_action_type")
+            or ""
+        )
+        label = f"[{kind}] {api}" + (f" ({raw})" if raw else "")
+    else:
+        label = f"[{kind}] {api}"
+    if elem and kind != "BOT_DEFINITION":
+        label += f"  — element:{elem}"
+    lines.append(prefix + connector + label)
+    children = node.get("children") or []
+    child_prefix = prefix + ("    " if is_last else "│   ")
+    for i, c in enumerate(children):
+        render_tree(c, child_prefix, i == len(children) - 1, lines, agent_)
+    return lines
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stderr.write(
+            "summarize_tree.py: usage: python3 summarize_tree.py <tree_json_path> "
+            "<out_md_path> <built_at_utc>\n"
+        )
+        return 1
+
+    tree_path = pathlib.Path(sys.argv[1])
+    out_path = pathlib.Path(sys.argv[2])
+    built_at = sys.argv[3]
+
+    try:
+        tree = json.loads(tree_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"summarize_tree.py: cannot read {tree_path}: {e}\n")
+        return 1
+
+    a = tree.get("agent", {}) or {}
+    kc = tree.get("_kind_counts", {}) or {}
+
+    lines = [
+        f"# {a.get('api_name', '?')} {a.get('version', '?')} — declared action tree",
+        "",
+        f"- **Bot ID:** `{a.get('bot_id', '?')}`",
+        f"- **Master label:** {a.get('master_label', '?')}",
+        f"- **Generation:** {a.get('generation', 'unknown')}",
+        f"- **Planner:** `{a.get('planner_name', '?')}` ({a.get('planner_type', '?')})",
+        f"- **Version auto-picked:** {a.get('_version_auto_picked', False)}",
+        f"- **Built at (UTC):** {built_at}",
+        f"- **Node count:** {tree.get('node_count', 0)}",
+        f"- **Depth:** {tree.get('depth', 0)}",
+        f"- **Partial:** {tree.get('_partial', False)}",
+        "",
+        "## Kind counts",
+        "",
+    ]
+    for k in KC_ORDER:
+        lines.append(f"- `{k}`: {kc.get(k, 0)}")
+
+    lines += [
+        "",
+        "## Declared action tree",
+        "",
+        "```",
+    ]
+    root = tree.get("root") or {"kind": "BOT_DEFINITION", "api_name": a.get("api_name", "?"), "children": []}
+    lines.extend(render_tree(root, "", True, None, a))
+    lines.append("```")
+
+    if tree.get("_unresolved"):
+        lines += ["", "## Unresolved", ""]
+        for u in tree["_unresolved"]:
+            lines.append(
+                f"- `{u.get('kind')}`/`{u.get('api_name')}` — {u.get('reason')}"
+            )
+
+    content = "\n".join(lines) + "\n"
+
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+        tmp.write_text(content)
+        os.replace(tmp, out_path)
+    except OSError as e:
+        sys.stderr.write(f"summarize_tree.py: write failed: {e}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/scripts/tests/_bootstrap.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/_bootstrap.py
@@ -1,0 +1,23 @@
+"""Shared sys.path bootstrap for the test suite.
+
+The scripts/ scripts expect to be imported as top-level modules (config,
+soql_loader, rest_client, sf_cli) — that's how they behave when main.py
+does `from config import ...`. Tests mirror that by inserting scripts/
+onto sys.path.
+
+fs_guard is now sourced via ``from config import fs_guard`` (config.py
+re-exports it from the plugin _shared/ package). No tools/ entry on
+sys.path is required — config.py's dev-fallback walks up to the repo's
+``plugins/investigating-agentforce-architecture/shared/`` when ``scripts/_shared/``
+hasn't yet been mirrored by install.sh / the build script.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+
+s = str(_SCRIPTS_DIR)
+if s not in sys.path:
+    sys.path.insert(0, s)

--- a/skills/investigating-agentforce-architecture/scripts/tests/fixtures/genai_payloads.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/fixtures/genai_payloads.py
@@ -1,0 +1,400 @@
+"""Synthetic GenAi query payloads for main pipeline integration tests.
+
+Phase 2 Batch 1: these fixtures model the shapes live Salesforce returns
+for each of the 7 Wave A + 3 Wave B SOQL calls. Field names come from
+`references/soql_fields.md` (live-describe verified on my-org-alias +
+my-perf-org-alias, 2026-05-02).
+
+Two shapes covered:
+  * CLASSIC_*  — MyAgent v5-shaped payloads (AiCopilot__* planner,
+    InvocationTarget is DeveloperName strings, PlannerId set on bundle-
+    scope functions).
+  * NGA_*      — MyAgent2 v3-shaped payloads (Atlas__* planner,
+    InvocationTarget is Salesforce Ids, PluginId set on every function).
+
+SEQUENTIAL_* is a third variant: classic PlannerType but 0 plugins, 1
+bundle-scope function — reproduces the SequentialPlannerIntentClassifier
+bot shape which tests often miss.
+"""
+from __future__ import annotations
+
+
+# ===========================================================================
+# Classic shape (MyAgent v5-style)
+# ===========================================================================
+
+CLASSIC_PLANNER = {
+    "Id": "1VxVF0000000001",
+    "DeveloperName": "MyAgent",
+    "MasterLabel": "Service Agent",
+    "Description": "Classic ReAct MyAgent",
+    "PlannerType": "AiCopilot__ReActAiPlannerV1",
+    "Capabilities": None,
+    "AgentGraph": None,
+}
+
+CLASSIC_PLUGINS = [
+    {
+        # Distinct Ids per plugin; the plugin→function join table keys on
+        # this Id, so collapsing them would fan actions across every topic.
+        "Id": f"1VyVF000000TOP{i}",
+        "DeveloperName": f"Topic{i}",
+        "MasterLabel": f"Topic {i}",
+        "Description": f"Topic {i} desc",
+        "PluginType": "Custom",
+        "Scope": f"Topic {i} scope",
+        "IsLocal": True,
+        "CanEscalate": False,
+        "Source": "Declarative",
+        "ParentId": "1VxVF0000000001",
+        "LocalDeveloperName": f"Topic{i}",
+    }
+    for i in range(1, 7)  # 6 topics → matches the "6 topics" assertion
+]
+
+# Classic functions: 2 bundle-scope (PlannerId set, PluginId null) +
+# 2 topic-scope (PluginId set under Topic1). Invocation targets are
+# DeveloperName strings (classic).
+CLASSIC_FUNCTIONS = [
+    # Bundle-scope
+    {
+        "Id": "1VuVF0000000B01",
+        "DeveloperName": "LookupOrderFlow",
+        "MasterLabel": "Lookup Order",
+        "Description": None,
+        "InvocationTargetType": "flow",
+        "InvocationTarget": "LookupOrder",
+        "IsLocal": False,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": None,
+        "PlannerId": "1VxVF0000000001",
+        "ParentId": None,
+        "LocalDeveloperName": "LookupOrderFlow",
+    },
+    {
+        "Id": "1VuVF0000000B02",
+        "DeveloperName": "EscalateCase",
+        "MasterLabel": "Escalate Case",
+        "Description": None,
+        "InvocationTargetType": "apex",
+        "InvocationTarget": "CaseEscalationHandler",
+        "IsLocal": False,
+        "IsConfirmationRequired": True,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": None,
+        "PlannerId": "1VxVF0000000001",
+        "ParentId": None,
+        "LocalDeveloperName": "EscalateCase",
+    },
+    # Topic-scope (Topic1)
+    {
+        "Id": "1VuVF0000000T01",
+        "DeveloperName": "GetOrderDetails",
+        "MasterLabel": "Get Order Details",
+        "Description": None,
+        "InvocationTargetType": "flow",
+        "InvocationTarget": "GetOrderDetails",
+        "IsLocal": True,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": True,
+        "ProgressIndicatorMessage": "Looking up...",
+        "Source": "Declarative",
+        "PluginId": "1VyVF000000TOP1",
+        "PlannerId": None,
+        "ParentId": None,
+        "LocalDeveloperName": "GetOrderDetails",
+    },
+    {
+        "Id": "1VuVF0000000T02",
+        "DeveloperName": "ApplyDiscount",
+        "MasterLabel": "Apply Discount",
+        "Description": None,
+        "InvocationTargetType": "apex",
+        "InvocationTarget": "DiscountApplicator",
+        "IsLocal": True,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": "1VyVF000000TOP1",
+        "PlannerId": None,
+        "ParentId": None,
+        "LocalDeveloperName": "ApplyDiscount",
+    },
+]
+
+CLASSIC_PLUGIN_FUNCTIONS = [
+    {"Id": "1VqVF000001", "PluginId": "1VyVF000000TOP1", "Function": "1VuVF0000000T01"},
+    {"Id": "1VqVF000002", "PluginId": "1VyVF000000TOP1", "Function": "1VuVF0000000T02"},
+]
+
+CLASSIC_BUNDLE_FN_JOIN = [
+    {"Id": "1VrVF000001", "PlannerId": "1VxVF0000000001", "Plugin": "LookupOrderFlow"},
+    {"Id": "1VrVF000002", "PlannerId": "1VxVF0000000001", "Plugin": "EscalateCase"},
+]
+
+CLASSIC_INSTRUCTIONS = [
+    {
+        "Id": "1VwVF000001",
+        "GenAiPluginDefinitionId": "1VyVF000000TOP1",
+        "DeveloperName": "Instruction1",
+        "MasterLabel": "Use polite tone",
+        "Description": "Always greet the user first.",
+        "SortOrder": 1,
+    }
+]
+
+CLASSIC_ATTRS = [
+    {
+        "Id": "1VvVF000001",
+        "ParentId": "1VuVF0000000T01",
+        "DeveloperName": "OrderId",
+        "MasterLabel": "Order Id",
+        "Description": None,
+        "MappingType": "input",
+        "ParameterName": "orderId",
+    }
+]
+
+# Wave B classic: 2 flows (LookupOrder, GetOrderDetails), 2 apex
+# (CaseEscalationHandler, DiscountApplicator).
+CLASSIC_FLOW_DEFS = [
+    {"Id": "300VF001", "DeveloperName": "LookupOrder", "ActiveVersionId": "301VF001"},
+    {"Id": "300VF002", "DeveloperName": "GetOrderDetails", "ActiveVersionId": "301VF002"},
+]
+
+CLASSIC_APEX_ROWS = [
+    {
+        "Id": "01pVF001",
+        "Name": "CaseEscalationHandler",
+        "Body": "public class CaseEscalationHandler {}",
+        "SymbolTable": None,
+        "ApiVersion": 60.0,
+        "IsValid": True,
+    },
+    {
+        "Id": "01pVF002",
+        "Name": "DiscountApplicator",
+        "Body": "public class DiscountApplicator {}",
+        "SymbolTable": None,
+        "ApiVersion": 60.0,
+        "IsValid": True,
+    },
+]
+
+CLASSIC_FLOW_METADATA = {
+    "301VF001": {"Id": "301VF001", "FullName": "LookupOrder-1", "Metadata": {}},
+    "301VF002": {"Id": "301VF002", "FullName": "GetOrderDetails-1", "Metadata": {}},
+}
+
+
+# ===========================================================================
+# NGA shape (MyAgent2 v3-style) — InvocationTarget is Ids, PluginId-only
+# ===========================================================================
+
+NGA_PLANNER = {
+    "Id": "1VxVF0000000N01",
+    "DeveloperName": "MyAgent2",
+    "MasterLabel": "NGA Service Agent",
+    "Description": "Atlas MyAgent",
+    "PlannerType": "Atlas__ConcurrentMultiAgentOrchestration",
+    "Capabilities": None,
+    "AgentGraph": None,
+}
+
+NGA_PLUGINS = [
+    {
+        "Id": "1VyVF0000000N01",
+        "DeveloperName": "NGATopic1",
+        "MasterLabel": "NGA Topic 1",
+        "Description": None,
+        "PluginType": "Custom",
+        "Scope": "NGA scope",
+        "IsLocal": True,
+        "CanEscalate": False,
+        "Source": "Declarative",
+        "ParentId": "1VxVF0000000N01",
+        "LocalDeveloperName": "NGATopic1",
+    },
+]
+
+# NGA functions store InvocationTarget as Salesforce Ids — `01p...` for
+# Apex, `300...` for FlowDefinition. PluginId is always set; PlannerId
+# is null.
+NGA_FUNCTIONS = [
+    {
+        "Id": "1VuVF0000000N01",
+        "DeveloperName": "NGAFlowAction",
+        "MasterLabel": "NGA Flow Action",
+        "Description": None,
+        "InvocationTargetType": "flow",
+        "InvocationTarget": "300VF999NGAFLOW",
+        "IsLocal": True,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": "1VyVF0000000N01",
+        "PlannerId": None,
+        "ParentId": None,
+        "LocalDeveloperName": "NGAFlowAction",
+    },
+    {
+        "Id": "1VuVF0000000N02",
+        "DeveloperName": "NGAApexAction",
+        "MasterLabel": "NGA Apex Action",
+        "Description": None,
+        "InvocationTargetType": "apex",
+        "InvocationTarget": "01pVF999NGAAPEX",
+        "IsLocal": True,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": "1VyVF0000000N01",
+        "PlannerId": None,
+        "ParentId": None,
+        "LocalDeveloperName": "NGAApexAction",
+    },
+]
+
+NGA_PLUGIN_FUNCTIONS = [
+    {"Id": "1VqVF00N01", "PluginId": "1VyVF0000000N01", "Function": "1VuVF0000000N01"},
+    {"Id": "1VqVF00N02", "PluginId": "1VyVF0000000N01", "Function": "1VuVF0000000N02"},
+]
+
+# NGA reverse-lookup rows (B1 NGA variant + B3 NGA variant)
+NGA_FLOW_DEF_BY_ID = [
+    {
+        "Id": "300VF999NGAFLOW",
+        "DeveloperName": "NGAResolvedFlow",
+        "ActiveVersionId": "301VF999NGAVER",
+        "LatestVersionId": "301VF999NGAVER",
+    },
+]
+
+NGA_APEX_BY_ID = [
+    {
+        "Id": "01pVF999NGAAPEX",
+        "Name": "NGAResolvedApex",
+        "Body": "public class NGAResolvedApex {}",
+        "SymbolTable": None,
+        "ApiVersion": 60.0,
+        "IsValid": True,
+    },
+]
+
+
+# ===========================================================================
+# SequentialPlannerIntentClassifier shape
+# ===========================================================================
+# Classic family (AiCopilot__SequentialPlannerIntentClassifier), ZERO
+# plugins, exactly ONE bundle-scope function. Tests the
+# "empty plugin_ids short-circuits" path.
+
+SEQ_PLANNER = {
+    "Id": "1VxVF0000000SEQ",
+    "DeveloperName": "SequentialAgent",
+    "MasterLabel": "Sequential Agent",
+    "Description": None,
+    "PlannerType": "AiCopilot__SequentialPlannerIntentClassifier",
+    "Capabilities": None,
+    "AgentGraph": None,
+}
+
+SEQ_FUNCTIONS = [
+    {
+        "Id": "1VuVF0000000S01",
+        "DeveloperName": "StandardReply",
+        "MasterLabel": "Standard Reply",
+        "Description": None,
+        "InvocationTargetType": "standardInvocableAction",
+        "InvocationTarget": "reply",
+        "IsLocal": False,
+        "IsConfirmationRequired": False,
+        "IsIncludeInProgressIndicator": False,
+        "ProgressIndicatorMessage": None,
+        "Source": "Declarative",
+        "PluginId": None,
+        "PlannerId": "1VxVF0000000SEQ",
+        "ParentId": None,
+        "LocalDeveloperName": "StandardReply",
+    },
+]
+
+
+# ===========================================================================
+# Bot version / definition rows (Data API shape)
+# ===========================================================================
+
+def make_bot_versions(agent_api_name: str, versions=("v5",), active: str = "v5") -> list[dict]:
+    """Build BotVersion records list in the Data API shape."""
+    return [
+        {
+            "Id": f"0Xx{i:012d}",
+            "DeveloperName": v,
+            "Status": "Active" if v == active else "Inactive",
+            "BotDefinitionId": "0Xa000000000ABC",
+            "BotDefinition": {
+                "DeveloperName": agent_api_name,
+                "MasterLabel": f"{agent_api_name} bot",
+            },
+        }
+        for i, v in enumerate(versions)
+    ]
+
+
+BOT_DEFINITION_DETAIL_CLASSIC = {
+    "DeveloperName": "MyAgent",
+    "MasterLabel": "Service Agent",
+    "Description": "Classic bot",
+    "AgentType": "ExternalCopilot",
+    "Type": "Copilot",
+    "AgentTemplate": "EinsteinCopilotForServiceTmpl",
+    "BotSource": "EinsteinCopilot",
+}
+
+BOT_DEFINITION_DETAIL_NGA = {
+    "DeveloperName": "MyAgent2",
+    "MasterLabel": "NGA Service Agent",
+    "Description": "NGA bot",
+    "AgentType": "EinsteinAgentKind",
+    "Type": "Agentforce",
+    "AgentTemplate": "SvcCopilotTmpl__EinsteinAgentKind",
+    "BotSource": "AgentforceService",
+}
+
+
+# ===========================================================================
+# Probe-channels "all OK" + "PROBE_FAILED" payloads
+# ===========================================================================
+
+
+def probe_ok_payload() -> dict:
+    return {
+        "_schema": "channels/1",
+        "_built_at_utc": 0.0,
+        "status": "OK",
+        "channels": {},
+    }
+
+
+def probe_failed_payload(sobject: str = "GenAiPlannerDefinition",
+                        missing: list[str] | None = None) -> dict:
+    return {
+        "_schema": "channels/1",
+        "_built_at_utc": 0.0,
+        "status": "PROBE_FAILED",
+        "channels": {
+            sobject: {
+                "queryable_fields": [],
+                "mandatory_missing": missing or ["DeveloperName"],
+                "describe_error": None,
+            }
+        },
+    }

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_cache_check.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_cache_check.py
@@ -1,0 +1,307 @@
+"""cache_check.py schema-version mismatch → delete-on-read + MISS.
+
+Covers:
+  * manifest.schema_version == config.SCHEMA_VERSION → HIT
+  * manifest.schema_version != config.SCHEMA_VERSION → MISS +
+    CACHE_INVALIDATED_REASON=schema-version-mismatch + cache dir deleted
+  * missing manifest → MISS (existing behavior preserved)
+  * expired TTL + correct schema → MISS + dir NOT deleted
+  * _safe_rmtree_under_cache_root refuses paths outside CACHE_ROOT
+  * module import raises if CACHE_ROOT is a symlink
+
+The script reads env vars + writes eval-able K=V lines to stdout +
+exits 0 on both HIT and MISS. We drive it via subprocess so we exercise
+the real stdout stream and exit code.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+import cache_check  # type: ignore
+
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent.parent
+CACHE_CHECK = SCRIPTS_DIR / "cache_check.py"
+
+
+def _parse_kv(stdout: str) -> dict[str, str]:
+    """Parse the shlex-quoted K=V lines cache_check emits.
+
+    cache_check writes one `K=V` per line, V shlex-quoted. For our tests
+    we don't need full shell parsing — we just strip one surrounding
+    single-quote layer if present.
+    """
+    out: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if v.startswith("'") and v.endswith("'") and len(v) >= 2:
+            v = v[1:-1]
+        out[k] = v
+    return out
+
+
+class CacheCheckSchemaVersionTests(unittest.TestCase):
+    """strict schema-version match, delete-on-mismatch."""
+
+    def setUp(self) -> None:
+        # Isolated tempdir mirroring CACHE_ROOT so we can safely rmtree
+        # anything under it. We override config.CACHE_ROOT for the
+        # duration of each test — the script reads config.CACHE_ROOT at
+        # rmtree-validation time, and we drive the script via subprocess
+        # with CACHE_ROOT propagated through env only via a wrapper
+        # below (subprocess-style overrides).
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name).resolve()
+        self.cache_root = self.root / "cache"
+        self.data_root = self.root / "data"
+        self.work_dir = self.root / "work"
+        self.cache_root.mkdir()
+        self.data_root.mkdir()
+        self.work_dir.mkdir()
+        # Agent-keyed sub-path under cache_root.
+        self.agent = "TestAgent_v1"
+        self.version = "v1"
+        self.cache_dir = self.cache_root / "00D000000000ABC" / f"{self.agent}__{self.version}"
+        self.data_dir = self.data_root / "00D000000000ABC" / f"{self.agent}__{self.version}"
+        self.cache_dir.mkdir(parents=True)
+        # Data file manifest points at — must exist for the HIT path.
+        self.data_file = self.cache_dir / "metadata_tree.json"
+        self.data_file.write_text(json.dumps({"root": {"kind": "Bot"}}))
+        # summary.md dropped from the output contract — no
+        # longer written by cache seeding.
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_manifest(self, schema_version: str, age_days: int = 0) -> None:
+        built = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=age_days)
+        manifest = {
+            "schema_version": schema_version,
+            "data_path": str(self.data_file),
+            "built_at_utc": built.isoformat().replace("+00:00", "Z"),
+            "ttl_days": 7,
+            "node_count": 1,
+            "depth": 1,
+            "agent": {
+                "generation": "Einstein",
+                "bot_id": "0Xx000000000000",
+                "master_label": "TestAgent",
+                "planner_name": "p1",
+            },
+            "kind_counts": {"Bot": 1},
+            "partial": False,
+            "unresolved_count": 0,
+        }
+        (self.cache_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    def _run_with_patched_cache_root(self, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+        """Patch config.CACHE_ROOT via a small wrapper — simpler than the
+        HOME-redirect dance and keeps the test local to the module under
+        test. We write a tiny entry-point that monkeypatches config
+        before invoking cache_check.main, then runs it.
+        """
+        wrapper = self.root / "wrapper.py"
+        wrapper.write_text(
+            "import sys; sys.path.insert(0, %r); sys.path.insert(0, %r)\n"
+            "import config\n"
+            "config.CACHE_ROOT = __import__('pathlib').Path(%r)\n"
+            "import cache_check\n"
+            "sys.exit(cache_check.main())\n"
+            % (str(SCRIPTS_DIR), str(SCRIPTS_DIR.parent / 'tools'), str(self.cache_root))
+        )
+        env = os.environ.copy()
+        env.update({
+            "CACHE_DIR": str(self.cache_dir),
+            "DATA_DIR": str(self.data_dir),
+            "WORK_DIR": str(self.work_dir),
+            "AGENT_API_NAME": self.agent,
+            "AGENT_VERSION": self.version,
+        })
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            [sys.executable, str(wrapper)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_matching_schema_version_hits(self):
+        self._write_manifest(config.SCHEMA_VERSION)
+        cp = self._run_with_patched_cache_root()
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        kv = _parse_kv(cp.stdout)
+        self.assertEqual(kv.get("CACHE_HIT"), "true", cp.stdout)
+        self.assertNotIn("CACHE_INVALIDATED_REASON", kv)
+        # Cache dir survives.
+        self.assertTrue(self.cache_dir.exists())
+
+    def test_legacy_schema_version_misses_and_deletes(self):
+        """schema_version=2.4 (legacy) != 3.0 (current) → MISS + rmtree."""
+        self._write_manifest("2.4")
+        self.assertTrue(self.cache_dir.exists())
+        cp = self._run_with_patched_cache_root()
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        kv = _parse_kv(cp.stdout)
+        self.assertEqual(kv.get("CACHE_HIT"), "false")
+        self.assertEqual(kv.get("CACHE_INVALIDATED_REASON"), "schema-version-mismatch")
+        # Cache dir deleted by the safety-gated rmtree.
+        self.assertFalse(self.cache_dir.exists(),
+                         "cache_dir must be removed on schema-version mismatch")
+
+    def test_unexpected_future_schema_version_misses_and_deletes(self):
+        """Any value != current SCHEMA_VERSION invalidates (not just legacy)."""
+        self._write_manifest("99.99")
+        cp = self._run_with_patched_cache_root()
+        kv = _parse_kv(cp.stdout)
+        self.assertEqual(kv.get("CACHE_HIT"), "false")
+        self.assertEqual(kv.get("CACHE_INVALIDATED_REASON"), "schema-version-mismatch")
+        self.assertFalse(self.cache_dir.exists())
+
+    def test_missing_manifest_misses_no_deletion(self):
+        """Existing behavior: no manifest → MISS, NO rmtree, no reason emit."""
+        # Don't write any manifest.
+        cp = self._run_with_patched_cache_root()
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        kv = _parse_kv(cp.stdout)
+        self.assertEqual(kv.get("CACHE_HIT"), "false")
+        # Missing manifest is a different reason class — no invalidation
+        # reason emitted here (cache is simply cold, not corrupt).
+        self.assertNotIn("CACHE_INVALIDATED_REASON", kv)
+        self.assertTrue(self.cache_dir.exists(),
+                        "missing manifest must NOT trigger rmtree")
+
+    def test_expired_ttl_with_matching_schema_misses_no_deletion(self):
+        """TTL-expired cache with CURRENT schema → MISS but dir stays intact."""
+        self._write_manifest(config.SCHEMA_VERSION, age_days=30)  # 30 > 7
+        cp = self._run_with_patched_cache_root()
+        kv = _parse_kv(cp.stdout)
+        self.assertEqual(kv.get("CACHE_HIT"), "false")
+        # No schema-mismatch reason — it's a stale cache, not a corrupt one.
+        self.assertNotIn("CACHE_INVALIDATED_REASON", kv)
+        self.assertTrue(self.cache_dir.exists(),
+                        "expired TTL must NOT rmtree — just mark stale")
+
+
+class SafeRmtreeUnderCacheRootTests(unittest.TestCase):
+    """defensive: `_safe_rmtree_under_cache_root` refuses out-of-root paths."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name).resolve()
+        self.cache_root = self.root / "cache"
+        self.cache_root.mkdir()
+        # In-scope victim dir.
+        self.in_scope = self.cache_root / "agent_v1"
+        self.in_scope.mkdir()
+        (self.in_scope / "some.txt").write_text("x")
+        # Out-of-scope victim dir (sibling to cache_root).
+        self.out_of_scope = self.root / "other"
+        self.out_of_scope.mkdir()
+        (self.out_of_scope / "important.txt").write_text("do not delete")
+
+        # Monkeypatch config.CACHE_ROOT for the duration of each test.
+        self._orig_root = config.CACHE_ROOT
+        config.CACHE_ROOT = self.cache_root
+
+    def tearDown(self) -> None:
+        config.CACHE_ROOT = self._orig_root
+        self.tmp.cleanup()
+
+    def test_rmtree_under_cache_root_succeeds(self):
+        ok = cache_check._safe_rmtree_under_cache_root(self.in_scope)
+        self.assertTrue(ok)
+        self.assertFalse(self.in_scope.exists())
+
+    def test_rmtree_outside_cache_root_refused(self):
+        ok = cache_check._safe_rmtree_under_cache_root(self.out_of_scope)
+        self.assertFalse(ok, "out-of-root path must be refused")
+        # File still present.
+        self.assertTrue((self.out_of_scope / "important.txt").exists())
+
+    def test_nonexistent_under_root_is_noop_success(self):
+        """A caller asking to delete a path that doesn't exist under the
+        root gets a silent success — matches rmtree's semantics for
+        already-gone targets and avoids spurious error branches on the
+        miss() path."""
+        ghost = self.cache_root / "never_existed"
+        ok = cache_check._safe_rmtree_under_cache_root(ghost)
+        self.assertTrue(ok)
+
+
+class SymlinkedCacheRootRejectedAtImportTests(unittest.TestCase):
+    """module import raises if CACHE_ROOT is a symlink.
+
+    A symlinked CACHE_ROOT would defeat the rmtree safety gate — both
+    sides of `target.resolve().is_relative_to(root.resolve())` would
+    collapse to the same symlink target, so the gate would approve
+    deletion of arbitrary paths the attacker aimed the symlink at.
+    The defence is a fail-fast guard at cache_check import time.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name).resolve()
+        self.real_target = self.root / "evil_target"
+        self.real_target.mkdir()
+        self.symlinked_root = self.root / "symlinked_cache_root"
+        self.symlinked_root.symlink_to(self.real_target)
+        self._orig_root = config.CACHE_ROOT
+
+    def tearDown(self) -> None:
+        # Restore and reload so the rest of the suite sees a clean module.
+        config.CACHE_ROOT = self._orig_root
+        importlib.reload(cache_check)
+        self.tmp.cleanup()
+
+    def test_symlinked_cache_root_raises_on_import(self):
+        """Reloading cache_check with a symlinked CACHE_ROOT must raise
+        RuntimeError — proof that the guard actually fires and the fix
+        is load-bearing."""
+        config.CACHE_ROOT = self.symlinked_root
+        with self.assertRaises(RuntimeError) as ctx:
+            importlib.reload(cache_check)
+        msg = str(ctx.exception)
+        # Message must name the offending path so operators can fix it
+        # without spelunking the source. Don't over-specify wording —
+        # future maintainers may clarify the phrasing.
+        self.assertIn(str(self.symlinked_root), msg)
+        self.assertIn("symlink", msg.lower())
+
+    def test_real_directory_cache_root_passes(self):
+        """Sanity: the guard is not over-broad — a real directory (the
+        common case) reloads cleanly."""
+        real_dir = self.root / "real_cache_root"
+        real_dir.mkdir()
+        config.CACHE_ROOT = real_dir
+        # No raise.
+        importlib.reload(cache_check)
+
+    def test_nonexistent_cache_root_passes(self):
+        """Pristine install: CACHE_ROOT hasn't been created yet.
+        Path.is_symlink() returns False on non-existent paths, so import
+        must succeed — the directory will be materialized on first write."""
+        ghost = self.root / "does_not_exist_yet"
+        self.assertFalse(ghost.exists())
+        config.CACHE_ROOT = ghost
+        # No raise.
+        importlib.reload(cache_check)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_cache_check_main.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_cache_check_main.py
@@ -1,0 +1,283 @@
+"""In-process tests for ``cache_check.main``.
+
+The existing ``test_cache_check.py`` drives main via subprocess (so its
+Python branches don't show up in coverage). This file calls main()
+directly, patching ``os.environ`` + ``config.CACHE_ROOT`` so all the
+hit/miss decision branches register.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import cache_check  # type: ignore
+import config  # type: ignore
+
+
+def _build_valid_manifest(*, data_path: str,
+                          built_at_utc: str | None = None,
+                          schema_version: str = "3.1",
+                          node_count: int = 5,
+                          depth: int = 2,
+                          ttl_days: int = 7,
+                          partial: bool = False,
+                          unresolved_count: int = 0,
+                          generation: str = "nga",
+                          bot_id: str = "0Xx000000000Demo",
+                          master_label: str = "Demo Agent",
+                          version_auto_picked: bool = False,
+                          planner_name: str = "DemoPlanner",
+                          kind_counts: dict | None = None) -> dict:
+    if built_at_utc is None:
+        built_at_utc = (
+            dt.datetime.now(dt.timezone.utc)
+            .isoformat().replace("+00:00", "Z")
+        )
+    return {
+        "schema_version": schema_version,
+        "built_at_utc": built_at_utc,
+        "node_count": node_count,
+        "depth": depth,
+        "ttl_days": ttl_days,
+        "data_path": data_path,
+        "partial": partial,
+        "unresolved_count": unresolved_count,
+        "agent": {
+            "generation": generation,
+            "bot_id": bot_id,
+            "master_label": master_label,
+            "_version_auto_picked": version_auto_picked,
+            "planner_name": planner_name,
+        },
+        "kind_counts": kind_counts or {"TOPIC": 2, "STANDARD_ACTION": 3},
+    }
+
+
+class _CacheHarness:
+    """Patch CACHE_ROOT + os.environ + capture stdout."""
+
+    def __init__(self, *, env_overrides: dict | None = None,
+                 manifest: dict | None = None,
+                 plant_data_file: bool = True):
+        self.env_overrides = env_overrides or {}
+        self.manifest = manifest
+        self.plant_data_file = plant_data_file
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self.tmpdir = Path(self._tmp.name)
+        # Build a 4-deep CACHE_ROOT so cache_dir lives strictly inside it
+        # (the rmtree guard refuses paths NOT under CACHE_ROOT).
+        self.cache_root = self.tmpdir / "cache" / "investigating-agentforce-architecture"
+        self.cache_root.mkdir(parents=True)
+        self.cache_dir = self.cache_root / "ALPHA0000000000" / "MyAgent__v1"
+        self.cache_dir.mkdir(parents=True)
+        self.data_dir = self.tmpdir / "data" / "ALPHA0000000000" / "MyAgent__v1"
+        self.work_dir = self.tmpdir / "work"
+        self.work_dir.mkdir(parents=True)
+
+        # Plant the authoritative tree file UNDER cache_dir (where
+        # finalize.py originally wrote it). cache_check copies it INTO
+        # data_dir on hit, so source and dest must be different files.
+        self.tree_path = self.cache_dir / "MyAgent_v1_metadata_tree.json"
+        if self.plant_data_file:
+            self.tree_path.write_text(json.dumps({
+                "agent": {"api_name": "MyAgent", "version": "v1"},
+                "session": {"_schema_version": 1},
+            }))
+
+        # Plant the manifest under cache_dir
+        if self.manifest is not None:
+            (self.cache_dir / "manifest.json").write_text(
+                json.dumps(self.manifest)
+            )
+        elif self.manifest is None and self.plant_data_file:
+            # Default valid manifest pointing at the planted tree
+            (self.cache_dir / "manifest.json").write_text(json.dumps(
+                _build_valid_manifest(data_path=str(self.tree_path))
+            ))
+
+        self._env = {
+            "CACHE_DIR": str(self.cache_dir),
+            "DATA_DIR": str(self.data_dir),
+            "WORK_DIR": str(self.work_dir),
+            "AGENT_API_NAME": "MyAgent",
+            "AGENT_VERSION": "v1",
+        }
+        self._env.update(self.env_overrides)
+
+        self._saved_env = dict(os.environ)
+        os.environ.update(self._env)
+
+        self._patches = [
+            mock.patch.object(config, "CACHE_ROOT", self.cache_root),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        # Restore env
+        for k in self._env:
+            os.environ.pop(k, None)
+        os.environ.update(self._saved_env)
+        self._tmp.cleanup()
+
+
+def _run_main_capture() -> tuple[int, str]:
+    """Call main() with stdout captured. Translates SystemExit into rc."""
+    buf = io.StringIO()
+    rc: int
+    try:
+        with mock.patch("sys.stdout", buf):
+            rc = cache_check.main()
+    except SystemExit as e:
+        rc = e.code if isinstance(e.code, int) else 0
+    return rc, buf.getvalue()
+
+
+# -----------------------------------------------------------------------------
+# Hit path
+# -----------------------------------------------------------------------------
+
+
+class CacheHitTests(unittest.TestCase):
+
+    def test_hit_emits_cache_hit_true_with_full_export_block(self):
+        with _CacheHarness():
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=true", out)
+        # Full hit block has these signature fields
+        self.assertIn("CACHED_AT_UTC=", out)
+        self.assertIn("NODE_COUNT=", out)
+        self.assertIn("DEPTH=", out)
+        self.assertIn("AGENT_GENERATION=", out)
+        self.assertIn("BOT_ID=", out)
+        self.assertIn("PLANNER_NAME=", out)
+
+    def test_hit_copies_tree_into_data_dir(self):
+        with _CacheHarness() as h:
+            rc, _ = _run_main_capture()
+            self.assertEqual(rc, 0)
+            dst = h.data_dir / "MyAgent_v1_metadata_tree.json"
+            # File search across resolved tree to dodge /private/var ↔ /var.
+            written = list(h.tmpdir.rglob("MyAgent_v1_metadata_tree.json"))
+        self.assertGreaterEqual(len(written), 1)
+
+    def test_hit_stages_declared_action_tree_in_work_dir(self):
+        with _CacheHarness() as h:
+            _run_main_capture()
+            staged = list(h.tmpdir.rglob("declared_action_tree.json"))
+        self.assertGreaterEqual(len(staged), 1)
+
+    def test_hit_emits_kind_counts_with_kc_prefix(self):
+        with _CacheHarness():
+            _, out = _run_main_capture()
+        self.assertIn("KC_TOPIC=", out)
+        self.assertIn("KC_STANDARD_ACTION=", out)
+
+
+# -----------------------------------------------------------------------------
+# Miss paths (each one exits 0 with CACHE_HIT=false)
+# -----------------------------------------------------------------------------
+
+
+class CacheMissTests(unittest.TestCase):
+
+    def test_miss_when_force_refresh_true(self):
+        with _CacheHarness(env_overrides={"FORCE_REFRESH": "true"}):
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_when_manifest_missing(self):
+        # Build harness without auto-planted manifest
+        with _CacheHarness(manifest={}, plant_data_file=False) as h:
+            (h.cache_dir / "manifest.json").unlink()
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_when_manifest_malformed(self):
+        with _CacheHarness(manifest={}) as h:
+            (h.cache_dir / "manifest.json").write_text("<<<not json>>>")
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_with_invalidated_reason_on_schema_mismatch(self):
+        # Schema version != config.SCHEMA_VERSION → rmtree + miss
+        with _CacheHarness(manifest=_build_valid_manifest(
+            data_path="/tmp/x", schema_version="2.0",
+        )) as h:
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+        self.assertIn("CACHE_INVALIDATED_REASON=schema-version-mismatch", out)
+        # Cache dir got rmtree'd
+        self.assertFalse(h.cache_dir.exists())
+
+    def test_miss_when_data_path_missing(self):
+        with _CacheHarness(manifest=_build_valid_manifest(
+            data_path="/nope/not-a-real-path.json",
+        )):
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_when_built_at_unparseable(self):
+        with _CacheHarness() as h:
+            (h.cache_dir / "manifest.json").write_text(json.dumps(
+                _build_valid_manifest(
+                    data_path=str(h.tree_path),
+                    built_at_utc="not-a-timestamp",
+                ),
+            ))
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_when_ttl_expired(self):
+        # built_at_utc is far in the past + ttl_days=1 → age > ttl → miss
+        ancient = (dt.datetime.now(dt.timezone.utc)
+                   - dt.timedelta(days=30)).isoformat().replace("+00:00", "Z")
+        with _CacheHarness(manifest=None) as h:
+            (h.cache_dir / "manifest.json").write_text(json.dumps(
+                _build_valid_manifest(
+                    data_path=str(h.tree_path),
+                    built_at_utc=ancient,
+                    ttl_days=1,
+                ),
+            ))
+            rc, out = _run_main_capture()
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", out)
+
+    def test_miss_when_required_env_missing(self):
+        with _CacheHarness() as h:
+            os.environ.pop("CACHE_DIR", None)
+            buf = io.StringIO()
+            rc: int
+            try:
+                with mock.patch("sys.stdout", buf):
+                    with mock.patch("sys.stderr", io.StringIO()):
+                        rc = cache_check.main()
+            except SystemExit as e:
+                rc = e.code if isinstance(e.code, int) else 0
+        self.assertEqual(rc, 0)
+        self.assertIn("CACHE_HIT=false", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_config.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_config.py
@@ -1,0 +1,115 @@
+"""Tests for config path builders validate every component."""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+from config import fs_guard  # type: ignore — re-exported from _shared/
+
+
+class BuildAgentDataDirTests(unittest.TestCase):
+    def test_valid_inputs_produce_expected_path(self):
+        p = config.build_agent_data_dir(
+            org_id_15="00Dxx0000000000",
+            agent_api_name="MyAgent",
+            agent_version="v5",
+        )
+        self.assertEqual(p.name, "MyAgent__v5")
+        self.assertEqual(p.parent.name, "00Dxx0000000000")
+        # Full path must be under DATA_ROOT.
+        self.assertTrue(str(p).startswith(str(config.DATA_ROOT)))
+
+    def test_dotdot_in_agent_api_name_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_agent_data_dir(
+                org_id_15="00Dxx0000000000",
+                agent_api_name="..",
+                agent_version="v5",
+            )
+
+    def test_slash_in_agent_api_name_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_agent_data_dir(
+                org_id_15="00Dxx0000000000",
+                agent_api_name="foo/bar",
+                agent_version="v5",
+            )
+
+    def test_slash_in_org_id_15_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_agent_data_dir(
+                org_id_15="00D/x0000000000",
+                agent_api_name="MyAgent",
+                agent_version="v5",
+            )
+
+    def test_dotdot_in_agent_version_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_agent_data_dir(
+                org_id_15="00Dxx0000000000",
+                agent_api_name="MyAgent",
+                agent_version="..",
+            )
+
+
+class BuildAgentCacheDirTests(unittest.TestCase):
+    def test_valid_inputs_produce_expected_path(self):
+        p = config.build_agent_cache_dir(
+            org_id_15="00Dxx0000000000",
+            agent_api_name="MyAgent",
+            agent_version="v5",
+        )
+        self.assertEqual(p.name, "MyAgent__v5")
+        self.assertTrue(str(p).startswith(str(config.CACHE_ROOT)))
+
+    def test_slash_in_any_component_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_agent_cache_dir(
+                org_id_15="00Dxx0000000000",
+                agent_api_name="foo/bar",
+                agent_version="v5",
+            )
+
+
+class BuildProbeCacheDirTests(unittest.TestCase):
+    def test_valid_api_version_ok(self):
+        p = config.build_probe_cache_dir(
+            org_id_15="00Dxx0000000000",
+            api_version="v60.0",
+        )
+        self.assertEqual(p.name, "v60.0")
+        self.assertTrue(str(p).startswith(str(config.PROBE_CACHE_ROOT)))
+
+    def test_v60_no_minor_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_probe_cache_dir(
+                org_id_15="00Dxx0000000000",
+                api_version="v60",
+            )
+
+    def test_api_version_with_slash_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_probe_cache_dir(
+                org_id_15="00Dxx0000000000",
+                api_version="v60.0/../",
+            )
+
+    def test_api_version_dotdot_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_probe_cache_dir(
+                org_id_15="00Dxx0000000000",
+                api_version="..",
+            )
+
+    def test_slash_in_org_id_raises(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            config.build_probe_cache_dir(
+                org_id_15="00D/x0000000000",
+                api_version="v60.0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_end_to_end_fixture.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_end_to_end_fixture.py
@@ -1,0 +1,652 @@
+"""P2.3-3: end-to-end fixture integration tests.
+
+Drives `main.main(argv)` against synthetic fixtures — no real org, no
+sf CLI spawn, no HTTP. Every REST/sf boundary is mocked at the
+`main.fetch_*` / `main.run_sf` / `main.probe_channels` surface; all
+layers below (join, parse, render, finalize) run as production code.
+
+Tests (one per pipeline path):
+  1. classic_react_end_to_end       — STATUS=OK, tree + summary + architecture.md
+  2. nga_orchestration_end_to_end   — NGA reverse-lookup + `par/and` state diagram
+  3. cache_hit_end_to_end           — poisoned Wave A — must never be called
+  4. probe_failed_end_to_end        — STATUS=RETRIEVE_FAILED + schema-drift detail
+  5. force_refresh_end_to_end       — pre-populated fresh cache ignored
+  6. render_failure_end_to_end      — STATUS=PARTIAL_OK + RENDER_FAILED=true
+
+Each test carves its own tempdir for work/cache/data so no cross-test
+state leaks. Assertions focus on the observable surface (RESULT block
++ on-disk artifacts) rather than on implementation details of
+intermediate steps — the same tests survive a refactor of main.py's
+internal phase ordering.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+import soql_loader  # type: ignore
+import main  # type: ignore
+from tests.fixtures import genai_payloads as fx  # type: ignore
+
+# Same SOQL_DIR repoint as test_main_pipeline — CLAUDE_PLUGIN_ROOT is not
+# set during the test suite, so config's default resolves to a hub path
+# that doesn't match the dev checkout. Repoint to the repo source of truth
+# so load_soql reads the bundled templates.
+_REPO_SOQL_DIR = Path(__file__).resolve().parent.parent.parent / "assets" / "soql"
+config.SOQL_DIR = _REPO_SOQL_DIR
+soql_loader.SOQL_DIR = _REPO_SOQL_DIR
+
+# emit_result.py lives under tools/; tests invoke it via subprocess so the
+# tool's RESULT-formatting logic is exercised under the same contract the
+# SKILL.md Bash wrapper uses.
+_TOOLS_DIR = Path(__file__).resolve().parent.parent.parent / "tools"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrored from test_main_pipeline — intentionally copied
+# rather than imported, so a refactor of that file doesn't silently change
+# the end-to-end test behavior.)
+# ---------------------------------------------------------------------------
+
+
+def _args(work_dir: Path, **overrides) -> list[str]:
+    base = [
+        "--org-alias", "test-org",
+        "--agent", overrides.pop("agent", "MyAgent"),
+        "--work-dir", str(work_dir),
+        "--parallelism", "2",
+    ]
+    for k, v in overrides.items():
+        flag = "--" + k.replace("_", "-")
+        if isinstance(v, bool):
+            if v:
+                base.append(flag)
+        else:
+            base.extend([flag, str(v)])
+    return base
+
+
+def _mock_auth_probe(probe_result=None):
+    probe_result = probe_result or fx.probe_ok_payload()
+    org_display_payload = {
+        "status": 0,
+        "result": {
+            "instanceUrl": "https://example.my.salesforce.com",
+            "accessToken": "00Dxx0000000000!AQ_fake_token_value",
+            "id": "00Dxx0000000000AAA",
+            "apiVersion": "60.0",
+        },
+    }
+    return [
+        mock.patch.object(main, "run_sf", return_value=org_display_payload),
+        mock.patch.object(main, "probe_channels", return_value=probe_result),
+    ]
+
+
+def _mock_bot_resolution(agent_api_name="MyAgent", bot_def=None,
+                         versions=("v5",), active="v5"):
+    bot_def = bot_def or fx.BOT_DEFINITION_DETAIL_CLASSIC
+    return [
+        mock.patch.object(
+            main, "fetch_bot_versions",
+            return_value=fx.make_bot_versions(agent_api_name, versions, active),
+        ),
+        mock.patch.object(main, "fetch_bot_definition_details", return_value=bot_def),
+    ]
+
+
+def _mock_wave_a_classic():
+    return [
+        mock.patch.object(main, "fetch_planner_definition", return_value=fx.CLASSIC_PLANNER),
+        mock.patch.object(main, "fetch_plugins_by_planner", return_value=fx.CLASSIC_PLUGINS),
+        mock.patch.object(main, "fetch_planner_bundle_functions", return_value=fx.CLASSIC_BUNDLE_FN_JOIN),
+        mock.patch.object(main, "fetch_functions_by_plugins", return_value=fx.CLASSIC_FUNCTIONS),
+        mock.patch.object(main, "fetch_plugin_instructions", return_value=fx.CLASSIC_INSTRUCTIONS),
+        mock.patch.object(main, "fetch_plugin_functions", return_value=fx.CLASSIC_PLUGIN_FUNCTIONS),
+        mock.patch.object(main, "fetch_planner_attrs", return_value=fx.CLASSIC_ATTRS),
+    ]
+
+
+def _mock_wave_b_classic():
+    return [
+        mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=fx.CLASSIC_APEX_ROWS),
+        mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]),
+        mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=fx.CLASSIC_FLOW_DEFS),
+        mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]),
+        mock.patch.object(
+            main, "fetch_flow_metadata",
+            side_effect=lambda vid, *a, **kw: fx.CLASSIC_FLOW_METADATA.get(vid),
+        ),
+    ]
+
+
+def _mock_wave_a_nga():
+    return [
+        mock.patch.object(main, "fetch_planner_definition", return_value=fx.NGA_PLANNER),
+        mock.patch.object(main, "fetch_plugins_by_planner", return_value=fx.NGA_PLUGINS),
+        mock.patch.object(main, "fetch_planner_bundle_functions", return_value=[]),
+        mock.patch.object(main, "fetch_functions_by_plugins", return_value=fx.NGA_FUNCTIONS),
+        mock.patch.object(main, "fetch_plugin_instructions", return_value=[]),
+        mock.patch.object(main, "fetch_plugin_functions", return_value=fx.NGA_PLUGIN_FUNCTIONS),
+        mock.patch.object(main, "fetch_planner_attrs", return_value=[]),
+    ]
+
+
+def _mock_wave_b_nga():
+    return [
+        mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]),
+        mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=fx.NGA_APEX_BY_ID),
+        mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=[]),
+        mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=fx.NGA_FLOW_DEF_BY_ID),
+        mock.patch.object(main, "fetch_flow_metadata", return_value={
+            "Id": "301VF999NGAVER", "FullName": "NGAResolvedFlow-1", "Metadata": {},
+        }),
+    ]
+
+
+def _apply(patches):
+    for p in patches:
+        p.start()
+
+
+def _stop(patches):
+    for p in patches:
+        p.stop()
+
+
+def _run_emit_result(work_dir: Path) -> subprocess.CompletedProcess:
+    """Drive emit_result.py against the ctx main.py wrote.
+
+    Exercises the same SKILL.md Bash-wrapper contract: main.py writes
+    .emit_ctx.json, emit_result.py reads + renders. Subprocess call so
+    the tool runs under a clean env (no leaked test-process state).
+    """
+    env = {**os.environ, "WORK_DIR": str(work_dir)}
+    return subprocess.run(
+        [sys.executable, str(_TOOLS_DIR / "emit_result.py")],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+def _parse_result_block(stdout: str) -> dict:
+    """Pull KV pairs out of the `=== RESULT ===` block."""
+    lines = stdout.splitlines()
+    out: dict[str, str] = {}
+    in_block = False
+    for line in lines:
+        if line.strip() == "=== RESULT ===":
+            in_block = True
+            continue
+        if in_block and "=" in line:
+            k, _, v = line.partition("=")
+            out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — classic ReAct end-to-end
+# ---------------------------------------------------------------------------
+
+
+class ClassicReactEndToEndTests(unittest.TestCase):
+    """P2.3-3: classic ReAct pipeline on MyAgent-v5-shaped fixtures.
+
+    Asserts observable surface only: on-disk artifacts + RESULT block
+    KV pairs. Internal phase ordering can change without breaking this
+    test.
+    """
+
+    def test_classic_react_end_to_end_produces_full_artifact_set(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(
+                    main, "build_agent_data_dir",
+                    side_effect=lambda o, a, v: data_root / o / f"{a}__{v}",
+                ),
+                mock.patch.object(
+                    main, "build_agent_cache_dir",
+                    side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}",
+                ),
+            ]
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                _stop(patches)
+
+            self.assertEqual(rc, 0)
+
+            # --- on-disk artifacts ---
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            tree_file = data_dir / "MyAgent_v5_metadata_tree.json"
+            arch_file = data_dir / "MyAgent_v5_architecture.md"
+
+            self.assertTrue(tree_file.is_file(), "metadata_tree.json missing")
+            self.assertTrue(arch_file.is_file(), "architecture.md missing")
+            # summary.md dropped from the output contract —
+            # confirm it is NOT written.
+            self.assertFalse(
+                (data_dir / "MyAgent_v5_metadata_tree.summary.md").exists(),
+                "summary.md should have been dropped from the output contract",
+            )
+            # rendered architecture filename embeds the agent
+            # api name (new convention — proves the rename is wired).
+            self.assertTrue(
+                arch_file.name.startswith("MyAgent"),
+                f"architecture filename should start with agent api name, got {arch_file.name}",
+            )
+
+            tree = json.loads(tree_file.read_text())
+            self.assertGreater(tree.get("node_count", 0), 0)
+            self.assertEqual(tree["agent"]["generation"], "classic")
+
+            # --- emit_result RESULT block ---
+            r = _run_emit_result(work_dir)
+            self.assertEqual(r.returncode, 0, msg=r.stderr)
+            block = _parse_result_block(r.stdout)
+            self.assertIn(block["STATUS"], ("OK", "PARTIAL_OK"))
+            self.assertEqual(block["OUTPUT_ARCHITECTURE_PATH"], str(arch_file))
+            self.assertEqual(block["RENDER_FAILED"], "false")
+            self.assertGreater(int(block["NODE_COUNT"]), 0)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — NGA end-to-end
+# ---------------------------------------------------------------------------
+
+
+class NgaEndToEndTests(unittest.TestCase):
+    """P2.3-3: NGA ConcurrentMultiAgentOrchestration end-to-end.
+
+    Exercises the NGA reverse-lookup path (InvocationTarget is a 15/18-
+    char Id, not a DeveloperName) and verifies the architecture.md
+    carries NGA-specific state-diagram content (`par/and dispatch`).
+    """
+
+    def test_nga_end_to_end_produces_par_state_diagram(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(
+                    agent_api_name="MyAgent2",
+                    bot_def=fx.BOT_DEFINITION_DETAIL_NGA,
+                ),
+                *_mock_wave_a_nga(),
+                *_mock_wave_b_nga(),
+                mock.patch.object(
+                    main, "build_agent_data_dir",
+                    side_effect=lambda o, a, v: data_root / o / f"{a}__{v}",
+                ),
+                mock.patch.object(
+                    main, "build_agent_cache_dir",
+                    side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}",
+                ),
+            ]
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir, agent="MyAgent2"))
+            finally:
+                _stop(patches)
+
+            self.assertEqual(rc, 0)
+
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent2__v5"
+            tree_file = data_dir / "MyAgent2_v5_metadata_tree.json"
+            arch_file = data_dir / "MyAgent2_v5_architecture.md"
+
+            self.assertTrue(tree_file.is_file())
+            self.assertTrue(arch_file.is_file())
+
+            tree = json.loads(tree_file.read_text())
+            self.assertEqual(tree["agent"]["generation"], "nga")
+            # NGA reverse-lookup worked — the tree built a TOPIC node for
+            # NGATopic1 with 2 GEN_AI_FUNCTION children (Flow + Apex).
+            counts = tree["_kind_counts"]
+            self.assertEqual(counts.get("TOPIC"), 1)
+            self.assertEqual(counts.get("GEN_AI_FUNCTION"), 2)
+
+            # Architecture.md renders — surface the NGA tell via the
+            # Data flow / Topic anatomy sections. The Planner state
+            # machine section (which previously carried `par/and
+            # dispatch`) was retired from the default pipeline in
+            # 2026-05; the NGA-specific state-diagram output is now
+            # exercised directly in RenderNgaTests.
+            arch_text = arch_file.read_text()
+            self.assertIn("NGATopic1", arch_text)
+            self.assertIn("NGAFlowAction", arch_text)
+            self.assertIn("NGAApexAction", arch_text)
+            # Retired section must not appear.
+            self.assertNotIn("Planner state machine", arch_text)
+
+            r = _run_emit_result(work_dir)
+            block = _parse_result_block(r.stdout)
+            self.assertIn(block["STATUS"], ("OK", "PARTIAL_OK"))
+            self.assertEqual(block["AGENT_GENERATION"], "nga")
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — cache hit end-to-end
+# ---------------------------------------------------------------------------
+
+
+class CacheHitEndToEndTests(unittest.TestCase):
+    """P2.3-3: pre-populated fresh cache short-circuits the pipeline.
+
+    Wave A + Wave B fetchers are poisoned with AssertionError — the
+    test fails loudly if main.py attempts any fetch on a cache hit.
+    """
+
+    def test_cache_hit_end_to_end_skips_all_wave_calls(self):
+        import datetime as dt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir = cache_root / "00Dxx0000000000" / "MyAgent__v5"
+            data_dir.mkdir(parents=True)
+            cache_dir.mkdir(parents=True)
+
+            tree_base = "MyAgent_v5_metadata_tree"
+            # Minimal tree + architecture.md so the cache-hit emit ctx
+            # surfaces an OUTPUT_ARCHITECTURE_PATH.
+            # architecture filename is self-identifying.
+            (data_dir / f"{tree_base}.json").write_text(json.dumps({
+                "_schema_version": "3.0",
+                "agent": {"generation": "classic"},
+                "root": {"children": []},
+                "node_count": 12, "depth": 3,
+                "_kind_counts": {}, "_unresolved": [],
+            }))
+            (data_dir / "MyAgent_v5_architecture.md").write_text("# cached arch\n")
+
+            from config import SCHEMA_VERSION
+            manifest = {
+                "built_at_utc": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+                "schema_version": SCHEMA_VERSION,
+                "agent": {
+                    "version": "v5", "bot_id": "0Xa000000000ABC",
+                    "generation": "classic", "_version_auto_picked": True,
+                },
+                "node_count": 12, "depth": 3, "kind_counts": {},
+                "ttl_days": 7,
+                "data_path": str(data_dir / f"{tree_base}.json"),
+                "partial": False, "unresolved_count": 0,
+            }
+            (cache_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            def _poison(*_a, **_kw):
+                raise AssertionError("cache hit MUST NOT invoke any Wave fetcher")
+
+            poisoned_fetchers = [
+                mock.patch.object(main, name, side_effect=_poison)
+                for name in (
+                    "fetch_planner_definition",
+                    "fetch_plugins_by_planner",
+                    "fetch_planner_bundle_functions",
+                    "fetch_functions_by_plugins",
+                    "fetch_plugin_instructions",
+                    "fetch_plugin_functions",
+                    "fetch_planner_attrs",
+                    "fetch_apex_bodies_by_names",
+                    "fetch_apex_bodies_by_ids",
+                    "fetch_flow_definition_ids_by_names",
+                    "fetch_flow_definition_by_ids",
+                    "fetch_flow_metadata",
+                )
+            ]
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *poisoned_fetchers,
+                mock.patch.object(
+                    main, "build_agent_data_dir",
+                    side_effect=lambda o, a, v: data_dir,
+                ),
+                mock.patch.object(
+                    main, "build_agent_cache_dir",
+                    side_effect=lambda o, a, v: cache_dir,
+                ),
+            ]
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                _stop(patches)
+
+            self.assertEqual(rc, 0)
+
+            r = _run_emit_result(work_dir)
+            block = _parse_result_block(r.stdout)
+            self.assertEqual(block["STATUS"], "OK")
+            self.assertEqual(block["CACHE_HIT"], "true")
+            self.assertEqual(int(block["NODE_COUNT"]), 12)
+            # Cached architecture.md surfaces as the OUTPUT path.
+            # filename embeds agent api name + version.
+            self.assertTrue(block["OUTPUT_ARCHITECTURE_PATH"].endswith("MyAgent_v5_architecture.md"))
+            self.assertEqual(block["RENDER_FAILED"], "false")
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — probe-failed end-to-end
+# ---------------------------------------------------------------------------
+
+
+class ProbeFailedEndToEndTests(unittest.TestCase):
+    """P2.3-3: channel probe returns PROBE_FAILED -> RETRIEVE_FAILED.
+
+    Verifies Batch 2.1 remediation: schema-drift manifests as
+    STATUS=RETRIEVE_FAILED with ERROR_DETAIL containing `schema-drift`
+    rather than a fabricated SCHEMA_DRIFT enum value. The emit_result
+    STATUS enum doesn't include SCHEMA_DRIFT, so mapping to
+    RETRIEVE_FAILED preserves the existing contract while surfacing
+    the cause in ERROR_DETAIL.
+    """
+
+    def test_probe_failed_end_to_end_emits_retrieve_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            patches = _mock_auth_probe(
+                probe_result=fx.probe_failed_payload(
+                    sobject="GenAiPlannerDefinition",
+                    missing=["PlannerType", "DeveloperName"],
+                ),
+            )
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                _stop(patches)
+
+            # Pipeline returns nonzero on terminal failure — matches the
+            # SKILL.md Bash wrapper's set +e / capture _rc / exit _rc
+            # contract.
+            self.assertEqual(rc, 1)
+
+            r = _run_emit_result(work_dir)
+            self.assertEqual(r.returncode, 0, msg=r.stderr)
+            block = _parse_result_block(r.stdout)
+            self.assertEqual(block["STATUS"], "RETRIEVE_FAILED")
+            self.assertIn("schema-drift", block["ERROR_DETAIL"])
+            # The specific missing fields surface in the detail string
+            # (first 3 only per main.py's truncation).
+            self.assertIn("PlannerType", block["ERROR_DETAIL"])
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — --force end-to-end
+# ---------------------------------------------------------------------------
+
+
+class ForceRefreshEndToEndTests(unittest.TestCase):
+    """P2.3-3: fresh cache + --force -> full pipeline runs, cache supersedes.
+
+    Asserts:
+      * Wave A fetcher was invoked exactly once (cache was NOT used).
+      * CACHE_HIT=false in the RESULT block.
+      * Post-run manifest differs from pre-run manifest (node_count
+        reflects the live-fetched tree, not the 999-node placeholder).
+    """
+
+    def test_force_refresh_bypasses_fresh_cache(self):
+        import datetime as dt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir = cache_root / "00Dxx0000000000" / "MyAgent__v5"
+            data_dir.mkdir(parents=True)
+            cache_dir.mkdir(parents=True)
+            (data_dir / "MyAgent_v5_metadata_tree.json").write_text("{}")
+
+            from config import SCHEMA_VERSION
+            stale_manifest = {
+                "built_at_utc": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+                "schema_version": SCHEMA_VERSION,
+                "agent": {"version": "v5"},
+                # Bogus node count to detect whether the cache path or
+                # the live-fetched tree won.
+                "node_count": 999, "depth": 99, "kind_counts": {},
+                "ttl_days": 7,
+                "data_path": str(data_dir / "MyAgent_v5_metadata_tree.json"),
+                "partial": False, "unresolved_count": 0,
+            }
+            (cache_dir / "manifest.json").write_text(json.dumps(stale_manifest))
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(
+                    main, "build_agent_data_dir",
+                    side_effect=lambda o, a, v: data_dir,
+                ),
+                mock.patch.object(
+                    main, "build_agent_cache_dir",
+                    side_effect=lambda o, a, v: cache_dir,
+                ),
+            ]
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir, force=True))
+                planner_calls = main.fetch_planner_definition.call_count
+            finally:
+                _stop(patches)
+
+            self.assertEqual(rc, 0)
+            # Wave A actually fired — cache was NOT consulted.
+            self.assertEqual(planner_calls, 1)
+
+            # Manifest on disk post-run reflects the live fetch, not the
+            # 999-node placeholder.
+            post_manifest = json.loads((cache_dir / "manifest.json").read_text())
+            self.assertNotEqual(post_manifest.get("node_count"), 999)
+            self.assertGreater(post_manifest.get("node_count", 0), 0)
+
+            r = _run_emit_result(work_dir)
+            block = _parse_result_block(r.stdout)
+            self.assertIn(block["STATUS"], ("OK", "PARTIAL_OK"))
+            self.assertEqual(block["CACHE_HIT"], "false")
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — render failure end-to-end
+# ---------------------------------------------------------------------------
+
+
+class RenderFailureEndToEndTests(unittest.TestCase):
+    """P2.3-3: renderer raises -> tree OK, architecture.md.error sidecar,
+    STATUS=PARTIAL_OK, RENDER_FAILED=true in RESULT block.
+
+    contract. The pipeline does NOT abort on render failure —
+    the tree JSON is the authoritative output; architecture.md is
+    derived. This test asserts the signalling: downstream consumers can
+    distinguish "headline diagram missing" from "pipeline succeeded
+    cleanly" via RENDER_FAILED + the sidecar.
+    """
+
+    def test_render_failure_end_to_end_surfaces_partial_ok(self):
+        import render_architecture  # type: ignore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            def _boom(*_a, **_kw):
+                raise RuntimeError("render exploded for end-to-end test")
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(
+                    main, "build_agent_data_dir",
+                    side_effect=lambda o, a, v: data_root / o / f"{a}__{v}",
+                ),
+                mock.patch.object(
+                    main, "build_agent_cache_dir",
+                    side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}",
+                ),
+                mock.patch.object(render_architecture, "render", side_effect=_boom),
+            ]
+            _apply(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                _stop(patches)
+
+            self.assertEqual(rc, 0)
+
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            # Sidecar landed, architecture.md did NOT.
+            # filenames are self-identifying.
+            self.assertTrue((data_dir / "MyAgent_v5_architecture.md.error").is_file())
+            self.assertFalse((data_dir / "MyAgent_v5_architecture.md").is_file())
+            # Tree JSON DID land — the render failure is isolated to the
+            # derived artifact.
+            self.assertTrue(
+                (data_dir / "MyAgent_v5_metadata_tree.json").is_file()
+            )
+
+            r = _run_emit_result(work_dir)
+            block = _parse_result_block(r.stdout)
+            # emit_result auto-promotes OK -> PARTIAL_OK on render failure
+            # (see build_block .2-R1).
+            self.assertEqual(block["STATUS"], "PARTIAL_OK")
+            self.assertEqual(block["RENDER_FAILED"], "true")
+            self.assertEqual(block["OUTPUT_ARCHITECTURE_PATH"], "")
+            self.assertIn("RENDER_ERROR_DETAIL", block)
+            self.assertTrue(block["RENDER_ERROR_DETAIL"])  # non-empty
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_finalize.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_finalize.py
@@ -1,0 +1,278 @@
+"""Tests for ``finalize`` — declared-action-tree finalization + cache write.
+
+Covers:
+- ``sort_tree_in_place``  pure tree mutation (TOPIC-first, alphabetical-by-api_name)
+- ``main``                WORK_DIR / DATA_DIR / CACHE_DIR orchestration
+
+The pure-function tests build small dict trees inline. ``main`` tests
+construct a minimal WORK_DIR layout under ``tmp_path`` so the orchestration
+runs end-to-end without any external metadata fixtures.
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import finalize  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# sort_tree_in_place — pure tree mutation
+# -----------------------------------------------------------------------------
+
+
+class SortTreeInPlaceTests(unittest.TestCase):
+    """Per docstring: TOPIC nodes first, then non-topic plannerActions.
+    Within each tier, sorted by kind then api_name (case-insensitive).
+    Each TOPIC's own children: alphabetical by api_name (case-insensitive).
+    FLOW children are NOT sorted.
+    """
+
+    def test_empty_tree_is_noop(self):
+        root = {}
+        finalize.sort_tree_in_place(root)
+        self.assertEqual(root, {})
+
+    def test_root_with_no_children_is_noop(self):
+        root = {"children": []}
+        finalize.sort_tree_in_place(root)
+        self.assertEqual(root["children"], [])
+
+    def test_non_dict_root_is_safe(self):
+        # Non-dict input shouldn't blow up.
+        finalize.sort_tree_in_place(None)  # type: ignore[arg-type]
+        finalize.sort_tree_in_place([])  # type: ignore[arg-type]
+
+    def test_topics_come_before_non_topics_at_root(self):
+        root = {"children": [
+            {"kind": "STANDARD_ACTION", "api_name": "actA"},
+            {"kind": "TOPIC", "api_name": "topicZ"},
+            {"kind": "APEX", "api_name": "apexA"},
+            {"kind": "TOPIC", "api_name": "topicA"},
+        ]}
+        finalize.sort_tree_in_place(root)
+        kinds = [c["kind"] for c in root["children"]]
+        # Two TOPICs first, then non-topics
+        self.assertEqual(kinds[:2], ["TOPIC", "TOPIC"])
+        self.assertNotIn("TOPIC", kinds[2:])
+
+    def test_topics_sort_alphabetical_case_insensitive(self):
+        root = {"children": [
+            {"kind": "TOPIC", "api_name": "Zeta"},
+            {"kind": "TOPIC", "api_name": "alpha"},
+            {"kind": "TOPIC", "api_name": "Beta"},
+        ]}
+        finalize.sort_tree_in_place(root)
+        names = [c["api_name"] for c in root["children"]]
+        self.assertEqual(names, ["alpha", "Beta", "Zeta"])
+
+    def test_non_topics_sort_by_kind_then_name(self):
+        root = {"children": [
+            {"kind": "STANDARD_ACTION", "api_name": "z_act"},
+            {"kind": "APEX", "api_name": "z_apex"},
+            {"kind": "STANDARD_ACTION", "api_name": "a_act"},
+            {"kind": "APEX", "api_name": "a_apex"},
+        ]}
+        finalize.sort_tree_in_place(root)
+        # Tier 1 sorted by (kind, api_name): APEX rows before STANDARD_ACTION
+        kinds = [c["kind"] for c in root["children"]]
+        self.assertEqual(kinds, ["APEX", "APEX", "STANDARD_ACTION", "STANDARD_ACTION"])
+        names_apex = [c["api_name"] for c in root["children"][:2]]
+        self.assertEqual(names_apex, ["a_apex", "z_apex"])
+
+    def test_topic_children_sorted_alphabetical_case_insensitive(self):
+        root = {"children": [{
+            "kind": "TOPIC",
+            "api_name": "T1",
+            "children": [
+                {"kind": "STANDARD_ACTION", "api_name": "Zebra"},
+                {"kind": "STANDARD_ACTION", "api_name": "apple"},
+                {"kind": "STANDARD_ACTION", "api_name": "Banana"},
+            ],
+        }]}
+        finalize.sort_tree_in_place(root)
+        names = [c["api_name"] for c in root["children"][0]["children"]]
+        self.assertEqual(names, ["apple", "Banana", "Zebra"])
+
+    def test_topic_with_no_children_is_safe(self):
+        root = {"children": [{"kind": "TOPIC", "api_name": "T1"}]}
+        finalize.sort_tree_in_place(root)
+        self.assertEqual(root["children"][0]["api_name"], "T1")
+
+    def test_missing_api_name_treated_as_empty(self):
+        # Should sort to the front under casefold of empty string.
+        root = {"children": [
+            {"kind": "TOPIC", "api_name": "Beta"},
+            {"kind": "TOPIC"},  # no api_name
+        ]}
+        finalize.sort_tree_in_place(root)
+        names = [c.get("api_name", "") for c in root["children"]]
+        self.assertEqual(names[0], "")  # empty/missing comes first
+
+
+# -----------------------------------------------------------------------------
+# main — orchestration via env vars + WORK_DIR
+# -----------------------------------------------------------------------------
+
+
+def _build_workdir(tmp: Path, *, planner_name: str = "MyPlanner",
+                   pending: dict | None = None,
+                   unresolved: list | None = None) -> tuple[Path, Path, Path]:
+    """Construct a minimal WORK_DIR + DATA_DIR + CACHE_DIR triple.
+
+    Returns (work_dir, data_dir, cache_dir). Caller passes these as env
+    vars before invoking finalize.main().
+    """
+    work_dir = tmp / "work"
+    data_dir = tmp / "data" / "ALPHA0000000000" / "MyAgent__v1"
+    cache_dir = tmp / "cache" / "ALPHA0000000000" / "MyAgent__v1"
+    work_dir.mkdir(parents=True)
+
+    tree = {
+        "agent": {"api_name": "MyAgent", "version": "v1"},
+        "node_count": 1,
+        "depth": 1,
+        "_schema_version": "3.1",
+        "_kind_counts": {"TOPIC": 1},
+        "_pending_fetches": pending or {},
+        "_unresolved": unresolved or [],
+        "root": {"children": [{"kind": "TOPIC", "api_name": "Greetings"}]},
+    }
+    (work_dir / "declared_action_tree.json").write_text(json.dumps(tree))
+    return work_dir, data_dir, cache_dir
+
+
+class MainTests(unittest.TestCase):
+
+    def _run_main(self, work_dir: Path, data_dir: Path, cache_dir: Path,
+                  *, planner_name: str = "MyPlanner") -> int:
+        old = dict(os.environ)
+        os.environ.update({
+            "WORK_DIR": str(work_dir),
+            "DATA_DIR": str(data_dir),
+            "CACHE_DIR": str(cache_dir),
+            "AGENT_API_NAME": "MyAgent",
+            "AGENT_VERSION": "v1",
+            "PLANNER_NAME": planner_name,
+        })
+        try:
+            return finalize.main()
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+
+    def test_main_writes_tree_and_manifest_and_returns_zero(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(tmp)
+            rc = self._run_main(work_dir, data_dir, cache_dir)
+            self.assertEqual(rc, 0)
+            tree_file = data_dir / "MyAgent_v1_metadata_tree.json"
+            self.assertTrue(tree_file.exists())
+            self.assertTrue((data_dir / "last_built_at.txt").exists())
+            manifest = json.loads((cache_dir / "manifest.json").read_text())
+            self.assertEqual(manifest["agent"]["api_name"], "MyAgent")
+            self.assertEqual(manifest["partial"], False)
+            self.assertEqual(manifest["unresolved_count"], 0)
+
+    def test_main_marks_partial_when_planner_name_empty(self):
+        # Empty PLANNER_NAME → _partial=True, _partial_reason="no-planner".
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(tmp)
+            rc = self._run_main(work_dir, data_dir, cache_dir, planner_name="")
+            self.assertEqual(rc, 0)
+            tree = json.loads(
+                (data_dir / "MyAgent_v1_metadata_tree.json").read_text()
+            )
+            self.assertTrue(tree["_partial"])
+            self.assertEqual(tree["_partial_reason"], "no-planner")
+
+    def test_main_marks_partial_when_unresolved_present(self):
+        # Planner OK, _pending empty, but _unresolved non-empty
+        # → _partial=True, _partial_reason="unresolved-refs".
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(
+                tmp, unresolved=[{"reason": "404"}]
+            )
+            rc = self._run_main(work_dir, data_dir, cache_dir)
+            self.assertEqual(rc, 0)
+            tree = json.loads(
+                (data_dir / "MyAgent_v1_metadata_tree.json").read_text()
+            )
+            self.assertTrue(tree["_partial"])
+            self.assertEqual(tree["_partial_reason"], "unresolved-refs")
+
+    def test_main_marks_partial_when_pending_present(self):
+        # Planner OK, _unresolved empty, but _pending non-empty
+        # → _partial=True, _partial_reason="pending-refs".
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(
+                tmp, pending={"flows": ["FlowA"]}
+            )
+            rc = self._run_main(work_dir, data_dir, cache_dir)
+            self.assertEqual(rc, 0)
+            tree = json.loads(
+                (data_dir / "MyAgent_v1_metadata_tree.json").read_text()
+            )
+            self.assertTrue(tree["_partial"])
+            self.assertEqual(tree["_partial_reason"], "pending-refs")
+
+    def test_main_returns_one_when_env_missing(self):
+        old = dict(os.environ)
+        # Wipe required envs. Set only one.
+        for k in ("WORK_DIR", "DATA_DIR", "CACHE_DIR",
+                  "AGENT_API_NAME", "AGENT_VERSION"):
+            os.environ.pop(k, None)
+        try:
+            rc = finalize.main()
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+        self.assertEqual(rc, 1)
+
+    def test_main_returns_one_when_tree_json_missing(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = tmp / "work"
+            data_dir = tmp / "data"
+            cache_dir = tmp / "cache"
+            work_dir.mkdir()
+            # No declared_action_tree.json — finalize should bail.
+            rc = self._run_main(work_dir, data_dir, cache_dir)
+            self.assertEqual(rc, 1)
+
+    def test_main_strips_visited_from_durable_artifact(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(tmp)
+            tree_path = work_dir / "declared_action_tree.json"
+            tree = json.loads(tree_path.read_text())
+            tree["_visited"] = {"some": "internal-state"}
+            tree_path.write_text(json.dumps(tree))
+            rc = self._run_main(work_dir, data_dir, cache_dir)
+            self.assertEqual(rc, 0)
+            written = json.loads(
+                (data_dir / "MyAgent_v1_metadata_tree.json").read_text()
+            )
+            self.assertNotIn("_visited", written)
+
+    def test_main_seeds_gitignore_on_data_and_cache_roots(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir, data_dir, cache_dir = _build_workdir(tmp)
+            self._run_main(work_dir, data_dir, cache_dir)
+            # data_dir.parent.parent == tmp/data; cache_dir.parent.parent == tmp/cache
+            self.assertTrue((data_dir.parent.parent / ".gitignore").exists())
+            self.assertTrue((cache_dir.parent.parent / ".gitignore").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_flow_children_inflation.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_flow_children_inflation.py
@@ -1,0 +1,582 @@
+"""Tests for `main._build_flow_children` + end-to-end FLOW-child inflation.
+
+Closes the Batch-1 placeholder that left `flow_children = {}` unconditionally —
+every FLOW leaf shipped with `children: []` regardless of the subflow /
+actionCall content present in the fetched `Flow.Metadata`.
+
+Assertions focus on observable behavior:
+  * actionCalls are classified into the correct `kind` + carry `element_name`
+    (the flow-XML `<name>` that identifies WHICH Flow element invokes the
+    target — load-bearing for the rendered tree view).
+  * subflows become `{"kind": "FLOW", ...}` child refs with correct target.
+  * The output dict is keyed by FlowDefinition.DeveloperName (what
+    `walk_and_inflate` looks up), NOT by ActiveVersionId.
+  * Defensive skips on missing ActiveVersionId / missing `Metadata` payload.
+  * End-to-end: a mocked Wave B with populated Flow.Metadata produces a tree
+    where the FLOW node actually has descendants (the load-bearing integration
+    test).
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+import soql_loader  # type: ignore
+import main  # type: ignore
+from tests.fixtures import genai_payloads as fx  # type: ignore
+
+# Re-point SOQL lookup into the repo source (same recipe as test_main_pipeline).
+_REPO_SOQL_DIR = Path(__file__).resolve().parent.parent.parent / "assets" / "soql"
+config.SOQL_DIR = _REPO_SOQL_DIR
+soql_loader.SOQL_DIR = _REPO_SOQL_DIR
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _build_flow_children
+# ---------------------------------------------------------------------------
+
+
+class BuildFlowChildrenTests(unittest.TestCase):
+    def test_actioncalls_classified_correctly(self):
+        """Each actionType (apex / generatePromptResponse / other / empty)
+        must route through `classify_action_call` and produce the correct
+        `kind` + preserve `element_name` + `api_name`."""
+        flow_metadata = {
+            "301VF001": {
+                "Id": "301VF001", "FullName": "MixedFlow-1",
+                "Metadata": {
+                    "actionCalls": [
+                        {"name": "Call_Apex",
+                         "actionType": "apex",
+                         "actionName": "MyApexHandler"},
+                        {"name": "Generate_Output",
+                         "actionType": "generatePromptResponse",
+                         "actionName": "MyPromptTemplate"},
+                        {"name": "Send_Email",
+                         "actionType": "emailSimple",
+                         "actionName": "SendSimpleEmail"},
+                        {"name": "Unknown_Element",
+                         "actionType": "",
+                         "actionName": ""},
+                    ],
+                },
+            },
+        }
+        flow_def_rows = [
+            {"Id": "300VF001", "DeveloperName": "MixedFlow",
+             "ActiveVersionId": "301VF001"},
+        ]
+
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        self.assertIn("MixedFlow", out)
+        kids = out["MixedFlow"]
+        self.assertEqual(len(kids), 4)
+
+        by_element = {k["element_name"]: k for k in kids}
+
+        self.assertEqual(by_element["Call_Apex"]["kind"], "APEX")
+        self.assertEqual(by_element["Call_Apex"]["api_name"], "MyApexHandler")
+
+        self.assertEqual(by_element["Generate_Output"]["kind"], "PROMPT_TEMPLATE")
+        self.assertEqual(by_element["Generate_Output"]["api_name"], "MyPromptTemplate")
+
+        self.assertEqual(by_element["Send_Email"]["kind"], "STANDARD_ACTION")
+        self.assertEqual(by_element["Send_Email"]["api_name"], "SendSimpleEmail")
+        # `invocation_type` (schema 3.1 canonical name) is preserved for
+        # STANDARD_ACTION so render layers can surface the actionType
+        # qualifier (emailSimple, etc.) — e.g. `SendSimpleEmail (emailSimple)`
+        # in the rendered tree.
+        self.assertEqual(by_element["Send_Email"]["invocation_type"], "emailSimple")
+
+        # Empty actionType + empty actionName → UNKNOWN. `classify_action_call`
+        # substitutes "?" for the api_name when both are blank.
+        self.assertEqual(by_element["Unknown_Element"]["kind"], "UNKNOWN")
+
+    def test_subflows_become_flow_children(self):
+        """Two subflow entries → two `{"kind": "FLOW", ...}` child refs with
+        their `<subflows><name>` as `element_name` and `<flowName>` as
+        `api_name`. These are the load-bearing fields for the recursive
+        inflation step."""
+        flow_metadata = {
+            "301VF001": {
+                "Id": "301VF001", "FullName": "ParentFlow-1",
+                "Metadata": {
+                    "subflows": [
+                        {"name": "Handle_Fault",
+                         "flowName": "handleFlowFault"},
+                        {"name": "Run_Subroutine",
+                         "flowName": "mySubroutineFlow"},
+                    ],
+                },
+            },
+        }
+        flow_def_rows = [
+            {"Id": "300VF001", "DeveloperName": "ParentFlow",
+             "ActiveVersionId": "301VF001"},
+        ]
+
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        kids = out["ParentFlow"]
+        self.assertEqual(len(kids), 2)
+        self.assertTrue(all(k["kind"] == "FLOW" for k in kids))
+
+        by_element = {k["element_name"]: k for k in kids}
+        self.assertEqual(by_element["Handle_Fault"]["api_name"], "handleFlowFault")
+        self.assertEqual(by_element["Run_Subroutine"]["api_name"], "mySubroutineFlow")
+
+    def test_keyed_by_developer_name_not_version_id(self):
+        """The dict MUST be keyed by FlowDefinition.DeveloperName — that's
+        what `walk_and_inflate` looks up via `flow_children[leaf.api_name]`.
+        Keying by ActiveVersionId would silently return `{}` and the tree
+        would stay flat."""
+        flow_metadata = {
+            "301VF_A": {"Id": "301VF_A", "FullName": "FlowA-1",
+                       "Metadata": {"actionCalls": [
+                           {"name": "ac1", "actionType": "apex",
+                            "actionName": "ApexA"},
+                       ]}},
+            "301VF_B": {"Id": "301VF_B", "FullName": "FlowB-1",
+                       "Metadata": {"actionCalls": [
+                           {"name": "ac1", "actionType": "apex",
+                            "actionName": "ApexB"},
+                       ]}},
+        }
+        flow_def_rows = [
+            {"Id": "300VF_A", "DeveloperName": "FlowAlpha",
+             "ActiveVersionId": "301VF_A"},
+            {"Id": "300VF_B", "DeveloperName": "FlowBeta",
+             "ActiveVersionId": "301VF_B"},
+        ]
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        self.assertEqual(set(out.keys()), {"FlowAlpha", "FlowBeta"})
+        # Not the version IDs.
+        self.assertNotIn("301VF_A", out)
+        self.assertNotIn("301VF_B", out)
+
+    def test_missing_active_version_id_skipped(self):
+        """Inactive flows have no ActiveVersionId. They should be silently
+        skipped — not raise KeyError, not pollute `flow_children`."""
+        flow_metadata = {
+            "301VF001": {"Id": "301VF001", "FullName": "ActiveFlow-1",
+                        "Metadata": {"actionCalls": []}},
+        }
+        flow_def_rows = [
+            # Active flow: normal row.
+            {"Id": "300VF001", "DeveloperName": "ActiveFlow",
+             "ActiveVersionId": "301VF001"},
+            # Inactive flow: no ActiveVersionId. Must not raise.
+            {"Id": "300VF002", "DeveloperName": "InactiveFlow",
+             "ActiveVersionId": None},
+        ]
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        self.assertIn("ActiveFlow", out)
+        self.assertNotIn("InactiveFlow", out)
+
+    def test_empty_wave_b_produces_empty_dict(self):
+        """Zero flows → empty dict, no crash."""
+        self.assertEqual(main._build_flow_children({}, []), {})
+        self.assertEqual(main._build_flow_children(None or {}, None or []), {})
+
+    def test_missing_metadata_field_tolerated(self):
+        """A Flow record that for some reason lacks `Metadata` (empty dict,
+        None, or the key omitted entirely) must degrade to an empty child
+        list — never raise. `walk_and_inflate` treats an empty list and
+        "no key" identically, so we can be permissive and emit empty lists
+        in all three cases; the invariant is "does not raise + does not
+        fabricate children"."""
+        flow_metadata = {
+            "301VF001": {"Id": "301VF001", "FullName": "Empty-1", "Metadata": {}},
+            "301VF002": {"Id": "301VF002", "FullName": "None-1", "Metadata": None},
+            "301VF003": {"Id": "301VF003", "FullName": "NoKey-1"},
+        }
+        flow_def_rows = [
+            {"Id": "300VF001", "DeveloperName": "EmptyFlow",
+             "ActiveVersionId": "301VF001"},
+            {"Id": "300VF002", "DeveloperName": "NoneFlow",
+             "ActiveVersionId": "301VF002"},
+            {"Id": "300VF003", "DeveloperName": "NoKeyFlow",
+             "ActiveVersionId": "301VF003"},
+        ]
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        for name in ("EmptyFlow", "NoneFlow", "NoKeyFlow"):
+            self.assertIn(name, out)
+            self.assertEqual(out[name], [])
+
+    def test_subflow_missing_flow_name_dropped(self):
+        """A subflow entry without `flowName` has no api_name to descend
+        into — drop it silently rather than emit a broken child ref."""
+        flow_metadata = {
+            "301VF001": {"Id": "301VF001", "FullName": "Parent-1",
+                        "Metadata": {"subflows": [
+                            {"name": "BadSubflow"},  # missing flowName
+                            {"name": "GoodSubflow", "flowName": "TargetFlow"},
+                        ]}},
+        }
+        flow_def_rows = [
+            {"Id": "300VF001", "DeveloperName": "ParentFlow",
+             "ActiveVersionId": "301VF001"},
+        ]
+        out = main._build_flow_children(flow_metadata, flow_def_rows)
+        self.assertEqual(len(out["ParentFlow"]), 1)
+        self.assertEqual(out["ParentFlow"][0]["element_name"], "GoodSubflow")
+
+
+# ---------------------------------------------------------------------------
+# Integration test — end-to-end tree inflation through _run_parse_wave
+# ---------------------------------------------------------------------------
+
+
+def _mock_auth_probe():
+    org_display_payload = {
+        "status": 0,
+        "result": {
+            "instanceUrl": "https://example.my.salesforce.com",
+            "accessToken": "00Dxx0000000000!AQ_fake_token_value",
+            "id": "00Dxx0000000000AAA",
+            "apiVersion": "60.0",
+        },
+    }
+    return [
+        mock.patch.object(main, "run_sf", return_value=org_display_payload),
+        mock.patch.object(main, "probe_channels", return_value=fx.probe_ok_payload()),
+    ]
+
+
+def _mock_bot_resolution():
+    return [
+        mock.patch.object(
+            main, "fetch_bot_versions",
+            return_value=fx.make_bot_versions("MyAgent", ("v5",), "v5"),
+        ),
+        mock.patch.object(main, "fetch_bot_definition_details",
+                          return_value=fx.BOT_DEFINITION_DETAIL_CLASSIC),
+    ]
+
+
+class EndToEndInflationTests(unittest.TestCase):
+    """Load-bearing integration test.
+
+    Runs the full pipeline with a synthetic Flow.Metadata that has one
+    actionCall (apex) + one subflow. Asserts the resulting
+    `declared_action_tree.json` has a FLOW node whose `children` list
+    is NON-empty and carries the expected `element_name`. This is the
+    behavior the bug fix restores.
+    """
+
+    def test_end_to_end_inflation_produces_nested_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            # Single classic bot with one topic + one flow action. The
+            # flow's Metadata carries one actionCall (apex) + one subflow.
+            planner = dict(fx.CLASSIC_PLANNER)
+            plugins = [{
+                "Id": "1VyVF000000TOP1",
+                "DeveloperName": "OrderTopic",
+                "MasterLabel": "Order Topic",
+                "Description": None,
+                "PluginType": "Custom",
+                "Scope": "Order management",
+                "IsLocal": True,
+                "CanEscalate": False,
+                "Source": "Declarative",
+                "ParentId": planner["Id"],
+                "LocalDeveloperName": "OrderTopic",
+            }]
+            functions = [{
+                "Id": "1VuVF0000000F01",
+                "DeveloperName": "LookupOrderFn",
+                "MasterLabel": "LookupOrderFn",
+                "Description": None,
+                "InvocationTargetType": "flow",
+                "InvocationTarget": "LookupOrder",
+                "IsLocal": True,
+                "IsConfirmationRequired": False,
+                "IsIncludeInProgressIndicator": False,
+                "ProgressIndicatorMessage": None,
+                "Source": "Declarative",
+                "PluginId": plugins[0]["Id"],
+                "PlannerId": None,
+                "ParentId": None,
+                "LocalDeveloperName": "LookupOrderFn",
+            }]
+            plugin_fn_join = [{
+                "Id": "pfj1", "PluginId": plugins[0]["Id"],
+                "Function": functions[0]["Id"],
+            }]
+            flow_defs = [{
+                "Id": "300VF001", "DeveloperName": "LookupOrder",
+                "ActiveVersionId": "301VF001",
+            }]
+            flow_metadata_record = {
+                "Id": "301VF001", "FullName": "LookupOrder-1",
+                "Metadata": {
+                    "actionCalls": [{
+                        "name": "Call_The_Apex_Helper",
+                        "actionType": "apex",
+                        "actionName": "OrderLookupApex",
+                    }],
+                    "subflows": [{
+                        "name": "Run_Subflow",
+                        "flowName": "OrderLookupSubflow",
+                    }],
+                },
+            }
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                mock.patch.object(main, "fetch_planner_definition", return_value=planner),
+                mock.patch.object(main, "fetch_plugins_by_planner", return_value=plugins),
+                mock.patch.object(main, "fetch_planner_bundle_functions", return_value=[]),
+                mock.patch.object(main, "fetch_functions_by_plugins",
+                                  return_value=functions),
+                mock.patch.object(main, "fetch_plugin_instructions", return_value=[]),
+                mock.patch.object(main, "fetch_plugin_functions",
+                                  return_value=plugin_fn_join),
+                mock.patch.object(main, "fetch_planner_attrs", return_value=[]),
+                mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]),
+                mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]),
+                mock.patch.object(main, "fetch_flow_definition_ids_by_names",
+                                  return_value=flow_defs),
+                mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]),
+                mock.patch.object(
+                    main, "fetch_flow_metadata",
+                    side_effect=lambda vid, *a, **kw: (
+                        flow_metadata_record if vid == "301VF001" else None
+                    ),
+                ),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            for p in patches:
+                p.start()
+            try:
+                rc = main.main([
+                    "--org-alias", "test-org",
+                    "--agent", "MyAgent",
+                    "--work-dir", str(work_dir),
+                    "--parallelism", "2",
+                ])
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            tree = json.loads((work_dir / "declared_action_tree.json").read_text())
+
+            # Locate the FLOW leaf under the topic's GEN_AI_FUNCTION.
+            topic = tree["root"]["children"][0]
+            gen_ai_fn = topic["children"][0]
+            flow_leaf = gen_ai_fn["children"][0]
+            self.assertEqual(flow_leaf["kind"], "FLOW")
+            self.assertEqual(flow_leaf["api_name"], "LookupOrder")
+
+            # BUG FIX ASSERTION: the FLOW node now has non-empty children.
+            # Before the fix, `flow_children = {}` meant every FLOW leaf
+            # shipped with `children: []` regardless of actionCalls /
+            # subflows content.
+            self.assertEqual(len(flow_leaf["children"]), 2)
+
+            element_names = {c["element_name"] for c in flow_leaf["children"]}
+            self.assertIn("Call_The_Apex_Helper", element_names)
+            self.assertIn("Run_Subflow", element_names)
+
+            # Kinds are correctly classified — APEX for the actionCall,
+            # FLOW for the subflow.
+            by_element = {c["element_name"]: c for c in flow_leaf["children"]}
+            self.assertEqual(by_element["Call_The_Apex_Helper"]["kind"], "APEX")
+            self.assertEqual(
+                by_element["Call_The_Apex_Helper"]["api_name"],
+                "OrderLookupApex",
+            )
+            self.assertEqual(by_element["Run_Subflow"]["kind"], "FLOW")
+            self.assertEqual(
+                by_element["Run_Subflow"]["api_name"],
+                "OrderLookupSubflow",
+            )
+
+    def test_nested_subflow_subtree_populated_via_iteration(self):
+        """iterative Wave B must expand shared
+        utility-flow leaves.
+
+        Before the iteration pass: the top-level flow `LookupOrder`
+        referenced a subflow `handleFlowFault`, which landed as an empty
+        FLOW leaf because its body was never queried. This test pushes
+        end-to-end through `main()` and asserts the `handleFlowFault`
+        node in the tree has CHILDREN — specifically the Apex class
+        `XCSF_FlowFaultMessage` referenced by its own body.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            planner = dict(fx.CLASSIC_PLANNER)
+            plugins = [{
+                "Id": "1VyVF000000TOP1",
+                "DeveloperName": "OrderTopic",
+                "MasterLabel": "Order Topic",
+                "Description": None,
+                "PluginType": "Custom",
+                "Scope": "Order management",
+                "IsLocal": True,
+                "CanEscalate": False,
+                "Source": "Declarative",
+                "ParentId": planner["Id"],
+                "LocalDeveloperName": "OrderTopic",
+            }]
+            functions = [{
+                "Id": "1VuVF0000000F01",
+                "DeveloperName": "LookupOrderFn",
+                "MasterLabel": "LookupOrderFn",
+                "Description": None,
+                "InvocationTargetType": "flow",
+                "InvocationTarget": "LookupOrder",
+                "IsLocal": True,
+                "IsConfirmationRequired": False,
+                "IsIncludeInProgressIndicator": False,
+                "ProgressIndicatorMessage": None,
+                "Source": "Declarative",
+                "PluginId": plugins[0]["Id"],
+                "PlannerId": None,
+                "ParentId": None,
+                "LocalDeveloperName": "LookupOrderFn",
+            }]
+            plugin_fn_join = [{
+                "Id": "pfj1", "PluginId": plugins[0]["Id"],
+                "Function": functions[0]["Id"],
+            }]
+
+            # Flow registry keyed by DeveloperName → (FlowDefinition row,
+            # Flow.Metadata record). The mock fetcher consults this on
+            # each iteration round.
+            flow_registry = {
+                "LookupOrder": (
+                    {"Id": "300VF001", "DeveloperName": "LookupOrder",
+                     "ActiveVersionId": "301VF001"},
+                    {"Id": "301VF001", "FullName": "LookupOrder-1",
+                     "Metadata": {
+                         "actionCalls": [],
+                         "subflows": [{
+                             "name": "Handle_Flow_Fault",
+                             "flowName": "handleFlowFault",
+                         }],
+                     }},
+                ),
+                "handleFlowFault": (
+                    {"Id": "300VF002", "DeveloperName": "handleFlowFault",
+                     "ActiveVersionId": "301VF002"},
+                    {"Id": "301VF002", "FullName": "handleFlowFault-1",
+                     "Metadata": {
+                         "actionCalls": [{
+                             "name": "Parse_and_log_fault",
+                             "actionType": "apex",
+                             "actionName": "XCSF_FlowFaultMessage",
+                         }],
+                         "subflows": [],
+                     }},
+                ),
+            }
+
+            def fake_flow_def_by_names(names, *a, **kw):
+                return [
+                    flow_registry[n][0] for n in names if n in flow_registry
+                ]
+
+            def fake_flow_metadata(vid, *a, **kw):
+                for _name, (fd, fm) in flow_registry.items():
+                    if fd["ActiveVersionId"] == vid:
+                        return fm
+                return None
+
+            # Apex bodies: XCSF_FlowFaultMessage is discovered via the
+            # subflow's actionCall in iteration round 2.
+            def fake_apex_by_names(names, *a, **kw):
+                apex_registry = {
+                    "XCSF_FlowFaultMessage": {
+                        "Id": "01pVF001", "Name": "XCSF_FlowFaultMessage",
+                        "Body": "public class XCSF_FlowFaultMessage { }",
+                    },
+                }
+                return [apex_registry[n] for n in names if n in apex_registry]
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                mock.patch.object(main, "fetch_planner_definition", return_value=planner),
+                mock.patch.object(main, "fetch_plugins_by_planner", return_value=plugins),
+                mock.patch.object(main, "fetch_planner_bundle_functions", return_value=[]),
+                mock.patch.object(main, "fetch_functions_by_plugins",
+                                  return_value=functions),
+                mock.patch.object(main, "fetch_plugin_instructions", return_value=[]),
+                mock.patch.object(main, "fetch_plugin_functions",
+                                  return_value=plugin_fn_join),
+                mock.patch.object(main, "fetch_planner_attrs", return_value=[]),
+                mock.patch.object(main, "fetch_apex_bodies_by_names",
+                                  side_effect=fake_apex_by_names),
+                mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]),
+                mock.patch.object(main, "fetch_flow_definition_ids_by_names",
+                                  side_effect=fake_flow_def_by_names),
+                mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]),
+                mock.patch.object(main, "fetch_flow_metadata",
+                                  side_effect=fake_flow_metadata),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            for p in patches:
+                p.start()
+            try:
+                rc = main.main([
+                    "--org-alias", "test-org",
+                    "--agent", "MyAgent",
+                    "--work-dir", str(work_dir),
+                    "--parallelism", "2",
+                ])
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            tree = json.loads((work_dir / "declared_action_tree.json").read_text())
+
+            topic = tree["root"]["children"][0]
+            gen_ai_fn = topic["children"][0]
+            top_flow = gen_ai_fn["children"][0]
+            self.assertEqual(top_flow["api_name"], "LookupOrder")
+
+            # LookupOrder → Handle_Flow_Fault (FLOW leaf, pre-iteration
+            # this was empty). Post-iteration, it must carry children.
+            handle_flow_fault = top_flow["children"][0]
+            self.assertEqual(handle_flow_fault["kind"], "FLOW")
+            self.assertEqual(handle_flow_fault["api_name"], "handleFlowFault")
+
+            # Core assertion: the shared utility flow's subtree is now
+            # populated via iterative Wave B fetching its body.
+            self.assertTrue(
+                handle_flow_fault["children"],
+                "handleFlowFault subtree is empty — iterative Wave B "
+                "did not fetch its body. This is the bug.",
+            )
+            apex_kids = [
+                c for c in handle_flow_fault["children"]
+                if c["kind"] == "APEX" and c["api_name"] == "XCSF_FlowFaultMessage"
+            ]
+            self.assertEqual(len(apex_kids), 1)
+            self.assertEqual(apex_kids[0]["element_name"], "Parse_and_log_fault")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_fs_guard.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_fs_guard.py
@@ -1,0 +1,113 @@
+"""Tests for fs_guard Python-importable validators + api_version check."""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+from config import fs_guard  # type: ignore — re-exported from _shared/
+
+
+class ValidateApiNameTests(unittest.TestCase):
+    def test_valid_name_passes(self):
+        fs_guard.validate_api_name("MyAgent", label="name")
+        fs_guard.validate_api_name("Foo_v2", label="name")
+        fs_guard.validate_api_name("x", label="name")
+
+    def test_dotdot_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name("..", label="agent_api_name")
+
+    def test_slash_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name("foo/bar", label="agent_api_name")
+
+    def test_dotdot_in_path_segment_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name("foo/../bar", label="agent_api_name")
+
+    def test_null_byte_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name("foo\x00bar", label="name")
+
+    def test_empty_string_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name("", label="name")
+
+    def test_none_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name(None, label="name")
+
+    def test_non_string_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_name(42, label="name")
+
+    def test_validation_error_carries_label(self):
+        with self.assertRaises(fs_guard.ValidationError) as ctx:
+            fs_guard.validate_api_name("bad/name", label="agent_api_name")
+        self.assertEqual(ctx.exception.label, "agent_api_name")
+
+
+class ValidateApiVersionTests(unittest.TestCase):
+    def test_v60_0_ok(self):
+        fs_guard.validate_api_version("v60.0", label="api_version")
+
+    def test_v66_0_ok(self):
+        fs_guard.validate_api_version("v66.0", label="api_version")
+
+    def test_v60_no_minor_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_version("v60", label="api_version")
+
+    def test_bare_number_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_version("60.0", label="api_version")
+
+    def test_slash_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_version("v60.0/../", label="api_version")
+
+    def test_dotdot_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_version("..", label="api_version")
+
+    def test_empty_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_api_version("", label="api_version")
+
+
+class ValidateOrgId15Tests(unittest.TestCase):
+    def test_valid_15_char_alnum_ok(self):
+        fs_guard.validate_org_id_15("00Dxx0000000000", label="org_id_15")
+
+    def test_slash_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_org_id_15("00D/x0000000000", label="org_id_15")
+
+    def test_wrong_length_rejected(self):
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_org_id_15("00Dxx000000000", label="org_id_15")
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_org_id_15("00Dxx0000000000X", label="org_id_15")
+
+    def test_underscore_rejected(self):
+        # ORG_ID_15_RE forbids underscores — stricter than api_name.
+        with self.assertRaises(fs_guard.ValidationError):
+            fs_guard.validate_org_id_15("00Dxx00000000_0", label="org_id_15")
+
+
+class CliApiVersionCheckTests(unittest.TestCase):
+    """The api_version check type is registered in VALID_CHECKS + CHECKS."""
+
+    def test_registered_in_valid_checks(self):
+        self.assertIn("api_version", fs_guard.VALID_CHECKS)
+
+    def test_registered_in_checks_dispatch(self):
+        self.assertIn("api_version", fs_guard.CHECKS)
+
+    def test_check_function_exists(self):
+        self.assertTrue(callable(fs_guard.check_api_version))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_iterative_wave_b.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_iterative_wave_b.py
@@ -1,0 +1,478 @@
+"""Tests for `main._iterate_wave_b` — iterative subflow + apex discovery.
+
+The initial `_run_wave_b` only enumerates top-level flow refs from
+`bundle_parsed`. When those flow bodies reference subflows (shared
+utility flows like `handleFlowFault`) or new Apex classes, their bodies
+were never fetched. `_iterate_wave_b` drives Wave B to a fixed point so
+every reachable flow/apex body lands in the tree.
+
+Assertions focus on observable behavior:
+  * Convergence shape — no extra fetches when there are no new refs.
+  * Correctness — a utility flow referenced from the top-level round is
+    fetched in the next round and its metadata lands in the merged dict.
+  * Safety — iteration cap surfaces remaining unfetched names via
+    `unresolved`; fetch failures are tolerated without crashing.
+  * Cross-kind discovery — a subflow's actionCall referencing a new
+    Apex class adds that class to `apex_rows`.
+  * Deduplication — the same subflow referenced twice is fetched once.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401
+
+import main  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _creds_provider():
+    return ("https://example.my.salesforce.com", "fake_token")
+
+
+def _refresh_fn():
+    return _creds_provider()
+
+
+def _flow_def_row(dev_name: str, version_id: str) -> dict:
+    """Shape matches what `fetch_flow_definition_ids_by_names` returns —
+    the fields `_build_flow_children` + the pipeline downstream expect."""
+    return {
+        "Id": f"300{dev_name}",
+        "DeveloperName": dev_name,
+        "ActiveVersionId": version_id,
+    }
+
+
+def _flow_metadata_record(
+    version_id: str,
+    full_name: str,
+    *,
+    subflows: list[tuple[str, str]] | None = None,
+    action_calls: list[dict] | None = None,
+) -> dict:
+    """Shape a synthetic Flow.Metadata record the way `fetch_flow_metadata`
+    returns it — a dict with Id/FullName/Metadata. Subflow tuples are
+    `(element_name, flow_name)`; action_calls are raw dicts."""
+    md: dict = {}
+    if subflows is not None:
+        md["subflows"] = [
+            {"name": elem, "flowName": target} for elem, target in subflows
+        ]
+    if action_calls is not None:
+        md["actionCalls"] = action_calls
+    return {"Id": version_id, "FullName": full_name, "Metadata": md}
+
+
+def _apex_row(name: str) -> dict:
+    """Shape matches `fetch_apex_bodies_by_names` output — `_iterate_wave_b`
+    tracks already-fetched by `Name`."""
+    return {"Id": f"01p_{name}", "Name": name, "Body": "public class ..."}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class IterativeWaveBTests(unittest.TestCase):
+    def test_single_round_when_no_subflows(self):
+        """Round 1 flow body references no subflows and no new apex →
+        `_extract_refs_from_flow_metadata` returns empty sets →
+        `_fetch_wave_b_by_names` is never invoked → initial wave_b passes
+        through unchanged."""
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [_flow_def_row("TopFlow", "301TOP")],
+            "flow_metadata": {
+                "301TOP": _flow_metadata_record(
+                    "301TOP", "TopFlow-1", subflows=[], action_calls=[],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        with mock.patch.object(main, "_fetch_wave_b_by_names") as mocked:
+            out = main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=5,
+            )
+
+        mocked.assert_not_called()
+        self.assertEqual(
+            {r["DeveloperName"] for r in out["flow_def_rows"]},
+            {"TopFlow"},
+        )
+        self.assertEqual(out["unresolved"], [])
+
+    def test_two_rounds_for_shared_utility_flow(self):
+        """Round 1: a top-level flow body references subflow `handleFlowFault`.
+        Round 2: fetches `handleFlowFault`'s metadata. Round 3: no new refs.
+        Converges. Final flow_metadata contains BOTH flows.
+
+        This is the real-org `MyAgent__v5` shape — `handleFlowFault`
+        is shared across every flow and should be fetched in one extra
+        round.
+        """
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [_flow_def_row("AGNT_Top_Flow", "301TOP")],
+            "flow_metadata": {
+                "301TOP": _flow_metadata_record(
+                    "301TOP", "AGNT_Top_Flow-1",
+                    subflows=[("Handle_Flow_Fault", "handleFlowFault")],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        # Mock `_fetch_wave_b_by_names` for two rounds:
+        # Round 1: flow_names=[handleFlowFault] → returns metadata whose
+        # actionCalls reference a NEW apex (XCSF_FlowFaultMessage).
+        # Round 2: apex_names=[XCSF_FlowFaultMessage] → apex row returned.
+        # Round 3: no new refs → converge.
+        calls: list[dict] = []
+
+        def fake_fetch(**kwargs):
+            calls.append({
+                "flow_names": list(kwargs["flow_names"]),
+                "apex_names": list(kwargs["apex_names"]),
+            })
+            if kwargs["flow_names"] == ["handleFlowFault"]:
+                return {
+                    "apex_rows": [],
+                    "flow_def_rows": [
+                        _flow_def_row("handleFlowFault", "301UTIL"),
+                    ],
+                    "flow_metadata": {
+                        "301UTIL": _flow_metadata_record(
+                            "301UTIL", "handleFlowFault-1",
+                            subflows=[],
+                            action_calls=[{
+                                "name": "Parse_and_log_fault",
+                                "actionType": "apex",
+                                "actionName": "XCSF_FlowFaultMessage",
+                            }],
+                        ),
+                    },
+                    "unresolved": [],
+                }
+            if kwargs["apex_names"] == ["XCSF_FlowFaultMessage"]:
+                return {
+                    "apex_rows": [_apex_row("XCSF_FlowFaultMessage")],
+                    "flow_def_rows": [],
+                    "flow_metadata": {},
+                    "unresolved": [],
+                }
+            raise AssertionError(f"unexpected fetch call: {kwargs}")
+
+        with mock.patch.object(
+            main, "_fetch_wave_b_by_names", side_effect=fake_fetch,
+        ) as mocked:
+            out = main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=5,
+            )
+
+        # Exactly two rounds: round 1 picks up handleFlowFault, round 2
+        # picks up the apex discovered in round 1's subflow body, round 3
+        # converges without invoking the fetcher.
+        self.assertEqual(mocked.call_count, 2)
+        dev_names = {r["DeveloperName"] for r in out["flow_def_rows"]}
+        self.assertEqual(dev_names, {"AGNT_Top_Flow", "handleFlowFault"})
+        self.assertIn("301UTIL", out["flow_metadata"])
+        apex_names_out = {r["Name"] for r in out["apex_rows"]}
+        self.assertIn("XCSF_FlowFaultMessage", apex_names_out)
+        # Call-order sanity: flow round precedes apex round.
+        self.assertEqual(calls[0]["flow_names"], ["handleFlowFault"])
+        self.assertEqual(calls[1]["apex_names"], ["XCSF_FlowFaultMessage"])
+
+    def test_actioncall_discovers_new_apex(self):
+        """A subflow body carries an actionCall referencing a new Apex
+        class. Round 2 fetches that Apex. `wave_b["apex_rows"]` grows."""
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [_flow_def_row("TopFlow", "301TOP")],
+            "flow_metadata": {
+                "301TOP": _flow_metadata_record(
+                    "301TOP", "TopFlow-1",
+                    subflows=[],
+                    action_calls=[{
+                        "name": "Invoke_Helper",
+                        "actionType": "apex",
+                        "actionName": "NewApexHelper",
+                    }],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        def fake_fetch(**kwargs):
+            # Must be the apex-only round — no new flow names.
+            self.assertEqual(kwargs["flow_names"], [])
+            self.assertEqual(kwargs["apex_names"], ["NewApexHelper"])
+            return {
+                "apex_rows": [_apex_row("NewApexHelper")],
+                "flow_def_rows": [],
+                "flow_metadata": {},
+                "unresolved": [],
+            }
+
+        with mock.patch.object(
+            main, "_fetch_wave_b_by_names", side_effect=fake_fetch,
+        ) as mocked:
+            out = main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=5,
+            )
+
+        self.assertEqual(mocked.call_count, 1)
+        apex_names_seen = {r["Name"] for r in out["apex_rows"]}
+        self.assertEqual(apex_names_seen, {"NewApexHelper"})
+
+    def test_dedup_across_rounds(self):
+        """The same subflow referenced from two parent flows is fetched
+        exactly once. `_iterate_wave_b` diffs against already-fetched
+        names — duplicates are filtered before dispatch."""
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [
+                _flow_def_row("ParentA", "301A"),
+                _flow_def_row("ParentB", "301B"),
+            ],
+            "flow_metadata": {
+                "301A": _flow_metadata_record(
+                    "301A", "ParentA-1",
+                    subflows=[("Handle_A", "SharedUtility")],
+                ),
+                "301B": _flow_metadata_record(
+                    "301B", "ParentB-1",
+                    subflows=[("Handle_B", "SharedUtility")],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        call_log: list[list[str]] = []
+
+        def fake_fetch(**kwargs):
+            call_log.append(list(kwargs["flow_names"]))
+            return {
+                "apex_rows": [],
+                "flow_def_rows": [_flow_def_row("SharedUtility", "301UTIL")],
+                "flow_metadata": {
+                    "301UTIL": _flow_metadata_record(
+                        "301UTIL", "SharedUtility-1", subflows=[],
+                    ),
+                },
+                "unresolved": [],
+            }
+
+        with mock.patch.object(
+            main, "_fetch_wave_b_by_names", side_effect=fake_fetch,
+        ) as mocked:
+            main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=5,
+            )
+
+        # Exactly ONE round of fetching — round 1 queries [SharedUtility]
+        # (deduped across the two parents); round 2 finds no new refs.
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(call_log[0], ["SharedUtility"])
+
+    def test_iteration_cap_surfaces_pending(self):
+        """Pathological graph where every round introduces a new subflow
+        reference (chain: F1 → F2 → F3 → ...). After `max_iterations`
+        rounds, remaining unfetched names are surfaced in `unresolved`
+        so the pipeline can degrade to PARTIAL_OK with a clear cause.
+
+        Use `max_iterations=3` to keep the test fast; the shape is
+        identical to the production cap of 5.
+        """
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [_flow_def_row("F0", "301_V0")],
+            "flow_metadata": {
+                "301_V0": _flow_metadata_record(
+                    "301_V0", "F0-1", subflows=[("Chain", "F1")],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        round_counter = {"i": 1}
+
+        def fake_fetch(**kwargs):
+            """Each round returns a flow whose body references the next
+            flow in the chain — unbounded growth."""
+            requested = kwargs["flow_names"][0]
+            next_flow = f"F{round_counter['i'] + 1}"
+            round_counter["i"] += 1
+            return {
+                "apex_rows": [],
+                "flow_def_rows": [_flow_def_row(requested, f"301_V{requested}")],
+                "flow_metadata": {
+                    f"301_V{requested}": _flow_metadata_record(
+                        f"301_V{requested}", f"{requested}-1",
+                        subflows=[("Chain", next_flow)],
+                    ),
+                },
+                "unresolved": [],
+            }
+
+        with mock.patch.object(
+            main, "_fetch_wave_b_by_names", side_effect=fake_fetch,
+        ) as mocked:
+            out = main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=3,
+            )
+
+        # We exhausted exactly max_iterations rounds.
+        self.assertEqual(mocked.call_count, 3)
+        # The unfetched chain-tail lands in `unresolved` with the cap
+        # reason so the pipeline can reflect it in the RESULT block.
+        iter_cap_entries = [
+            u for u in out["unresolved"]
+            if "wave-b-iteration-cap" in (u.get("reason") or "")
+        ]
+        self.assertTrue(iter_cap_entries)
+        # The next-round flow reference (F4, unfetched) must be among them.
+        pending_names = {u.get("api_name") for u in iter_cap_entries}
+        self.assertIn("F4", pending_names)
+
+    def test_fetch_failure_tolerated(self):
+        """If the round-N fetch raises (managed-package flow not readable,
+        permission denied, etc.), the iteration doesn't crash. The
+        affected name stays absent from `flow_def_rows` and surfaces via
+        the pending-fetches path downstream; other rounds continue.
+
+        Concretely: we simulate the failure by having the mocked
+        `_fetch_wave_b_by_names` append an `unresolved` entry instead of
+        returning metadata for the troubled name, which is exactly the
+        contract `_fetch_wave_b_by_names` follows internally (it
+        catches RestClientError / SoqlParamError and logs to
+        `unresolved` without raising).
+        """
+        initial = {
+            "apex_rows": [],
+            "flow_def_rows": [_flow_def_row("TopFlow", "301TOP")],
+            "flow_metadata": {
+                "301TOP": _flow_metadata_record(
+                    "301TOP", "TopFlow-1",
+                    subflows=[
+                        ("Good_Sub", "GoodSubflow"),
+                        ("Bad_Sub", "UnreachableFlow"),
+                    ],
+                ),
+            },
+            "unresolved": [],
+        }
+
+        def fake_fetch(**kwargs):
+            # Only the reachable one resolves. The unreachable one is
+            # reported via the `unresolved` channel by the inner fetcher.
+            return {
+                "apex_rows": [],
+                "flow_def_rows": [_flow_def_row("GoodSubflow", "301GOOD")],
+                "flow_metadata": {
+                    "301GOOD": _flow_metadata_record(
+                        "301GOOD", "GoodSubflow-1", subflows=[],
+                    ),
+                },
+                "unresolved": [{
+                    "kind": "FLOW",
+                    "reason": "flow-def-by-name-failed:managed-package-403",
+                }],
+            }
+
+        with mock.patch.object(
+            main, "_fetch_wave_b_by_names", side_effect=fake_fetch,
+        ):
+            out = main._iterate_wave_b(
+                initial, _creds_provider, _refresh_fn,
+                api_version="v60.0", org_alias="test-org",
+                parallelism=2, max_iterations=5,
+            )
+
+        dev_names = {r["DeveloperName"] for r in out["flow_def_rows"]}
+        # GoodSubflow made it in; UnreachableFlow did not.
+        self.assertIn("GoodSubflow", dev_names)
+        self.assertNotIn("UnreachableFlow", dev_names)
+        # The inner-fetch's unresolved entry propagates.
+        reasons = [u.get("reason") or "" for u in out["unresolved"]]
+        self.assertTrue(
+            any("managed-package-403" in r for r in reasons),
+            f"expected propagated failure reason; got {reasons}",
+        )
+        # UnreachableFlow is still referenced but not fetched — after
+        # iteration converges on subsequent rounds (no new discoveries
+        # because GoodSubflow is leaf), it lands as iteration-cap
+        # pending. In this test max_iterations=5 and the chain stops at
+        # round 1; UnreachableFlow is still missing from fetched names,
+        # so the convergence scan at the end flags it? Actually no —
+        # convergence only surfaces via the cap. Let's verify that the
+        # pipeline's parse_wave path would still mark it as pending via
+        # visited-vs-referenced — but that's out of scope for this unit
+        # test. The contract here is: iteration doesn't crash, good
+        # flows are merged, bad-flow signal propagates.
+
+
+class ExtractRefsFromFlowMetadataTests(unittest.TestCase):
+    """Direct coverage for `_extract_refs_from_flow_metadata` — the
+    load-bearing extractor that drives iteration. Its permissiveness
+    (tolerating missing/None/malformed records) is a correctness
+    property: if it raised on edge cases, iteration would crash on any
+    flow with a weird metadata shape."""
+
+    def test_extracts_subflow_and_apex_names(self):
+        flow_metadata = {
+            "301A": _flow_metadata_record(
+                "301A", "A-1",
+                subflows=[("E1", "SubA"), ("E2", "SubB")],
+                action_calls=[
+                    {"name": "ApexCall", "actionType": "apex",
+                     "actionName": "MyApex"},
+                    # non-apex actionCall shouldn't appear in apex set
+                    {"name": "StdCall", "actionType": "emailSimple",
+                     "actionName": "SendEmail"},
+                ],
+            ),
+        }
+        subs, apex = main._extract_refs_from_flow_metadata(flow_metadata)
+        self.assertEqual(subs, {"SubA", "SubB"})
+        self.assertEqual(apex, {"MyApex"})
+
+    def test_tolerates_missing_fields(self):
+        """None records, non-dict metadata, missing keys, blank names —
+        none of these should raise; they all drop silently."""
+        flow_metadata = {
+            "301A": None,
+            "301B": {"Metadata": None},
+            "301C": {"Metadata": "not-a-dict"},
+            "301D": {"Metadata": {}},
+            "301E": {"Metadata": {
+                "subflows": [{"name": "noName"}, "not-a-dict",
+                             {"name": "E", "flowName": ""}],
+                "actionCalls": [{"actionType": "apex", "actionName": ""},
+                                "not-a-dict"],
+            }},
+        }
+        subs, apex = main._extract_refs_from_flow_metadata(flow_metadata)
+        self.assertEqual(subs, set())
+        self.assertEqual(apex, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_main_pipeline.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_main_pipeline.py
@@ -1,0 +1,3225 @@
+"""Phase 2 Batch 1 integration tests for `main.py`.
+
+End-to-end pipeline exercise without hitting a real org. Every SOQL-level
+primitive (`fetch_*`, `run_sf`, `probe_channels`) is mocked on the
+`main` module's import namespace so the orchestrator sees synthetic
+rows shaped like live describe output.
+
+What these tests assert:
+  * RESULT-level behavior — the `.emit_ctx.json` that main.py writes
+    is the contract with emit_result.py. We read that JSON back and
+    assert status + key counts.
+  * Tree shape — `declared_action_tree.json` is parsed; node count,
+    depth, kind counts, and the AGENT block are checked against
+    fixture expectations.
+  * Failure-mode mapping — probe failures map to RETRIEVE_FAILED
+    (design decision, see module docstring); empty planner fetch →
+    AGENT_NOT_FOUND; empty bot fetch → AGENT_NOT_FOUND + AVAILABLE_BOTS.
+
+Every test must run offline. If you see a real `sf` subprocess spawn or
+a real `urllib` request in a failure output, a mock is missing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+import soql_loader  # type: ignore
+import main  # type: ignore
+from tests.fixtures import genai_payloads as fx  # type: ignore
+
+# The test-suite process doesn't run under CLAUDE_PLUGIN_ROOT, so
+# `config.SOQL_DIR` resolves to `~/.claude/skills/...` which isn't the
+# install location for a dev run. Repoint at the repo's source-of-truth.
+# Same pattern as test_probe_cli_recipes.py uses for CLI_DIR.
+_REPO_SOQL_DIR = Path(__file__).resolve().parent.parent.parent / "assets" / "soql"
+config.SOQL_DIR = _REPO_SOQL_DIR
+# `soql_loader` captures `SOQL_DIR` via `from config import SOQL_DIR`, so
+# the module-level binding needs patching too.
+soql_loader.SOQL_DIR = _REPO_SOQL_DIR
+
+
+def _args(work_dir: Path, **overrides) -> list[str]:
+    base = [
+        "--org-alias", "test-org",
+        "--agent", overrides.pop("agent", "MyAgent"),
+        "--work-dir", str(work_dir),
+        "--parallelism", "2",
+    ]
+    for k, v in overrides.items():
+        flag = "--" + k.replace("_", "-")
+        if isinstance(v, bool):
+            if v:
+                base.append(flag)
+        else:
+            base.extend([flag, str(v)])
+    return base
+
+
+def _mock_wave_a_classic():
+    """Patch every main.fetch_* Wave A function with classic-shape returns."""
+    return [
+        mock.patch.object(main, "fetch_planner_definition", return_value=fx.CLASSIC_PLANNER),
+        mock.patch.object(main, "fetch_plugins_by_planner", return_value=fx.CLASSIC_PLUGINS),
+        mock.patch.object(main, "fetch_planner_bundle_functions", return_value=fx.CLASSIC_BUNDLE_FN_JOIN),
+        mock.patch.object(main, "fetch_functions_by_plugins", return_value=fx.CLASSIC_FUNCTIONS),
+        mock.patch.object(main, "fetch_plugin_instructions", return_value=fx.CLASSIC_INSTRUCTIONS),
+        mock.patch.object(main, "fetch_plugin_functions", return_value=fx.CLASSIC_PLUGIN_FUNCTIONS),
+        mock.patch.object(main, "fetch_planner_attrs", return_value=fx.CLASSIC_ATTRS),
+    ]
+
+
+def _mock_wave_b_classic():
+    return [
+        mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=fx.CLASSIC_APEX_ROWS),
+        mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]),
+        mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=fx.CLASSIC_FLOW_DEFS),
+        mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]),
+        mock.patch.object(
+            main, "fetch_flow_metadata",
+            side_effect=lambda vid, *a, **kw: fx.CLASSIC_FLOW_METADATA.get(vid),
+        ),
+    ]
+
+
+def _mock_wave_a_nga():
+    return [
+        mock.patch.object(main, "fetch_planner_definition", return_value=fx.NGA_PLANNER),
+        mock.patch.object(main, "fetch_plugins_by_planner", return_value=fx.NGA_PLUGINS),
+        mock.patch.object(main, "fetch_planner_bundle_functions", return_value=[]),
+        mock.patch.object(main, "fetch_functions_by_plugins", return_value=fx.NGA_FUNCTIONS),
+        mock.patch.object(main, "fetch_plugin_instructions", return_value=[]),
+        mock.patch.object(main, "fetch_plugin_functions", return_value=fx.NGA_PLUGIN_FUNCTIONS),
+        mock.patch.object(main, "fetch_planner_attrs", return_value=[]),
+    ]
+
+
+def _mock_wave_b_nga():
+    return [
+        mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]),
+        mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=fx.NGA_APEX_BY_ID),
+        mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=[]),
+        mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=fx.NGA_FLOW_DEF_BY_ID),
+        mock.patch.object(main, "fetch_flow_metadata", return_value={
+            "Id": "301VF999NGAVER", "FullName": "NGAResolvedFlow-1", "Metadata": {},
+        }),
+    ]
+
+
+def _mock_auth_probe(probe_result=None):
+    """Patch run_sf (for org_display) + probe_channels + bot data fetches."""
+    probe_result = probe_result or fx.probe_ok_payload()
+    org_display_payload = {
+        "status": 0,
+        "result": {
+            "instanceUrl": "https://example.my.salesforce.com",
+            "accessToken": "00Dxx0000000000!AQ_fake_token_value",
+            "id": "https://login.salesforce.com/id/00Dxx0000000000AAA/005xx0000000000AAA",
+            "apiVersion": "60.0",
+        },
+    }
+    # The code reads `result.id` — some orgs return a full URL here, some
+    # return the 18-char id directly. We patch to a direct 18-char id to
+    # keep the derivation trivial.
+    org_display_payload["result"]["id"] = "00Dxx0000000000AAA"
+    return [
+        mock.patch.object(main, "run_sf", return_value=org_display_payload),
+        mock.patch.object(main, "probe_channels", return_value=probe_result),
+    ]
+
+
+def _mock_bot_resolution(agent_api_name="MyAgent", versions=("v5",), active="v5",
+                         bot_def=None):
+    bot_def = bot_def or fx.BOT_DEFINITION_DETAIL_CLASSIC
+    return [
+        mock.patch.object(
+            main, "fetch_bot_versions",
+            return_value=fx.make_bot_versions(agent_api_name, versions, active),
+        ),
+        mock.patch.object(main, "fetch_bot_definition_details", return_value=bot_def),
+    ]
+
+
+def _apply_all(patches):
+    """Enter every patch in `patches`; return a list of the started mocks."""
+    mocks = []
+    for p in patches:
+        mocks.append(p.start())
+    return mocks
+
+
+def _read_ctx(work_dir: Path) -> dict:
+    return json.loads((work_dir / ".emit_ctx.json").read_text())
+
+
+def _read_tree(work_dir: Path) -> dict:
+    return json.loads((work_dir / "declared_action_tree.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Classic happy path
+# ---------------------------------------------------------------------------
+
+
+class ClassicHappyPathTests(unittest.TestCase):
+    def test_classic_pipeline_builds_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                # Keep pipeline writes contained to tmp.
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            ctx = _read_ctx(work_dir)
+            self.assertIn(ctx["status"], ("OK", "PARTIAL_OK"))
+            self.assertEqual(ctx["agent_api_name"], "MyAgent")
+            self.assertEqual(ctx["agent_version"], "v5")
+            self.assertTrue(ctx["version_auto_picked"])
+
+            tree = _read_tree(work_dir)
+            # 6 topics, no bundle-direct actions (a planner never has direct
+            # functions — 2026-05-05). Root has exactly TOPIC children.
+            self.assertEqual(len(tree["root"]["children"]), 6)
+            # Agent block fields resolved from BotDefinition detail row
+            self.assertEqual(tree["agent"]["generation"], "classic")
+            self.assertEqual(tree["agent"]["planner_type"],
+                             "AiCopilot__ReActAiPlannerV1")
+            # Kind counts — BOT_DEFINITION, TOPIC(6), GEN_AI_FUNCTION(2 in
+            # Topic1, 0 elsewhere).
+            counts = tree["_kind_counts"]
+            self.assertEqual(counts.get("BOT_DEFINITION"), 1)
+            self.assertEqual(counts.get("TOPIC"), 6)
+            self.assertEqual(counts.get("GEN_AI_FUNCTION"), 2)
+
+
+# ---------------------------------------------------------------------------
+# NGA happy path
+# ---------------------------------------------------------------------------
+
+
+class NgaHappyPathTests(unittest.TestCase):
+    def test_nga_pipeline_reverse_lookup_builds_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(
+                    agent_api_name="MyAgent2",
+                    bot_def=fx.BOT_DEFINITION_DETAIL_NGA,
+                ),
+                *_mock_wave_a_nga(),
+                *_mock_wave_b_nga(),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir, agent="MyAgent2"))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            tree = _read_tree(work_dir)
+            self.assertEqual(tree["agent"]["generation"], "nga")
+            self.assertEqual(tree["agent"]["planner_type"],
+                             "Atlas__ConcurrentMultiAgentOrchestration")
+            # 1 topic + 0 bundle actions; topic has 2 functions. Confirm
+            # both topic-scope functions are present.
+            self.assertEqual(tree["_kind_counts"].get("TOPIC"), 1)
+            self.assertEqual(tree["_kind_counts"].get("GEN_AI_FUNCTION"), 2)
+
+
+# ---------------------------------------------------------------------------
+# Sequential planner (no plugins)
+# ---------------------------------------------------------------------------
+
+
+class SequentialPlannerTests(unittest.TestCase):
+    def test_zero_plugins_one_bundle_function(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(agent_api_name="SequentialAgent"),
+                mock.patch.object(main, "fetch_planner_definition",
+                                  return_value=fx.SEQ_PLANNER),
+                mock.patch.object(main, "fetch_plugins_by_planner", return_value=[]),
+                mock.patch.object(main, "fetch_planner_bundle_functions", return_value=[]),
+                mock.patch.object(main, "fetch_functions_by_plugins",
+                                  return_value=fx.SEQ_FUNCTIONS),
+                mock.patch.object(main, "fetch_plugin_instructions", return_value=[]),
+                mock.patch.object(main, "fetch_plugin_functions", return_value=[]),
+                mock.patch.object(main, "fetch_planner_attrs", return_value=[]),
+                mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]),
+                mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]),
+                mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=[]),
+                mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]),
+                mock.patch.object(main, "fetch_flow_metadata", return_value=None),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir, agent="SequentialAgent"))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            tree = _read_tree(work_dir)
+            # 2026-05-05: a planner never has direct functions. A
+            # SequentialPlannerIntentClassifier bot with zero plugins
+            # therefore has zero declared actions — `functions_by_plugins`
+            # short-circuits on empty plugin_ids. The tree is a bare
+            # BOT_DEFINITION with no children; no TOPIC, no
+            # GEN_AI_FUNCTION, no STANDARD_ACTION.
+            counts = tree["_kind_counts"]
+            self.assertNotIn("TOPIC", counts)
+            self.assertNotIn("GEN_AI_FUNCTION", counts)
+            self.assertNotIn("STANDARD_ACTION", counts)
+            self.assertEqual(counts.get("BOT_DEFINITION"), 1)
+
+
+# ---------------------------------------------------------------------------
+# Bot not found
+# ---------------------------------------------------------------------------
+
+
+class BotNotFoundTests(unittest.TestCase):
+    def test_empty_bot_versions_emits_agent_not_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            patches = [
+                *_mock_auth_probe(),
+                mock.patch.object(main, "fetch_bot_versions", return_value=[]),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir, agent="MissingAgent"))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 1)
+            ctx = _read_ctx(work_dir)
+            self.assertEqual(ctx["status"], "AGENT_NOT_FOUND")
+            self.assertEqual(ctx["available_bots"], "")
+
+
+# ---------------------------------------------------------------------------
+# Probe failure on mandatory field → RETRIEVE_FAILED + "schema-drift" detail.
+# ---------------------------------------------------------------------------
+
+
+class ProbeFailureTests(unittest.TestCase):
+    def test_probe_failed_emits_retrieve_failed_schema_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            patches = _mock_auth_probe(
+                probe_result=fx.probe_failed_payload(
+                    sobject="GenAiPlannerDefinition",
+                    missing=["PlannerType"],
+                ),
+            )
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 1)
+            ctx = _read_ctx(work_dir)
+            self.assertEqual(ctx["status"], "RETRIEVE_FAILED")
+            self.assertIn("schema-drift", ctx["error_detail"])
+            self.assertIn("PlannerType", ctx["error_detail"])
+
+
+# ---------------------------------------------------------------------------
+# Cache hit / force refresh
+# ---------------------------------------------------------------------------
+
+
+class CacheBehaviourTests(unittest.TestCase):
+    def test_cache_hit_skips_wave_calls(self):
+        """Populate a fresh manifest, confirm pipeline returns CACHE_HIT=true
+        without invoking any Wave A fetcher."""
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir = cache_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir.mkdir(parents=True)
+            data_dir.mkdir(parents=True)
+            tree_base = "MyAgent_v5_metadata_tree"
+            (data_dir / f"{tree_base}.json").write_text("{}")
+
+            import datetime as dt
+            from config import SCHEMA_VERSION
+            manifest = {
+                "built_at_utc": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+                "schema_version": SCHEMA_VERSION,
+                "agent": {
+                    "version": "v5", "bot_id": "0Xa000000000ABC",
+                    "generation": "classic", "_version_auto_picked": True,
+                },
+                "node_count": 12, "depth": 3, "kind_counts": {},
+                "ttl_days": 7,
+                "data_path": str(data_dir / f"{tree_base}.json"),
+                "partial": False, "unresolved_count": 0,
+            }
+            (cache_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            # Wave fetchers get mocks that would raise if touched.
+            forbidden = [
+                mock.patch.object(main, "fetch_planner_definition",
+                                  side_effect=AssertionError("cache hit MUST NOT run Wave A")),
+            ]
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *forbidden,
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_dir),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_dir),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            ctx = _read_ctx(work_dir)
+            self.assertEqual(ctx["status"], "OK")
+            self.assertTrue(ctx["cache_hit"])
+            self.assertEqual(ctx["node_count"], 12)
+
+    def test_force_refresh_reruns_pipeline_even_if_cache_is_fresh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir = cache_root / "00Dxx0000000000" / "MyAgent__v5"
+            cache_dir.mkdir(parents=True)
+            data_dir.mkdir(parents=True)
+            (data_dir / "MyAgent_v5_metadata_tree.json").write_text("{}")
+
+            import datetime as dt
+            from config import SCHEMA_VERSION
+            manifest = {
+                "built_at_utc": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+                "schema_version": SCHEMA_VERSION,
+                "agent": {"version": "v5"},
+                "node_count": 1, "depth": 1, "kind_counts": {},
+                "ttl_days": 7,
+                "data_path": str(data_dir / "MyAgent_v5_metadata_tree.json"),
+                "partial": False, "unresolved_count": 0,
+            }
+            (cache_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_dir),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_dir),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir, force=True))
+                planner_mock = main.fetch_planner_definition  # the MagicMock
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            # Wave A ran — the planner mock was called exactly once.
+            self.assertEqual(planner_mock.call_count, 1)
+            ctx = _read_ctx(work_dir)
+            self.assertFalse(ctx["cache_hit"])
+
+
+# ---------------------------------------------------------------------------
+# 401 refresh path
+# ---------------------------------------------------------------------------
+
+
+class Refresh401Tests(unittest.TestCase):
+    def test_401_on_tooling_query_triggers_refresh_and_completes(self):
+        """Patch `fetch_soql.tooling_query` so the REAL fetch_planner_definition
+        runs; the first query raises HTTPError 401, refresh fires, the retry
+        succeeds.
+
+        This exercises the production retry_on_401 path end-to-end .
+        We drive retries at the `tooling_query` layer — the fetcher wrappers
+        in fetch_soql are untouched. If the refresh contract regressed, this
+        test would either 401 a second time (if stale creds were reused) or
+        propagate the original HTTPError (if the decorator didn't catch).
+        """
+        import fetch_soql  # type: ignore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            # Stub the raw tooling_query primitive: first call for the
+            # planner raises 401; subsequent calls (after refresh) return
+            # the classic planner row.
+            call_counter = {"n": 0}
+            refresh_counter = {"n": 0}
+
+            def tooling_query_401_once(creds_provider, soql, *, api_version, on_401_refresh):
+                call_counter["n"] += 1
+                # Call creds_provider + refresh to simulate retry_on_401's
+                # behavior. The real tooling_query wires retry_on_401
+                # INSIDE itself; here we emulate the same contract so the
+                # refresh counter advances and the planner row is returned.
+                creds_provider()
+                if call_counter["n"] == 1:
+                    # Simulate the wrapped call having already handled the
+                    # 401 (called refresh_fn + retried) and then returned
+                    # the row. We invoke on_401_refresh ourselves to prove
+                    # the refresh plumbing is callable from the fetcher.
+                    on_401_refresh()
+                    refresh_counter["n"] += 1
+                # Shape the response — fetch_planner_definition extracts
+                # records[0]. For non-planner queries (A2..A7) this same
+                # stub returns an empty records list and those fetchers
+                # short-circuit gracefully.
+                if "GenAiPlannerDefinition" in soql:
+                    return {"records": [fx.CLASSIC_PLANNER]}
+                if "GenAiPluginDefinition" in soql and "WHERE PlannerId" in soql:
+                    return {"records": fx.CLASSIC_PLUGINS}
+                if "GenAiPlannerFunctionDef" in soql:
+                    return {"records": fx.CLASSIC_BUNDLE_FN_JOIN}
+                if "GenAiFunctionDefinition" in soql:
+                    return {"records": fx.CLASSIC_FUNCTIONS}
+                if "GenAiPluginInstructionDef" in soql:
+                    return {"records": fx.CLASSIC_INSTRUCTIONS}
+                if "GenAiPluginFunctionDef" in soql:
+                    return {"records": fx.CLASSIC_PLUGIN_FUNCTIONS}
+                if "GenAiPlannerAttrDefinition" in soql:
+                    return {"records": fx.CLASSIC_ATTRS}
+                if "ApexClass" in soql:
+                    return {"records": fx.CLASSIC_APEX_ROWS}
+                if "FlowDefinition" in soql:
+                    return {"records": fx.CLASSIC_FLOW_DEFS}
+                if "FROM Flow " in soql or "FROM Flow\n" in soql:
+                    return {"records": []}
+                return {"records": []}
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                mock.patch.object(fetch_soql, "tooling_query",
+                                  side_effect=tooling_query_401_once),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            # Refresh plumbing was invoked at least once.
+            self.assertGreaterEqual(refresh_counter["n"], 1)
+            ctx = _read_ctx(work_dir)
+            self.assertIn(ctx["status"], ("OK", "PARTIAL_OK"))
+            # No token ever leaks into the ctx (redact_error contract).
+            self.assertNotIn("Bearer", json.dumps(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Smoke: empty args raise argparse error — guard against a test infra
+# regression where CLI parsing silently accepts partial argv.
+# ---------------------------------------------------------------------------
+
+
+class PartialTreeTests(unittest.TestCase):
+    """When parse_wave returns a _partial tree (max-depth cap or residual
+    pending refs), main.py must surface STATUS=PARTIAL_OK with the
+    `_partial_reason` + `pending_fetches_count` plumbed through."""
+
+    def test_max_depth_cap_surfaces_partial_ok(self):
+        import parse_wave  # type: ignore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            # Wrap walk_and_inflate so it injects a synthetic
+            # depth-cap-pending ref regardless of flow_children contents.
+            # This mirrors what a real deep-subflow traversal would
+            # accumulate when MAX_BFS_DEPTH trips.
+            original_walk = parse_wave.walk_and_inflate
+
+            def walk_with_fake_depth_cap(node, flow_children, depth=0, pending_out=None):
+                if pending_out is not None:
+                    pending_out.setdefault("FLOW", set()).add("DeeplyNestedSubflow")
+                return original_walk(node, flow_children, depth, pending_out)
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(parse_wave, "walk_and_inflate",
+                                  side_effect=walk_with_fake_depth_cap),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+            ctx = _read_ctx(work_dir)
+            # Partial flag may emit as OK (finalize's _partial recompute
+            # depends on pending + planner_ok), so we check the tree's
+            # internal signal rather than the ctx status alone.
+            tree = _read_tree(work_dir)
+            self.assertEqual(tree["_partial_reason"], "max-depth-cap")
+            self.assertIn("DeeplyNestedSubflow", tree["_pending_fetches"]["FLOW"])
+            self.assertGreaterEqual(ctx["pending_fetches_count"], 1)
+
+
+class RenderFailureIntegrationTests(unittest.TestCase):
+    """end-to-end — render raises -> sidecar + RESULT signals.
+
+    The defect both reviewers flagged: if render_architecture raises,
+    _run_finalize writes `architecture.md.error` and continues. The
+    tree JSON + summary land fine; STATUS stays OK. Consumers have no
+    way to know the headline output is missing.
+
+    This test drives the full pipeline with a patched renderer that
+    raises, then asserts:
+      * The sidecar landed in the data_dir.
+      * The emit ctx carries render_failed=True + a detail string.
+      * _emit_ok auto-promoted STATUS to PARTIAL_OK.
+      * emit_result (run as a subprocess against the ctx) emits
+        RENDER_FAILED=true in the RESULT block.
+    """
+
+    def test_render_raises_surfaces_partial_ok_and_render_failed_true(self):
+        import render_architecture  # type: ignore
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            def _boom(*_a, **_kw):
+                raise RuntimeError("render exploded for test")
+
+            patches = [
+                *_mock_auth_probe(),
+                *_mock_bot_resolution(),
+                *_mock_wave_a_classic(),
+                *_mock_wave_b_classic(),
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+                # Patch the renderer at its import site. `main._run_finalize`
+                # does a lazy `from render_architecture import render`, so
+                # we patch `render_architecture.render` module-wide.
+                mock.patch.object(render_architecture, "render",
+                                  side_effect=_boom),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+
+            # Sidecar landed in the final data_dir (post-swap).
+            # filenames are self-identifying.
+            data_dir = data_root / "00Dxx0000000000" / "MyAgent__v5"
+            sidecar = data_dir / "MyAgent_v5_architecture.md.error"
+            self.assertTrue(sidecar.is_file(), f"sidecar missing at {sidecar}")
+            self.assertIn(
+                "render exploded for test",
+                sidecar.read_text(),
+            )
+            # architecture.md must NOT have been produced.
+            self.assertFalse((data_dir / "MyAgent_v5_architecture.md").is_file())
+
+            # emit ctx carries the render-failure signals.
+            ctx = _read_ctx(work_dir)
+            self.assertTrue(ctx["render_failed"])
+            self.assertIn("RuntimeError", ctx["render_error_detail"])
+            self.assertEqual(ctx["architecture_path"], "")
+            # _emit_ok path leaves status=OK when tree is healthy; the
+            # emit_result-time auto-promote is what flips it to PARTIAL_OK.
+            # But the tree IS healthy here, so status stays OK at the ctx
+            # level — the promotion happens in build_block.
+            self.assertIn(ctx["status"], ("OK", "PARTIAL_OK"))
+
+            # Drive emit_result against this ctx and confirm the RESULT
+            # block reflects the render failure.
+            tools_dir = Path(__file__).resolve().parent.parent.parent / "tools"
+            import subprocess, sys as _sys
+            env = {**os.environ, "WORK_DIR": str(work_dir)}
+            r = subprocess.run(
+                [_sys.executable, str(tools_dir / "emit_result.py")],
+                env=env, capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(r.returncode, 0, msg=r.stderr)
+            block = r.stdout
+            self.assertIn("STATUS=PARTIAL_OK", block)
+            self.assertIn("RENDER_FAILED=true", block)
+            self.assertIn("RENDER_ERROR_DETAIL=", block)
+            self.assertIn("OUTPUT_ARCHITECTURE_PATH=", block)
+
+
+class ArgParseSmokeTests(unittest.TestCase):
+    def test_missing_required_args_raises_systemexit(self):
+        # argparse prints usage to stderr before SystemExit. Redirect so
+        # the test runner output stays clean.
+        import contextlib
+        import io
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(io.StringIO()):
+            main.parse_args([])
+
+
+# ---------------------------------------------------------------------------
+# thread-safe refresh_fn with monotonic dedupe window
+# ---------------------------------------------------------------------------
+
+
+class ThreadSafeRefreshTests(unittest.TestCase):
+    """`_build_creds_plumbing` must:
+      * serialize concurrent refresh_fn calls behind a lock (no overlapping
+        `sf org display` spawns)
+      * dedupe refreshes within a monotonic time window — N threads racing
+        within the window collapse to a single `resolve_creds` call
+
+    These are pre-conditions for Wave B's parallelism: if 5 parallel
+    Flow.Metadata fetches each 401 simultaneously, only ONE real sf-CLI
+    spawn should fire (not 5).
+    """
+
+    def _spawn_workers(self, refresh_fn, n=5, barrier=None):
+        """Run `n` threads that each call refresh_fn once. Returns the
+        list of return values. A `threading.Barrier` is used to align the
+        thread launches — all threads hit `refresh_fn` within the same
+        monotonic window, which is the condition the dedupe optimizes for.
+        """
+        import threading as _t
+        results: list = [None] * n
+        threads: list[_t.Thread] = []
+
+        def _worker(i):
+            if barrier is not None:
+                barrier.wait()
+            results[i] = refresh_fn()
+
+        for i in range(n):
+            threads.append(_t.Thread(target=_worker, args=(i,)))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return results
+
+    def test_five_threads_single_refresh_within_window(self):
+        """5 threads concurrently call refresh_fn within the 1-second
+        dedupe window → `resolve_creds` is invoked exactly ONCE.
+        """
+        import threading as _t
+
+        call_count = {"n": 0}
+        call_lock = _t.Lock()
+
+        def fake_resolve():
+            # Increment under a lock so a second concurrent call couldn't
+            # race and register as one (this is what we're testing AGAINST:
+            # the outer dedupe should guarantee only one entry here).
+            with call_lock:
+                call_count["n"] += 1
+            return ("https://example.my.salesforce.com", "tok_v2")
+
+        _provider, refresh, _cell = main._build_creds_plumbing(
+            ("https://example.my.salesforce.com", "tok_v1"),
+            resolve_creds=fake_resolve,
+        )
+
+        barrier = _t.Barrier(5)
+        results = self._spawn_workers(refresh, n=5, barrier=barrier)
+
+        # Dedupe held — exactly ONE real resolve spawn.
+        self.assertEqual(call_count["n"], 1)
+        # Every thread got the refreshed tuple back.
+        self.assertTrue(all(r == ("https://example.my.salesforce.com", "tok_v2") for r in results))
+
+    def test_refresh_lock_serializes_resolve_spawns(self):
+        """If 5 threads race with a SHORT dedupe window (simulated via
+        a 0-length window), `resolve_creds` calls are serialized by the
+        lock — we observe a strict 1:1 count of entries to spawns. This
+        is the "last-writer-wins" worst case: every thread still spawns
+        once, but they're serialized, NOT overlapping. The test asserts
+        the lock DOES serialize (not that it dedupes) when the window
+        is effectively disabled.
+        """
+        import threading as _t
+
+        active = {"n": 0, "max": 0}
+        spawns = {"n": 0}
+        state_lock = _t.Lock()
+
+        def fake_resolve():
+            with state_lock:
+                active["n"] += 1
+                active["max"] = max(active["max"], active["n"])
+                spawns["n"] += 1
+            # Hold for a short beat to let any racing worker enter if the
+            # lock weren't serializing.
+            import time as _time
+            _time.sleep(0.02)
+            with state_lock:
+                active["n"] -= 1
+            return ("url", "tok")
+
+        _provider, refresh, _cell = main._build_creds_plumbing(
+            ("url", "old"),
+            resolve_creds=fake_resolve,
+            dedupe_window_s=0.0,  # disable dedupe so every call spawns
+        )
+
+        self._spawn_workers(refresh, n=5)
+
+        # Lock serialized the spawns — no overlap inside `fake_resolve`.
+        self.assertEqual(active["max"], 1)
+        # All 5 eventually ran (no silent drops when dedupe is off).
+        self.assertEqual(spawns["n"], 5)
+
+    def test_sequential_calls_outside_window_trigger_new_refresh(self):
+        """A refresh OUTSIDE the dedupe window is NOT suppressed. The
+        dedupe is a ceiling, not a one-shot latch.
+        """
+        import time as _time
+
+        call_count = {"n": 0}
+
+        def fake_resolve():
+            call_count["n"] += 1
+            return ("url", f"tok_{call_count['n']}")
+
+        _provider, refresh, _cell = main._build_creds_plumbing(
+            ("url", "tok_0"),
+            resolve_creds=fake_resolve,
+            dedupe_window_s=0.05,  # 50ms window for test latency
+        )
+
+        refresh()
+        _time.sleep(0.08)  # sleep past the window
+        refresh()
+
+        self.assertEqual(call_count["n"], 2)
+
+    def test_provider_reads_cell_after_refresh(self):
+        """After refresh mutates the cell, the NEXT `creds_provider()`
+        call returns the fresh tuple (the  contract).
+        """
+        provider, refresh, cell = main._build_creds_plumbing(
+            ("url", "old"),
+            resolve_creds=lambda: ("url", "new"),
+        )
+
+        self.assertEqual(provider(), ("url", "old"))
+        refresh()
+        self.assertEqual(provider(), ("url", "new"))
+        self.assertEqual(cell[0], ("url", "new"))
+
+
+# ---------------------------------------------------------------------------
+# on_401_refresh is a required kwarg on every fetcher
+# ---------------------------------------------------------------------------
+
+
+class RequiredOn401RefreshKwargTests(unittest.TestCase):
+    """Every fetcher in `fetch_soql` must make `on_401_refresh` a REQUIRED
+    keyword-only argument. The previous default (`on_401_refresh or
+    creds_provider`) silently collapsed to "re-read the same stale token"
+    when a caller passed `None` — the retry hit the same stale token on
+    the second attempt and 401'd again, bypassing  entirely.
+
+    We can't exercise the full retry chain here (that's Fix 5's
+    integration test) — this test enforces the call-site contract at the
+    signature level, so a regression is a TypeError not an auth bypass.
+    """
+
+    FETCHERS = (
+        "fetch_planner_definition",
+        "fetch_plugins_by_planner",
+        "fetch_planner_bundle_functions",
+        "fetch_functions_by_plugins",
+        "fetch_plugin_instructions",
+        "fetch_plugin_functions",
+        "fetch_planner_attrs",
+        "fetch_apex_bodies_by_names",
+        "fetch_apex_bodies_by_ids",
+        "fetch_flow_definition_ids_by_names",
+        "fetch_flow_definition_view_by_durable_ids",
+        "fetch_flow_definition_by_ids",
+        "fetch_flow_metadata",
+        "fetch_bot_versions",
+        "fetch_bot_definition_details",
+    )
+
+    def test_every_fetcher_requires_on_401_refresh(self):
+        """Each fetcher raises TypeError when `on_401_refresh` is omitted.
+
+        `api_version` is now also required. To
+        isolate the `on_401_refresh` contract (not conflate it with the
+        new `api_version` contract — that's covered by
+        `ApiVersionRequiredOnEveryFetcherTests` below), we pass a valid
+        `api_version` and check the TypeError is specifically about the
+        missing `on_401_refresh` — otherwise a regression that made
+        `on_401_refresh` optional again would be masked by the
+        `api_version` TypeError.
+        """
+        import fetch_soql  # type: ignore
+
+        # Sentinel that won't survive the call — we never reach the HTTP
+        # layer because signature validation fires first.
+        def _noop_provider():
+            return ("url", "tok")
+
+        for name in self.FETCHERS:
+            fn = getattr(fetch_soql, name)
+            with self.subTest(fetcher=name):
+                if name == "fetch_planner_definition":
+                    # Signature: (agent_api_name, version, creds_provider, *, ...)
+                    args = ("Agent", "v2", _noop_provider)
+                elif name in {
+                    "fetch_plugins_by_planner",
+                    "fetch_planner_bundle_functions",
+                    "fetch_bot_versions", "fetch_bot_definition_details",
+                }:
+                    args = ("Name", _noop_provider)
+                elif name in {"fetch_functions_by_plugins",
+                              "fetch_plugin_instructions", "fetch_plugin_functions",
+                              "fetch_planner_attrs",
+                              "fetch_apex_bodies_by_names",
+                              "fetch_apex_bodies_by_ids",
+                              "fetch_flow_definition_ids_by_names",
+                              "fetch_flow_definition_view_by_durable_ids",
+                              "fetch_flow_definition_by_ids"}:
+                    args = (["Name"], _noop_provider)
+                elif name == "fetch_flow_metadata":
+                    args = ("301VF000000xyz", _noop_provider)
+                else:
+                    self.fail(f"unmapped fetcher {name}")
+
+                with self.assertRaises(TypeError) as ctx:
+                    # Pass api_version so the TypeError pinpoints
+                    # on_401_refresh specifically.
+                    fn(*args, api_version="v60.0")
+                self.assertIn(
+                    "on_401_refresh", str(ctx.exception),
+                    msg=f"{name} must name on_401_refresh in its TypeError",
+                )
+
+    def test_every_fetcher_requires_api_version(self):
+        """every fetcher must require the
+        `api_version` kwarg. Symmetric to the `on_401_refresh` contract.
+
+        Omitting `api_version` must be a TypeError at call time, not a
+        silent regression back to the old hardcoded `v60.0` floor.
+        """
+        import fetch_soql  # type: ignore
+
+        def _noop_provider():
+            return ("url", "tok")
+
+        def _noop_refresh():
+            return ("url", "tok")
+
+        for name in self.FETCHERS:
+            fn = getattr(fetch_soql, name)
+            with self.subTest(fetcher=name):
+                if name == "fetch_planner_definition":
+                    args = ("Agent", "v2", _noop_provider)
+                elif name in {
+                    "fetch_plugins_by_planner",
+                    "fetch_planner_bundle_functions",
+                    "fetch_bot_versions", "fetch_bot_definition_details",
+                }:
+                    args = ("Name", _noop_provider)
+                elif name in {"fetch_functions_by_plugins",
+                              "fetch_plugin_instructions", "fetch_plugin_functions",
+                              "fetch_planner_attrs",
+                              "fetch_apex_bodies_by_names",
+                              "fetch_apex_bodies_by_ids",
+                              "fetch_flow_definition_ids_by_names",
+                              "fetch_flow_definition_view_by_durable_ids",
+                              "fetch_flow_definition_by_ids"}:
+                    args = (["Name"], _noop_provider)
+                elif name == "fetch_flow_metadata":
+                    args = ("301VF000000xyz", _noop_provider)
+                else:
+                    self.fail(f"unmapped fetcher {name}")
+
+                with self.assertRaises(TypeError) as ctx:
+                    # Pass on_401_refresh so the TypeError pinpoints
+                    # api_version specifically.
+                    fn(*args, on_401_refresh=_noop_refresh)
+                self.assertIn(
+                    "api_version", str(ctx.exception),
+                    msg=f"{name} must name api_version in its TypeError",
+                )
+
+    def test_fetcher_with_explicit_refresh_does_not_raise_typeerror(self):
+        """Control: passing `on_401_refresh=<callable>` + `api_version=...`
+        bypasses the signature guard and the call reaches inner logic
+        (mocked here). Any non-TypeError outcome is acceptable — we're
+        only asserting the signature is satisfied.
+
+        `api_version` is now a sibling required
+        kwarg to `on_401_refresh`; both must be supplied.
+        """
+        import fetch_soql  # type: ignore
+
+        # Empty-list short-circuit → returns [] without firing a SOQL call.
+        out = fetch_soql.fetch_plugin_instructions(
+            [],
+            lambda: ("url", "tok"),
+            api_version="v60.0",
+            on_401_refresh=lambda: ("url", "tok"),
+        )
+        self.assertEqual(out, [])
+
+
+# ---------------------------------------------------------------------------
+# atomic finalize via staging-sibling swap
+# ---------------------------------------------------------------------------
+
+
+class AtomicFinalizeTests(unittest.TestCase):
+    """`_run_finalize` must never leave `data_dir` in an empty / missing
+    state. The prior `shutil.rmtree; rename` pattern opened a window
+    where a crash or a concurrent reader saw an empty path. The new
+    `_swap_dir_atomic` uses staging-siblings + `os.replace` so:
+      * on success, `data_dir` transitions atomically from OLD → NEW
+      * on a mid-swap crash, the backup sibling is restored to `data_dir`
+    """
+
+    def _make_tree(self) -> dict:
+        return {
+            "_schema_version": "3.0",
+            "agent": {"api_name": "A", "version": "v1"},
+            "root": {"kind": "BOT_DEFINITION", "api_name": "A", "children": []},
+            "node_count": 1, "depth": 0,
+            "_kind_counts": {"BOT_DEFINITION": 1},
+            "_pending_fetches": {k: [] for k in ("FLOW", "APEX", "PROMPT_TEMPLATE", "STANDARD_ACTION")},
+            "_unresolved": [],
+        }
+
+    def test_happy_path_swaps_atomically(self):
+        """Finalize runs cleanly: data_dir + cache_dir end up populated
+        with the fresh tree/manifest, staging/backup siblings are gone.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            work_dir = tmp_p / "work"
+            work_dir.mkdir()
+            data_dir = tmp_p / "data" / "A__v1"
+            cache_dir = tmp_p / "cache" / "A__v1"
+
+            tree = self._make_tree()
+            main._run_finalize(
+                data_dir, cache_dir, tree, work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+
+            self.assertTrue(data_dir.is_dir())
+            self.assertTrue((data_dir / "A_v1_metadata_tree.json").is_file())
+            self.assertTrue((cache_dir / "manifest.json").is_file())
+
+            # No staging / backup siblings left behind.
+            siblings = list(data_dir.parent.iterdir()) + list(cache_dir.parent.iterdir())
+            for s in siblings:
+                self.assertFalse(
+                    s.name.startswith(".") and ("staging" in s.name or "backup" in s.name),
+                    f"leftover staging/backup: {s}",
+                )
+
+    def test_existing_dir_replaced_not_emptied_midswap(self):
+        """Run finalize TWICE. The second run must swap atomically — at
+        no observable moment does `data_dir` exist and contain zero
+        files. We verify by inspecting post-run state (the swap is
+        atomic, so the invariant reduces to "data_dir is populated with
+        NEW artifacts after the call returns").
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            work_dir = tmp_p / "work"
+            work_dir.mkdir()
+            data_dir = tmp_p / "data" / "A__v1"
+            cache_dir = tmp_p / "cache" / "A__v1"
+
+            # First run
+            main._run_finalize(
+                data_dir, cache_dir, self._make_tree(), work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+            self.assertTrue((data_dir / "A_v1_metadata_tree.json").is_file())
+
+            # Second run — different node_count so we can confirm the
+            # replacement took effect (not a stale file).
+            tree2 = self._make_tree()
+            tree2["node_count"] = 42
+            main._run_finalize(
+                data_dir, cache_dir, tree2, work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+            tree_out = json.loads((data_dir / "A_v1_metadata_tree.json").read_text())
+            self.assertEqual(tree_out["node_count"], 42)
+
+    def test_crash_during_final_swap_restores_original(self):
+        """Inject an `os.replace` failure on the SECOND rename of the
+        data_dir swap (staging → target). The function must:
+          * raise the underlying OSError (we assert)
+          * leave `data_dir` populated with the ORIGINAL contents
+            (backup was restored)
+
+        We patch `main._swap_dir_atomic` internals via patching
+        `os.replace` at the main-module's namespace with a side_effect
+        that fails the second-target replace only.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            work_dir = tmp_p / "work"
+            work_dir.mkdir()
+            data_dir = tmp_p / "data" / "A__v1"
+            cache_dir = tmp_p / "cache" / "A__v1"
+
+            # Prime data_dir with sentinel content to prove it survives.
+            data_dir.mkdir(parents=True)
+            (data_dir / "sentinel.txt").write_text("original-data")
+
+            real_replace = os.replace
+            call_seq = {"n": 0}
+
+            def fail_on_staging_to_target(src, dst):
+                """First replace: target → backup (must succeed, allows
+                the function to proceed to the risky step). Second
+                replace: staging → target (we force this to fail). The
+                function should catch that, restore backup → target, and
+                reraise."""
+                call_seq["n"] += 1
+                # Let the "target → backup" rename succeed (n==1).
+                # Also let the recovery "backup → target" rename succeed
+                # (fires AFTER we raise below). Fail only on n==2 (the
+                # "staging → target" rename).
+                if call_seq["n"] == 2:
+                    raise OSError("synthetic swap failure")
+                return real_replace(src, dst)
+
+            with mock.patch.object(main.os, "replace", side_effect=fail_on_staging_to_target):
+                with self.assertRaises(OSError):
+                    main._run_finalize(
+                        data_dir, cache_dir, self._make_tree(), work_dir,
+                        agent_api_name="A", agent_version="v1", planner_name="A",
+                    )
+
+            # Invariant: data_dir still exists AND still contains the
+            # original sentinel (the backup was restored).
+            self.assertTrue(data_dir.is_dir())
+            self.assertTrue((data_dir / "sentinel.txt").is_file())
+            self.assertEqual((data_dir / "sentinel.txt").read_text(), "original-data")
+
+    def test_leftover_staging_from_prior_crash_is_cleared(self):
+        """If a previous crashed run left a `.<name>.staging.<pid>`
+        sibling behind, the next finalize blows it away before staging
+        its own writes. Otherwise `mkdir(parents=True)` would raise
+        FileExistsError.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            work_dir = tmp_p / "work"
+            work_dir.mkdir()
+            data_dir = tmp_p / "data" / "A__v1"
+            cache_dir = tmp_p / "cache" / "A__v1"
+
+            # Synthesize a leftover staging dir for THIS pid.
+            stale_staging = data_dir.parent / f".{data_dir.name}.staging.{os.getpid()}"
+            stale_staging.mkdir(parents=True)
+            (stale_staging / "stale.txt").write_text("junk")
+
+            main._run_finalize(
+                data_dir, cache_dir, self._make_tree(), work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+
+            # Stale staging is gone (replaced with a successful swap).
+            self.assertFalse(stale_staging.exists())
+            # And data_dir has the fresh tree.
+            self.assertTrue((data_dir / "A_v1_metadata_tree.json").is_file())
+
+
+# ---------------------------------------------------------------------------
+# real 401 retry carries the new token
+# ---------------------------------------------------------------------------
+
+
+class Real401RetryIntegrationTests(unittest.TestCase):
+    """The existing `Refresh401Tests` mocks at the `tooling_query`
+    boundary — it bypasses the decorator stack and can't verify the
+    retry actually carries the NEW token into the second request.
+
+    This test mocks at the lowest-level `build_opener` seam in
+    `rest_client`. A mock `OpenerDirector.open` inspects the
+    Authorization header on each call:
+      * call 1: Bearer old_token → raise HTTPError(401)
+      * refresh_fn fires (via the real retry_on_401 decorator)
+      * call 2: Bearer new_token → return a valid response
+
+    If the  contract regressed — e.g. the retry re-used the stale
+    token — call 2 would still carry Bearer old_token and the test
+    would fail.
+    """
+
+    def test_retry_carries_new_token_after_401(self):
+        import io
+        import urllib.error
+        import fetch_soql  # type: ignore
+        import rest_client  # type: ignore
+
+        observed_auth_headers: list[str] = []
+
+        def _make_401_response() -> urllib.error.HTTPError:
+            # HTTPError tolerates hdrs=None; retry_on_401 does not touch
+            # .headers on a 401 (only the 403-path reads .read()).
+            return urllib.error.HTTPError(
+                url="https://example.my.salesforce.com/services/data/v60.0/tooling/query/",
+                code=401,
+                msg="Unauthorized",
+                hdrs=None,
+                fp=io.BytesIO(b"INVALID_SESSION_ID"),
+            )
+
+        class _FakeResp:
+            """Context-manager compatible fake response returning JSON."""
+
+            def __init__(self, body_bytes: bytes):
+                self._body = body_bytes
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return self._body
+
+        class _RecordingOpener:
+            def __init__(self):
+                self.n = 0
+
+            def open(self, req):
+                # Record the Authorization header so the test can assert
+                # the new token landed on the retry request.
+                auth = req.headers.get("Authorization") or req.get_header("Authorization")
+                observed_auth_headers.append(auth or "")
+                self.n += 1
+                if self.n == 1:
+                    raise _make_401_response()
+                # Retry: return a valid Tooling query response.
+                return _FakeResp(b'{"records":[{"Id":"001","DeveloperName":"X"}]}')
+
+        # Build creds plumbing that swaps tokens on refresh.
+        provider, refresh, _cell = main._build_creds_plumbing(
+            ("https://example.my.salesforce.com", "old_token"),
+            resolve_creds=lambda: ("https://example.my.salesforce.com", "new_token"),
+            dedupe_window_s=0.0,  # allow the refresh to fire unconditionally
+        )
+
+        opener = _RecordingOpener()
+        with mock.patch.object(rest_client, "build_opener", return_value=opener):
+            # Use a fetcher that triggers one Tooling query. v2+ branch
+            # goes through `load_soql` + the chain template — exercises the
+            # same tooling_query seam the test is here to verify.
+            result = fetch_soql.fetch_planner_definition(
+                "SomePlanner", "v2", provider,
+                api_version="v60.0", on_401_refresh=refresh,
+            )
+
+        # Contract: both requests were made; first with old_token,
+        # second with new_token (the post-refresh value).
+        self.assertEqual(len(observed_auth_headers), 2)
+        self.assertEqual(observed_auth_headers[0], "Bearer old_token")
+        self.assertEqual(observed_auth_headers[1], "Bearer new_token")
+        # And the retry response shaped correctly.
+        self.assertEqual(result.get("DeveloperName"), "X")
+
+
+class ApiVersionEndToEndTests(unittest.TestCase):
+    """the `api_version` reported by `sf org display --json`
+    threads through the pipeline all the way to the REST query URL.
+
+    Orgs on v66 must NOT hit `/services/data/v60.0/...` — that was
+    . This test drives the full pipeline with a mocked
+    org-display payload reporting `apiVersion=66.0` and asserts every
+    Tooling/Data query fetcher receives `api_version="v66.0"`.
+    """
+
+    def test_full_pipeline_passes_v66_to_every_fetcher(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+            data_root = Path(tmp) / "data"
+            cache_root = Path(tmp) / "cache"
+
+            # sf org display payload reports v66 — this is the shape real
+            # orgs return today (my-org-alias, my-perf-org-alias).
+            org_display_payload = {
+                "status": 0,
+                "result": {
+                    "instanceUrl": "https://example.my.salesforce.com",
+                    "accessToken": "00Dxx0000000000!AQ_fake_token_value",
+                    "id": "00Dxx0000000000AAA",
+                    "apiVersion": "66.0",
+                },
+            }
+
+            # Capture api_version passed to each fetcher via mock.call_args.
+            wave_a_patches = [
+                mock.patch.object(main, "fetch_planner_definition",
+                                  return_value=fx.CLASSIC_PLANNER),
+                mock.patch.object(main, "fetch_plugins_by_planner",
+                                  return_value=fx.CLASSIC_PLUGINS),
+                mock.patch.object(main, "fetch_planner_bundle_functions",
+                                  return_value=fx.CLASSIC_BUNDLE_FN_JOIN),
+                mock.patch.object(main, "fetch_functions_by_plugins",
+                                  return_value=fx.CLASSIC_FUNCTIONS),
+                mock.patch.object(main, "fetch_plugin_instructions",
+                                  return_value=fx.CLASSIC_INSTRUCTIONS),
+                mock.patch.object(main, "fetch_plugin_functions",
+                                  return_value=fx.CLASSIC_PLUGIN_FUNCTIONS),
+                mock.patch.object(main, "fetch_planner_attrs",
+                                  return_value=fx.CLASSIC_ATTRS),
+            ]
+            wave_b_patches = [
+                mock.patch.object(main, "fetch_apex_bodies_by_names",
+                                  return_value=fx.CLASSIC_APEX_ROWS),
+                mock.patch.object(main, "fetch_apex_bodies_by_ids",
+                                  return_value=[]),
+                mock.patch.object(main, "fetch_flow_definition_ids_by_names",
+                                  return_value=fx.CLASSIC_FLOW_DEFS),
+                mock.patch.object(main, "fetch_flow_definition_by_ids",
+                                  return_value=[]),
+                mock.patch.object(
+                    main, "fetch_flow_metadata",
+                    side_effect=lambda vid, *a, **kw: fx.CLASSIC_FLOW_METADATA.get(vid),
+                ),
+            ]
+            patches = [
+                mock.patch.object(main, "run_sf", return_value=org_display_payload),
+                mock.patch.object(main, "probe_channels",
+                                  return_value=fx.probe_ok_payload()),
+                *_mock_bot_resolution(),
+                *wave_a_patches,
+                *wave_b_patches,
+                mock.patch.object(main, "build_agent_data_dir",
+                                  side_effect=lambda o, a, v: data_root / o / f"{a}__{v}"),
+                mock.patch.object(main, "build_agent_cache_dir",
+                                  side_effect=lambda o, a, v: cache_root / o / f"{a}__{v}"),
+            ]
+            _apply_all(patches)
+            try:
+                rc = main.main(_args(work_dir))
+                # Snapshot call lists BEFORE `p.stop()` restores the
+                # originals — otherwise `main.fetch_*` drops back to the
+                # real function with no `.call_args_list`.
+                fetcher_call_lists = {
+                    name: getattr(main, name).call_args_list
+                    for name in (
+                        "fetch_planner_definition",
+                        "fetch_plugins_by_planner",
+                        "fetch_planner_bundle_functions",
+                        "fetch_functions_by_plugins",
+                        "fetch_plugin_instructions",
+                        "fetch_plugin_functions",
+                        "fetch_planner_attrs",
+                        "fetch_apex_bodies_by_names",
+                        "fetch_flow_definition_ids_by_names",
+                        "fetch_flow_metadata",
+                        "fetch_bot_versions",
+                        "fetch_bot_definition_details",
+                    )
+                }
+            finally:
+                for p in patches:
+                    p.stop()
+
+            self.assertEqual(rc, 0)
+
+            # Every Wave-A + Wave-B fetcher received `api_version="v66.0"`.
+            # We inspect call_args.kwargs rather than positional args — the
+            # kwarg is keyword-only by design.
+            expected = "v66.0"
+            for name, calls in fetcher_call_lists.items():
+                calls_with_version = [
+                    c for c in calls
+                    if c.kwargs.get("api_version") == expected
+                ]
+                self.assertTrue(
+                    calls_with_version,
+                    f"{name}: no call observed with api_version={expected!r}. "
+                    f"All calls: {calls}",
+                )
+
+
+class UncaughtExceptionToResultBlockTests(unittest.TestCase):
+    """the skill contract says every exit path emits a RESULT
+    block. Before the fix, an uncaught exception in the pipeline (e.g.
+    the HTTP 405 from , or any future bug) propagated to the
+    process boundary — users saw a Python traceback on stderr and the
+    wrapper skill never got `.emit_ctx.json`. `main()` now wraps
+    `_run_pipeline` in `try/except Exception` and funnels failures
+    through `_emit_fail(..., "RETRIEVE_FAILED", "uncaught-exception: ...")`.
+    """
+
+    def test_uncaught_exception_surfaces_as_retrieve_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            # Patch `_run_pipeline` to raise an arbitrary non-HTTP bug
+            # shape — proves the wrapper catches broad `Exception`, not
+            # just the specific HTTPError from .
+            with mock.patch.object(
+                main, "_run_pipeline",
+                side_effect=RuntimeError("unexpected defect in phase 6"),
+            ):
+                rc = main.main(_args(work_dir))
+
+            # Exit code MUST be non-zero (failure signal) but controlled —
+            # no Python traceback on stderr.
+            self.assertEqual(rc, 1)
+
+            # `.emit_ctx.json` MUST exist — the skill contract.
+            ctx_path = work_dir / ".emit_ctx.json"
+            self.assertTrue(ctx_path.is_file(),
+                            "uncaught exception must still write .emit_ctx.json")
+            ctx = _read_ctx(work_dir)
+            self.assertEqual(ctx["status"], "RETRIEVE_FAILED")
+            self.assertIn("uncaught-exception", ctx["error_detail"])
+            self.assertIn("RuntimeError", ctx["error_detail"])
+            self.assertIn("unexpected defect in phase 6", ctx["error_detail"])
+
+    def test_uncaught_exception_redacts_bearer_tokens(self):
+        """the redacted error_detail must not leak tokens even if
+        the exception message happens to carry one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            leaky = RuntimeError(
+                "downstream failed: Authorization: Bearer TESTONLY_LEAKY_TOKEN"
+            )
+            with mock.patch.object(main, "_run_pipeline", side_effect=leaky):
+                rc = main.main(_args(work_dir))
+
+            self.assertEqual(rc, 1)
+            ctx = _read_ctx(work_dir)
+            self.assertEqual(ctx["status"], "RETRIEVE_FAILED")
+            # Token must NOT appear.
+            self.assertNotIn("TESTONLY_LEAKY_TOKEN", ctx["error_detail"])
+            # Redaction sentinel must appear — proof the scrub ran.
+            self.assertIn("<redacted>", ctx["error_detail"])
+
+    def test_systemexit_still_propagates(self):
+        """argparse's --help path raises SystemExit. That MUST propagate
+        unchanged — catching it would silently swallow `--help` + any
+        other intentional early exit. The wrapper catches `Exception`,
+        not `BaseException`, so SystemExit is unaffected."""
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp) / "work"
+
+            with mock.patch.object(main, "_run_pipeline",
+                                   side_effect=SystemExit(2)):
+                with self.assertRaises(SystemExit) as ctx:
+                    main.main(_args(work_dir))
+            self.assertEqual(ctx.exception.code, 2)
+
+
+class NormalizeFlowIdTargetsTests(unittest.TestCase):
+    """classic bots occasionally store NGA-style
+    300Uv-prefix FlowDefinition IDs or 301-prefix Flow version IDs as
+    InvocationTarget. After Wave B resolves them we rewrite bundle_parsed
+    in place so parse_wave sees DeveloperNames and the pending/visited
+    diff collapses to zero for legitimate targets."""
+
+    def test_rewrites_flowdefinition_id_to_developer_name(self):
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [{
+                    "name": "A",
+                    "invocationTarget": "300UvXXXXXXXXXXXX",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        flow_def_rows = [{
+            "Id": "300UvXXXXXXXXXXXX",
+            "DeveloperName": "MyFlowName",
+            "ActiveVersionId": "301VfYYYYYYYYYYYY",
+        }]
+        main._normalize_flow_id_targets(bundle, flow_def_rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "MyFlowName")
+        self.assertEqual(action["_original_invocation_target_id"],
+                         "300UvXXXXXXXXXXXX")
+
+    def test_rewrites_flow_version_id_via_active_version_map(self):
+        """301-prefix IDs should also resolve — via the ActiveVersionId
+        side of the bi-directional map."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "301VfYYYYYYYYYYYY",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        flow_def_rows = [{
+            "Id": "300UvXXXXXXXXXXXX",
+            "DeveloperName": "MyFlowName",
+            "ActiveVersionId": "301VfYYYYYYYYYYYY",
+        }]
+        main._normalize_flow_id_targets(bundle, flow_def_rows)
+        self.assertEqual(
+            bundle["topics"][0]["actions"][0]["invocationTarget"],
+            "MyFlowName",
+        )
+
+    def test_preserves_classic_developer_name_targets(self):
+        """Classic DeveloperName targets must pass through untouched —
+        they have nothing to resolve AND shouldn't pick up the sentinel
+        _original_invocation_target_id field."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "AGNT_Case_Create",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        flow_def_rows = [{
+            "Id": "300UvXXXXXXXXXXXX",
+            "DeveloperName": "AGNT_Case_Create",
+            "ActiveVersionId": "301VfYYYYYYYYYYYY",
+        }]
+        main._normalize_flow_id_targets(bundle, flow_def_rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "AGNT_Case_Create")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+    def test_unmatched_id_stays_as_is(self):
+        """An ID that doesn't appear in flow_def_rows (Flow not queryable
+        / managed package invisible) stays unchanged — that's how it
+        correctly surfaces in _pending_fetches instead of silently
+        discarding."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "300UvZZZZZZZZZZZZ",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        main._normalize_flow_id_targets(bundle, [{
+            "Id": "300UvXXXXXXXXXXXX",
+            "DeveloperName": "DifferentFlow",
+            "ActiveVersionId": "301VfYYYYYYYYYYYY",
+        }])
+        self.assertEqual(
+            bundle["topics"][0]["actions"][0]["invocationTarget"],
+            "300UvZZZZZZZZZZZZ",
+        )
+
+    def test_apex_target_with_300_prefix_not_rewritten(self):
+        """Only invocationTargetType=='flow' is rewritten. A target that
+        happens to match a flow id but is declared as apex stays put —
+        it's a caller-error we surface, not one we silently rewrite."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "300UvXXXXXXXXXXXX",
+                    "invocationTargetType": "apex",  # wrong type
+                }],
+            }],
+            "plannerActions": [],
+        }
+        flow_def_rows = [{
+            "Id": "300UvXXXXXXXXXXXX",
+            "DeveloperName": "MyFlow",
+            "ActiveVersionId": "301VfYYYYYYYYYYYY",
+        }]
+        main._normalize_flow_id_targets(bundle, flow_def_rows)
+        self.assertEqual(
+            bundle["topics"][0]["actions"][0]["invocationTarget"],
+            "300UvXXXXXXXXXXXX",
+        )
+
+    def test_empty_inputs_noop(self):
+        """Empty flow_def_rows → immediate return, no mutation, no crash
+        on missing 'topics' / 'plannerActions' keys."""
+        bundle = {}
+        main._normalize_flow_id_targets(bundle, [])
+        self.assertEqual(bundle, {})
+
+        bundle2 = {
+            "topics": [{"actions": [{
+                "invocationTarget": "300Uv", "invocationTargetType": "flow",
+            }]}],
+            "plannerActions": [],
+        }
+        main._normalize_flow_id_targets(bundle2, [])
+        # Untouched — no lookup map to rewrite against.
+        self.assertEqual(
+            bundle2["topics"][0]["actions"][0]["invocationTarget"], "300Uv",
+        )
+
+    def test_rewrites_both_topics_and_planner_actions(self):
+        """Fix must cover both the per-topic actions path AND the
+        bundle-scope plannerActions path."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "300UvAAAA",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [{
+                "invocationTarget": "300UvBBBB",
+                "invocationTargetType": "flow",
+            }],
+        }
+        flow_def_rows = [
+            {"Id": "300UvAAAA", "DeveloperName": "TopicFlow",
+             "ActiveVersionId": "301AAAA"},
+            {"Id": "300UvBBBB", "DeveloperName": "BundleFlow",
+             "ActiveVersionId": "301BBBB"},
+        ]
+        main._normalize_flow_id_targets(bundle, flow_def_rows)
+        self.assertEqual(
+            bundle["topics"][0]["actions"][0]["invocationTarget"], "TopicFlow",
+        )
+        self.assertEqual(
+            bundle["plannerActions"][0]["invocationTarget"], "BundleFlow",
+        )
+
+    def test_none_invocation_target_type_ignored_safely(self):
+        """Defensive: invocationTargetType missing → treat as 'not a
+        flow', skip. No crash."""
+        bundle = {
+            "topics": [{"actions": [{
+                "invocationTarget": "300UvAAAA",
+                "invocationTargetType": None,
+            }]}],
+            "plannerActions": [],
+        }
+        main._normalize_flow_id_targets(bundle, [
+            {"Id": "300UvAAAA", "DeveloperName": "X", "ActiveVersionId": "301"}
+        ])
+        self.assertEqual(
+            bundle["topics"][0]["actions"][0]["invocationTarget"], "300UvAAAA",
+        )
+
+
+class CollectWaveBTargetsStandardActionTests(unittest.TestCase):
+    """`_route` in `_collect_wave_b_targets` must
+    short-circuit on declared-only target types (standardInvocableAction,
+    generatePromptResponse, genai*, prompt*) BEFORE calling
+    resolve_or_unresolved — otherwise it pollutes `_unresolved` with
+    spurious "invalid-id-format" entries for perfectly valid identifiers
+    that simply aren't Salesforce Ids."""
+
+    def test_standard_action_not_routed_through_id_resolver(self):
+        """`streamKnowledgeSearch` is a built-in standard action — not
+        an Id. It should not end up in apex_ids, flow_ids, apex_names,
+        or flow_names AND it should NOT appear in the `_unresolved`
+        list that resolve_or_unresolved populates on non-Id inputs.
+        """
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [{
+                    "name": "A",
+                    "invocationTarget": "streamKnowledgeSearch",
+                    "invocationTargetType": "standardInvocableAction",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertEqual(result["apex_names"], [])
+        self.assertEqual(result["apex_ids"], [])
+        self.assertEqual(result["flow_names"], [])
+        self.assertEqual(result["flow_ids"], [])
+        self.assertEqual(
+            result["_unresolved"], [],
+            "standardInvocableAction must not pollute _unresolved with "
+            "invalid-id-format entries",
+        )
+
+    def test_generate_prompt_response_short_circuits(self):
+        """`generatePromptResponse` targets are prompt-template names;
+        not routed to Apex/Flow fetchers (Batch 1 is body-only for
+        Apex+Flow; prompts flow through the retrieve path)."""
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [{
+                    "invocationTarget": "MyPromptTemplate",
+                    "invocationTargetType": "generatePromptResponse",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertEqual(result["apex_names"], [])
+        self.assertEqual(result["flow_names"], [])
+        self.assertEqual(result["_unresolved"], [])
+
+    def test_flow_and_apex_still_route_correctly(self):
+        """Positive control — the short-circuit must not break flow/apex
+        routing. A mix of classic DeveloperNames + NGA IDs should land in
+        the right buckets, and standard actions should pass through
+        without polluting anything."""
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [
+                    # Classic flow by DeveloperName
+                    {"invocationTarget": "MyFlow",
+                     "invocationTargetType": "flow"},
+                    # Classic apex by name
+                    {"invocationTarget": "MyApex",
+                     "invocationTargetType": "apex"},
+                    # Standard action (new short-circuit path)
+                    {"invocationTarget": "streamKnowledgeSearch",
+                     "invocationTargetType": "standardInvocableAction"},
+                    # NGA apex by Id
+                    {"invocationTarget": "01p1N000005SsDNQA0",
+                     "invocationTargetType": "apex"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertIn("MyFlow", result["flow_names"])
+        self.assertIn("MyApex", result["apex_names"])
+        self.assertIn("01p1N000005SsDNQA0", result["apex_ids"])
+        self.assertEqual(result["_unresolved"], [])
+
+    def test_unknown_type_silently_skipped(self):
+        """An unrecognized invocationTargetType falls through all the
+        known-type branches and is silently skipped. parse_wave tags the
+        node as UNKNOWN in the tree (via `_kind_counts`), so the signal
+        is visible without polluting _unresolved."""
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [{
+                    "invocationTarget": "SomeThing",
+                    "invocationTargetType": "unheardOfType",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertEqual(result["apex_names"], [])
+        self.assertEqual(result["flow_names"], [])
+        self.assertEqual(
+            result["_unresolved"], [],
+            "Unknown invocationTargetType shouldn't reach the ID router, "
+            "so _unresolved stays clean.",
+        )
+
+    def test_classic_flow_name_not_routed_through_id_resolver(self):
+        """classic bots store plain DeveloperNames
+        like `MyFlow` — not Salesforce Ids. The router must route these
+        directly to flow_names via invocationTargetType, NOT through
+        resolve_or_unresolved (which would reject them as invalid-id-
+        format and pollute _unresolved)."""
+        bundle = {
+            "topics": [{
+                "actions": [
+                    {"invocationTarget": "MyFlow",
+                     "invocationTargetType": "flow"},
+                    {"invocationTarget": "AGNT_Foo",
+                     "invocationTargetType": "apex"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertIn("MyFlow", result["flow_names"])
+        self.assertIn("AGNT_Foo", result["apex_names"])
+        self.assertEqual(
+            result["_unresolved"], [],
+            "Classic DeveloperNames shouldn't be sent through the ID "
+            "resolver at all — they're not Ids.",
+        )
+
+
+class NormalizePromptTemplateIdTargetsTests(unittest.TestCase):
+    """Bug 1 fix (2026-05-05): classic bots occasionally store 0hf-prefix
+    GenAiPromptTemplate IDs as `GenAiFunctionDefinition.InvocationTarget`.
+    After Wave B resolves them via `list_prompt_template_metadata`
+    (GenAiPromptTemplate is NOT SOQL-queryable — Metadata API only) we
+    rewrite bundle_parsed in place so Wave B's retrieve uses the
+    DeveloperName Metadata API expects."""
+
+    def test_rewrites_prompt_template_id_to_developer_name(self):
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "0hfUv0000021mCjIAI",
+                    "invocationTargetType": "GenAiPromptTemplate",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        rows = [{"Id": "0hfUv0000021mCjIAI", "DeveloperName": "My_Prompt"}]
+        main._normalize_prompt_template_id_targets(bundle, rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "My_Prompt")
+        self.assertEqual(
+            action["_original_invocation_target_id"], "0hfUv0000021mCjIAI"
+        )
+
+    def test_preserves_classic_developer_name_targets(self):
+        """Classic DeveloperName targets pass through untouched — the
+        rewrite is only for Id-shaped targets that appeared in the lookup."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "Existing_Prompt_Name",
+                    "invocationTargetType": "GenAiPromptTemplate",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        # Lookup covers a different Id entirely — the DeveloperName target
+        # isn't a key in the map so it's not rewritten.
+        rows = [{"Id": "0hfUv0000021Other", "DeveloperName": "Other_Prompt"}]
+        main._normalize_prompt_template_id_targets(bundle, rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "Existing_Prompt_Name")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+    def test_unmatched_id_stays_as_is(self):
+        """Id not present in the lookup (e.g. Tooling returned empty
+        because GenAiPromptTemplate isn't exposed on this org) stays
+        as-is so it correctly surfaces in _pending_fetches."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "0hfUv00000xxxxxYYY",
+                    "invocationTargetType": "GenAiPromptTemplate",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        main._normalize_prompt_template_id_targets(bundle, [])
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "0hfUv00000xxxxxYYY")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+
+class NormalizeApexIdTargetsTests(unittest.TestCase):
+    """Gap B fix (2026-05-05): classic bots occasionally store 01p-prefix
+    ApexClass Ids as `GenAiFunctionDefinition.InvocationTarget` (live-verified
+    on my-org-alias: 01p000000000000AAA -> MyController).
+    After Wave B resolves them via `fetch_apex_bodies_by_ids` we rewrite
+    bundle_parsed in place so the tree renders the ApexClass Name instead
+    of the raw Id."""
+
+    def test_rewrites_apex_id_to_class_name(self):
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "01p000000000000AAA",
+                    "invocationTargetType": "apex",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        rows = [{"Id": "01p000000000000AAA", "Name": "MyController"}]
+        main._normalize_apex_id_targets(bundle, rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "MyController")
+        self.assertEqual(
+            action["_original_invocation_target_id"], "01p000000000000AAA"
+        )
+
+    def test_non_apex_ttype_left_unchanged(self):
+        """Same Id but a non-apex ttype — the ttype gate must block the
+        rewrite so a Flow action whose target happens to collide with an
+        ApexClass Id isn't miscaught."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "01p000000000000AAA",
+                    "invocationTargetType": "flow",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        rows = [{"Id": "01p000000000000AAA", "Name": "MyController"}]
+        main._normalize_apex_id_targets(bundle, rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "01p000000000000AAA")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+    def test_unmatched_id_stays_as_is(self):
+        """Id not present in the lookup (e.g. by-Id fetch failed or the
+        class was deleted) stays as-is so it correctly surfaces in
+        _pending_fetches."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "01pFAKEIDFAKEIDAAA",
+                    "invocationTargetType": "apex",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        main._normalize_apex_id_targets(bundle, [])
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "01pFAKEIDFAKEIDAAA")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+    def test_preserves_classic_developer_name_targets(self):
+        """Classic Name targets pass through untouched — the rewrite is
+        only for Id-shaped targets (01p-prefix) that appeared in the lookup."""
+        bundle = {
+            "topics": [{
+                "actions": [{
+                    "invocationTarget": "MyApexClass",
+                    "invocationTargetType": "apex",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        # Lookup covers a different Id entirely — the Name target isn't
+        # Id-shaped and doesn't hit the prefix gate.
+        rows = [{"Id": "01p000000000000AAA", "Name": "MyController"}]
+        main._normalize_apex_id_targets(bundle, rows)
+        action = bundle["topics"][0]["actions"][0]
+        self.assertEqual(action["invocationTarget"], "MyApexClass")
+        self.assertNotIn("_original_invocation_target_id", action)
+
+
+class CollectWaveBTargetsPromptTemplateIdTests(unittest.TestCase):
+    """Bug 1 fix (2026-05-05): 0hf-prefix prompt template Ids are routed
+    to a dedicated `prompt_template_ids` bucket so post-Wave-B resolution
+    can rewrite them; DeveloperName targets still short-circuit as before."""
+
+    def test_prompt_template_id_routes_to_id_bucket(self):
+        bundle = {
+            "topics": [],
+            "plannerActions": [{
+                "invocationTarget": "0hfUv0000021mCjIAI",
+                "invocationTargetType": "GenAiPromptTemplate",
+            }],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertEqual(
+            result.get("prompt_template_ids"), ["0hfUv0000021mCjIAI"]
+        )
+        # DeveloperName bucket stays empty — the Id is routed to the Id
+        # bucket and the short-circuit returns BEFORE the DeveloperName
+        # branch would have run.
+        self.assertEqual(result.get("_unresolved"), [])
+
+    def test_prompt_template_developer_name_does_not_pollute_id_bucket(self):
+        bundle = {
+            "topics": [],
+            "plannerActions": [{
+                "invocationTarget": "My_Prompt_Template_Name",
+                "invocationTargetType": "GenAiPromptTemplate",
+            }],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        self.assertEqual(result.get("prompt_template_ids"), [])
+        # DeveloperName-shaped prompt-template targets still short-circuit
+        # (parse_wave enqueues them into PROMPT_TEMPLATE pending) — no
+        # change from prior behavior, verified via absence from all
+        # name/id buckets we'd route through.
+        self.assertEqual(result.get("apex_names"), [])
+        self.assertEqual(result.get("flow_names"), [])
+
+    def test_non_0hf_prefix_ignored(self):
+        """Id-shaped target for a prompt-template ttype but WRONG prefix
+        (e.g. a Flow Id accidentally typed with prompt ttype) doesn't
+        pollute prompt_template_ids — the prefix gate catches it."""
+        bundle = {
+            "topics": [],
+            "plannerActions": [{
+                "invocationTarget": "300Uv00000abcdeFGH",  # Flow-shaped Id
+                "invocationTargetType": "GenAiPromptTemplate",
+            }],
+        }
+        result = main._collect_wave_b_targets(bundle)
+        # Not routed anywhere — neither prompt-template Id bucket nor
+        # flow buckets (ttype gated). Surfaces nowhere, which is
+        # acceptable: classify_action_call downstream will still enqueue
+        # the string as-is as a PROMPT_TEMPLATE pending fetch.
+        self.assertEqual(result.get("prompt_template_ids"), [])
+
+
+class FetchFlowDefinitionViewByDurableIdsTests(unittest.TestCase):
+    """Option B (2026-05-05): `fetch_flow_definition_view_by_durable_ids`
+    is the Data-API fallback fetcher for managed-installed flows that
+    Tooling's `FlowDefinition` doesn't index.
+
+    Contract:
+      * Empty input short-circuits to `[]` without firing a SOQL call
+        (matches every other list-shaped fetcher in this module).
+      * Rows are returned from `data_query` verbatim — projection to
+        the `flow_def_rows` shape happens in the caller
+        (`fetch_flow_definition_ids_by_names`).
+    """
+
+    def test_happy_path_returns_rows(self):
+        import fetch_soql  # type: ignore
+        view_row = {
+            "DurableId": "SvcCopilotTmpl__VerifyCode",
+            "ApiName": "VerifyCode",
+            "Label": "Verify Code",
+            "NamespacePrefix": "SvcCopilotTmpl",
+            "ActiveVersionId": "SvcCopilotTmpl__VerifyCode-1",
+            "IsActive": True,
+            "ManageableState": "installed",
+            "ProcessType": "AutoLaunchedFlow",
+        }
+        with mock.patch.object(
+            fetch_soql, "data_query",
+            return_value={"records": [view_row]},
+        ) as mock_dq:
+            rows = fetch_soql.fetch_flow_definition_view_by_durable_ids(
+                ["SvcCopilotTmpl__VerifyCode"],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(rows, [view_row])
+        # Exactly one data_query call — the fetcher doesn't accidentally
+        # re-fire on the Tooling surface.
+        self.assertEqual(mock_dq.call_count, 1)
+
+    def test_empty_input_short_circuits(self):
+        """Empty durable_ids list returns [] WITHOUT firing a SOQL call
+        (matches the module-wide empty-input-short-circuit invariant)."""
+        import fetch_soql  # type: ignore
+        with mock.patch.object(fetch_soql, "data_query") as mock_dq:
+            rows = fetch_soql.fetch_flow_definition_view_by_durable_ids(
+                [],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(rows, [])
+        self.assertEqual(mock_dq.call_count, 0)
+
+    def test_multi_row_returns_all(self):
+        import fetch_soql  # type: ignore
+        view_rows = [
+            {
+                "DurableId": "SvcCopilotTmpl__VerifyCode",
+                "ApiName": "VerifyCode",
+                "NamespacePrefix": "SvcCopilotTmpl",
+                "ActiveVersionId": "SvcCopilotTmpl__VerifyCode-1",
+                "ManageableState": "installed",
+            },
+            {
+                "DurableId": "sales_inbound_flows__SendVerifyCode",
+                "ApiName": "SendVerifyCode",
+                "NamespacePrefix": "sales_inbound_flows",
+                "ActiveVersionId": "sales_inbound_flows__SendVerifyCode-2",
+                "ManageableState": "installed",
+            },
+        ]
+        with mock.patch.object(
+            fetch_soql, "data_query",
+            return_value={"records": view_rows},
+        ):
+            rows = fetch_soql.fetch_flow_definition_view_by_durable_ids(
+                [
+                    "SvcCopilotTmpl__VerifyCode",
+                    "sales_inbound_flows__SendVerifyCode",
+                ],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(len(rows), 2)
+        # Membership assertion rather than sort-order — codepoint sort of
+        # mixed-case prefixes is fragile; the fetcher returns rows in the
+        # order `data_query` supplies them.
+        self.assertEqual(
+            {r["DurableId"] for r in rows},
+            {
+                "SvcCopilotTmpl__VerifyCode",
+                "sales_inbound_flows__SendVerifyCode",
+            },
+        )
+
+
+class FlowDefinitionViewFallbackTests(unittest.TestCase):
+    """Option B (2026-05-05, updated after managed-bucket retirement):
+    `fetch_flow_definition_ids_by_names` fires a SINGLE Tooling
+    `FlowDefinition` query (unmanaged-only — the template filters
+    `NamespacePrefix IS NULL`). Any input name that query doesn't resolve
+    triggers a single follow-up `FlowDefinitionView` (Data API) query.
+    Projected view-only rows carry `Id=None`, `ActiveVersionId=None`,
+    `_body_available=False`, and `_source="FlowDefinitionView"`.
+    """
+
+    def test_fallback_fires_on_managed_miss(self):
+        """Tooling FlowDefinition returns empty for a `ns__Name` input
+        (managed flows aren't indexed on subscriber orgs + the unmanaged
+        query filters `NamespacePrefix IS NULL` anyway); FlowDefinitionView
+        returns a matching row. Output row carries the view-shaped markers
+        and `DeveloperName` = qualified ns__bare."""
+        import fetch_soql  # type: ignore
+        view_row = {
+            "DurableId": "SvcCopilotTmpl__VerifyCode",
+            "ApiName": "VerifyCode",
+            "Label": "Verify Code",
+            "NamespacePrefix": "SvcCopilotTmpl",
+            "ActiveVersionId": "SvcCopilotTmpl__VerifyCode-1",
+            "ManageableState": "installed",
+        }
+        with mock.patch.object(
+            fetch_soql, "tooling_query",
+            return_value={"records": []},
+        ), mock.patch.object(
+            fetch_soql, "data_query",
+            return_value={"records": [view_row]},
+        ) as mock_dq:
+            rows = fetch_soql.fetch_flow_definition_ids_by_names(
+                ["SvcCopilotTmpl__VerifyCode"],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertIsNone(row["Id"])
+        self.assertIsNone(row["ActiveVersionId"])
+        self.assertFalse(row["_body_available"])
+        self.assertEqual(row["_source"], "FlowDefinitionView")
+        self.assertEqual(row["DeveloperName"], "SvcCopilotTmpl__VerifyCode")
+        self.assertEqual(row["NamespacePrefix"], "SvcCopilotTmpl")
+        self.assertEqual(row["_bare_developer_name"], "VerifyCode")
+        self.assertEqual(mock_dq.call_count, 1)
+
+    def test_fallback_skipped_when_tooling_resolves_everything(self):
+        """All input names resolved by Tooling → FlowDefinitionView is
+        never queried. Guards against unnecessary Data-API calls on the
+        99% of runs where every referenced flow is unmanaged or locally
+        installed."""
+        import fetch_soql  # type: ignore
+        real_row = {
+            "Id": "300Uv000000Real",
+            "DeveloperName": "MyFlow",
+            "NamespacePrefix": None,
+            "ActiveVersionId": "301Vf000000Real",
+        }
+        with mock.patch.object(
+            fetch_soql, "tooling_query",
+            return_value={"records": [real_row]},
+        ), mock.patch.object(fetch_soql, "data_query") as mock_dq:
+            rows = fetch_soql.fetch_flow_definition_ids_by_names(
+                ["MyFlow"],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["_source"], "FlowDefinition")
+        self.assertTrue(rows[0]["_body_available"])
+        self.assertEqual(mock_dq.call_count, 0)
+
+    def test_mixed_resolution_paths(self):
+        """Three input names, three distinct fates:
+          1. `ExistingFlow` — unmanaged, resolved by Tooling.
+          2. `SvcCopilotTmpl__VerifyCode` — managed miss on Tooling,
+             resolved by FlowDefinitionView.
+          3. `ghost_ns__GhostFlow` — managed miss on BOTH surfaces.
+
+        Expected: 2 rows total (1 real + 1 view-only), the ghost flow
+        absent from the result set. FlowDefinitionView queried exactly
+        once with both unresolved names in the IN-list.
+        """
+        import fetch_soql  # type: ignore
+
+        real_row = {
+            "Id": "300Uv000000Real",
+            "DeveloperName": "ExistingFlow",
+            "NamespacePrefix": None,
+            "ActiveVersionId": "301Vf000000Real",
+        }
+        view_row = {
+            "DurableId": "SvcCopilotTmpl__VerifyCode",
+            "ApiName": "VerifyCode",
+            "NamespacePrefix": "SvcCopilotTmpl",
+            "ActiveVersionId": "SvcCopilotTmpl__VerifyCode-1",
+            "ManageableState": "installed",
+        }
+
+        # Tooling is called exactly once — the unmanaged query (template
+        # filters NamespacePrefix IS NULL). It matches only ExistingFlow;
+        # the two managed-qualified names return no rows from that
+        # surface and fall through to the view fallback.
+        with mock.patch.object(
+            fetch_soql, "tooling_query",
+            return_value={"records": [real_row]},
+        ) as mock_tq, mock.patch.object(
+            fetch_soql, "data_query",
+            return_value={"records": [view_row]},
+        ) as mock_dq:
+            rows = fetch_soql.fetch_flow_definition_ids_by_names(
+                [
+                    "ExistingFlow",
+                    "SvcCopilotTmpl__VerifyCode",
+                    "ghost_ns__GhostFlow",
+                ],
+                lambda: ("url", "tok"),
+                api_version="v60.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(len(rows), 2)
+        # Tooling queried exactly once for the full input (no bucketing).
+        self.assertEqual(mock_tq.call_count, 1)
+        # View fallback queried exactly once — no per-name fanout.
+        self.assertEqual(mock_dq.call_count, 1)
+
+        by_name = {r["DeveloperName"]: r for r in rows}
+        # Real Tooling row — source marker explicit.
+        self.assertEqual(by_name["ExistingFlow"]["Id"], "300Uv000000Real")
+        self.assertEqual(by_name["ExistingFlow"]["_source"], "FlowDefinition")
+        self.assertTrue(by_name["ExistingFlow"]["_body_available"])
+        # View-only row — no Id, no active version, marked unavailable.
+        view_result = by_name["SvcCopilotTmpl__VerifyCode"]
+        self.assertIsNone(view_result["Id"])
+        self.assertIsNone(view_result["ActiveVersionId"])
+        self.assertFalse(view_result["_body_available"])
+        self.assertEqual(view_result["_source"], "FlowDefinitionView")
+        # Ghost flow absent.
+        self.assertNotIn("ghost_ns__GhostFlow", by_name)
+
+
+class FetchPlannerDefinitionChainTests(unittest.TestCase):
+    """2026-05-05: `fetch_planner_definition(agent, version)` performs a
+    chain-LIKE lookup against GenAiPlannerDefinition. The accretive
+    naming invariant (v1=`<Agent>`, v2=`<Agent>_v2`, v3=
+    `<Agent>_v2_v3`, ...) means the correct planner always matches
+    `<Agent>%\\_vN` for vN>=2 and `<Agent>` exactly for v1. On multi-row
+    matches the resolver picks the row with the shortest DeveloperName.
+    """
+
+    def _stub_tooling(self, records):
+        """Patch `fetch_soql.tooling_query` to return a fixed record list."""
+        import fetch_soql  # type: ignore
+        return mock.patch.object(
+            fetch_soql, "tooling_query",
+            return_value={"records": records},
+        )
+
+    def test_v1_exact_match(self):
+        import fetch_soql  # type: ignore
+        with self._stub_tooling([
+            {"Id": "1VxVF000V1", "DeveloperName": "Inbound_Sales_Agent"},
+        ]):
+            row = fetch_soql.fetch_planner_definition(
+                "Inbound_Sales_Agent", None,
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertIsNotNone(row)
+        self.assertEqual(row["DeveloperName"], "Inbound_Sales_Agent")
+
+    def test_v1_explicit_string(self):
+        import fetch_soql  # type: ignore
+        with self._stub_tooling([
+            {"Id": "1VxVF000V1", "DeveloperName": "Inbound_Sales_Agent"},
+        ]):
+            row = fetch_soql.fetch_planner_definition(
+                "Inbound_Sales_Agent", "v1",
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(row["DeveloperName"], "Inbound_Sales_Agent")
+
+    def test_v2_single_match(self):
+        import fetch_soql  # type: ignore
+        with self._stub_tooling([
+            {"Id": "1VxVF000V2", "DeveloperName": "Inbound_Sales_Agent_v2"},
+        ]):
+            row = fetch_soql.fetch_planner_definition(
+                "Inbound_Sales_Agent", "v2",
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(row["DeveloperName"], "Inbound_Sales_Agent_v2")
+
+    def test_v2_multi_row_shortest_wins(self):
+        """LIKE `<Agent>%\\_v2` can match both `<Agent>_v2` and a deeper
+        chain like `<Agent>_foo_v2` (rare but possible). Shortest
+        DeveloperName wins — the canonical row carries no extra segment."""
+        import fetch_soql  # type: ignore
+        with self._stub_tooling([
+            {"Id": "1VxVF000DEEPER",
+             "DeveloperName": "Inbound_Sales_Agent_foo_v2"},
+            {"Id": "1VxVF000V2",
+             "DeveloperName": "Inbound_Sales_Agent_v2"},
+        ]):
+            row = fetch_soql.fetch_planner_definition(
+                "Inbound_Sales_Agent", "v2",
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertEqual(row["DeveloperName"], "Inbound_Sales_Agent_v2")
+
+    def test_zero_rows_returns_none(self):
+        import fetch_soql  # type: ignore
+        with self._stub_tooling([]):
+            row = fetch_soql.fetch_planner_definition(
+                "NoSuchAgent", "v3",
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertIsNone(row)
+
+    def test_chain_like_pattern_passed_to_soql_for_v5(self):
+        """The SOQL body that reaches `tooling_query` contains the chain
+        LIKE pattern literally. Verify AGENT_NAME + VERSION are rendered
+        through the template with the `%\\_` escape in between.
+        """
+        import fetch_soql  # type: ignore
+        captured: dict = {}
+
+        def fake_tooling(creds_provider, soql, *, api_version, on_401_refresh):
+            captured["soql"] = soql
+            return {"records": []}
+
+        with mock.patch.object(fetch_soql, "tooling_query",
+                               side_effect=fake_tooling):
+            fetch_soql.fetch_planner_definition(
+                "MyAgent", "v5",
+                lambda: ("url", "tok"),
+                api_version="v66.0",
+                on_401_refresh=lambda: ("url", "tok"),
+            )
+        self.assertIn("LIKE 'MyAgent%\\_v5'", captured["soql"])
+
+
+class SwapDirAtomicCoTenancyTests(unittest.TestCase):
+    """`_swap_dir_atomic` preserves sibling content in `target`. The prior
+    whole-directory `os.replace` wiped any co-tenant subdirs that another
+    caller may have written into the same `<agent>__<ver>/` directory."""
+
+    def test_preserves_sibling_session_dirs(self) -> None:
+        # Simulate co-tenancy: target dir already has a sibling subdir
+        # + a bare file written by some other caller.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            target = tmp_p / "agent__v1"
+            target.mkdir()
+            (target / "sibling-data").mkdir()
+            (target / "sibling-data" / "payload.json").write_text(
+                "from-other-caller"
+            )
+            (target / "_sessions").mkdir()
+            (target / "_sessions" / "marker.link").write_text(
+                "../agent__v1/sibling-data"
+            )
+
+            # Architecture's own previous output, about to be overwritten.
+            (target / "old_tree.json").write_text("old")
+
+            # Staging dir — what architecture wants to write.
+            staging = tmp_p / ".agent__v1.staging.123"
+            staging.mkdir()
+            (staging / "agent_v1_metadata_tree.json").write_text("new-tree")
+            (staging / "last_built_at.txt").write_text("2026-05-05T12:00:00Z\n")
+
+            main._swap_dir_atomic(target, staging)
+
+            # Sibling content survives — the whole point of the fix.
+            self.assertTrue(
+                (target / "sibling-data" / "payload.json").is_file()
+            )
+            self.assertEqual(
+                (target / "sibling-data" / "payload.json").read_text(),
+                "from-other-caller",
+            )
+            self.assertTrue((target / "_sessions" / "marker.link").is_file())
+
+            # Architecture's new files landed.
+            self.assertEqual(
+                (target / "agent_v1_metadata_tree.json").read_text(), "new-tree"
+            )
+            self.assertTrue((target / "last_built_at.txt").is_file())
+
+            # Old file that wasn't in staging stays untouched.
+            self.assertTrue((target / "old_tree.json").is_file())
+            self.assertEqual((target / "old_tree.json").read_text(), "old")
+
+            # Staging dir cleaned up.
+            self.assertFalse(staging.exists())
+
+    def test_overwrites_own_files_cleanly(self) -> None:
+        """Same filename in both target and staging → staging content wins."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            target = tmp_p / "agent__v1"
+            target.mkdir()
+            (target / "tree.json").write_text("old-content")
+
+            staging = tmp_p / ".agent__v1.staging.123"
+            staging.mkdir()
+            (staging / "tree.json").write_text("new-content")
+
+            main._swap_dir_atomic(target, staging)
+
+            self.assertEqual(
+                (target / "tree.json").read_text(), "new-content"
+            )
+
+    def test_overwrites_when_target_entry_is_dir(self) -> None:
+        """If the old target entry is a directory and the new staging
+        entry is a file (or vice versa), replace cleans up the old kind
+        before os.replace lands the new one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            target = tmp_p / "agent__v1"
+            target.mkdir()
+            # Old entry is a directory with nested content.
+            (target / "payload").mkdir()
+            (target / "payload" / "nested.txt").write_text("deep")
+
+            staging = tmp_p / ".agent__v1.staging.123"
+            staging.mkdir()
+            # New entry with the same name is a plain file.
+            (staging / "payload").write_text("now-a-file")
+
+            main._swap_dir_atomic(target, staging)
+
+            self.assertTrue((target / "payload").is_file())
+            self.assertEqual(
+                (target / "payload").read_text(), "now-a-file"
+            )
+
+    def test_missing_staging_raises(self) -> None:
+        """Pre-existing precondition: staging must exist, or we raise."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            target = tmp_p / "agent__v1"
+            target.mkdir()
+            staging = tmp_p / ".agent__v1.staging.does-not-exist"
+            with self.assertRaises(OSError):
+                main._swap_dir_atomic(target, staging)
+
+    def test_run_finalize_preserves_session_subdir_across_reruns(self) -> None:
+        """End-to-end via `_run_finalize`: after a first successful run
+        seeds a co-tenant session dir, a second run must not wipe it.
+        Covers the production path — the bug the user reported."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = Path(tmp)
+            work_dir = tmp_p / "work"
+            work_dir.mkdir()
+            data_dir = tmp_p / "data" / "A__v1"
+            cache_dir = tmp_p / "cache" / "A__v1"
+
+            tree = {
+                "_schema_version": "3.0",
+                "agent": {"api_name": "A", "version": "v1"},
+                "root": {"kind": "BOT_DEFINITION", "api_name": "A",
+                         "children": []},
+                "node_count": 1, "depth": 0,
+                "_kind_counts": {"BOT_DEFINITION": 1},
+                "_pending_fetches": {k: [] for k in (
+                    "FLOW", "APEX", "PROMPT_TEMPLATE", "STANDARD_ACTION",
+                )},
+                "_unresolved": [],
+            }
+            # First run — populate data_dir.
+            main._run_finalize(
+                data_dir, cache_dir, dict(tree), work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+            # Simulate a co-tenant dropping content alongside.
+            sibling_dir = data_dir / "sibling-payload"
+            sibling_dir.mkdir()
+            (sibling_dir / "payload.json").write_text("cotenant-data")
+
+            # Second run — the original bug: this would wipe the sibling dir.
+            main._run_finalize(
+                data_dir, cache_dir, dict(tree), work_dir,
+                agent_api_name="A", agent_version="v1", planner_name="A",
+            )
+
+            # Sibling dir and its contents must survive.
+            self.assertTrue(sibling_dir.is_dir())
+            self.assertTrue((sibling_dir / "payload.json").is_file())
+            self.assertEqual(
+                (sibling_dir / "payload.json").read_text(),
+                "cotenant-data",
+            )
+            # Architecture's own tree is still present (re-written).
+            self.assertTrue((data_dir / "A_v1_metadata_tree.json").is_file())
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 fix (2026-05-05): GenAiPromptTemplate is NOT SOQL-queryable. Id →
+# DeveloperName resolution runs through `sf org list metadata` (Metadata
+# API) via the new `list_prompt_template_metadata` helper.
+# ---------------------------------------------------------------------------
+
+
+class ListPromptTemplateMetadataTests(unittest.TestCase):
+    """Unit tests for `metadata_listing.list_prompt_template_metadata` —
+    thin wrapper over `run_sf("list_metadata_genaiprompttemplate", ...)`.
+
+    The shape we care about is produced by the sf CLI:
+        {"status": 0, "result": [{"id": "0hfUv...", "fullName": "Foo", ...}]}
+    Defensive returns on malformed result (None / wrong type) keep the
+    failure mode quiet — callers already tolerate empty lists.
+    """
+
+    def test_happy_path_returns_result_rows(self):
+        import metadata_listing  # type: ignore
+        payload = {
+            "status": 0,
+            "result": [
+                {"id": "0hfUv0000021mCjIAI", "fullName": "My_Prompt",
+                 "type": "GenAiPromptTemplate"},
+                {"id": "0hfUv0000021mOtherAAA", "fullName": "Other_Prompt",
+                 "type": "GenAiPromptTemplate"},
+            ],
+        }
+        with mock.patch.object(metadata_listing, "run_sf", return_value=payload):
+            rows = metadata_listing.list_prompt_template_metadata("test-org")
+        self.assertEqual(rows, payload["result"])
+
+    def test_empty_result_returns_empty_list(self):
+        import metadata_listing  # type: ignore
+        with mock.patch.object(
+            metadata_listing, "run_sf",
+            return_value={"status": 0, "result": []},
+        ):
+            rows = metadata_listing.list_prompt_template_metadata("test-org")
+        self.assertEqual(rows, [])
+
+    def test_malformed_result_returns_empty_list(self):
+        """Defensive: if sf CLI's `result` key is not a list (e.g. None
+        on some error paths that still exit 0), we degrade to []."""
+        import metadata_listing  # type: ignore
+        with mock.patch.object(
+            metadata_listing, "run_sf",
+            return_value={"status": 0, "result": None},
+        ):
+            rows = metadata_listing.list_prompt_template_metadata("test-org")
+        self.assertEqual(rows, [])
+
+
+class FetchWaveBPromptTemplateMetadataWiringTests(unittest.TestCase):
+    """Bug 1 fix (2026-05-05): `_fetch_wave_b_by_names` invokes
+    `list_prompt_template_metadata` (Metadata API listing), then filters +
+    reshapes to the {Id, DeveloperName} shape the downstream pipeline
+    expects. Verify the filter + reshape contract — only the requested
+    Ids come back, keyed as the pipeline's existing prompt_template_id_rows
+    shape.
+    """
+
+    def test_listmetadata_rows_filtered_and_reshaped(self):
+        with mock.patch.object(
+            main, "list_prompt_template_metadata",
+            return_value=[
+                {"id": "0hfAAA", "fullName": "TplA",
+                 "type": "GenAiPromptTemplate"},
+                {"id": "0hfBBB", "fullName": "TplB",
+                 "type": "GenAiPromptTemplate"},
+            ],
+        ):
+            with mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]), \
+                 mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]), \
+                 mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=[]), \
+                 mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]):
+                out = main._fetch_wave_b_by_names(
+                    apex_names=[],
+                    apex_ids=[],
+                    flow_names=[],
+                    flow_ids=[],
+                    prompt_template_ids=["0hfAAA"],
+                    creds_provider=lambda: ("url", "tok"),
+                    refresh_fn=lambda: ("url", "tok"),
+                    api_version="v60.0",
+                    org_alias="test-org",
+                    parallelism=2,
+                )
+        # Only the requested Id survives (0hfAAA); 0hfBBB is filtered out.
+        # The shape matches the old SOQL contract: {Id, DeveloperName}.
+        self.assertEqual(
+            out["prompt_template_id_rows"],
+            [{"Id": "0hfAAA", "DeveloperName": "TplA"}],
+        )
+
+    def test_listmetadata_failure_non_fatal(self):
+        """SfCliError from the Metadata listing is caught and surfaced via
+        the unresolved channel; the run continues with an empty rowset."""
+        from sf_cli import SfCliError  # type: ignore
+        with mock.patch.object(
+            main, "list_prompt_template_metadata",
+            side_effect=SfCliError("metadata-listing-exploded"),
+        ):
+            with mock.patch.object(main, "fetch_apex_bodies_by_names", return_value=[]), \
+                 mock.patch.object(main, "fetch_apex_bodies_by_ids", return_value=[]), \
+                 mock.patch.object(main, "fetch_flow_definition_ids_by_names", return_value=[]), \
+                 mock.patch.object(main, "fetch_flow_definition_by_ids", return_value=[]):
+                out = main._fetch_wave_b_by_names(
+                    apex_names=[],
+                    apex_ids=[],
+                    flow_names=[],
+                    flow_ids=[],
+                    prompt_template_ids=["0hfAAA"],
+                    creds_provider=lambda: ("url", "tok"),
+                    refresh_fn=lambda: ("url", "tok"),
+                    api_version="v60.0",
+                    org_alias="test-org",
+                    parallelism=2,
+                )
+        self.assertEqual(out["prompt_template_id_rows"], [])
+        reasons = [u.get("reason") or "" for u in out["unresolved"]]
+        self.assertTrue(
+            any("prompt-template-listmetadata-failed" in r for r in reasons),
+            f"expected listmetadata-failed in unresolved; got {reasons}",
+        )
+
+
+class RetrievePromptTemplatesTests(unittest.TestCase):
+    """Gap C (2026-05-05): unit tests for
+    `metadata_listing.retrieve_prompt_templates` — the sf CLI wrapper
+    that retrieves GenAiPromptTemplate bodies via
+    `sf project retrieve start --metadata GenAiPromptTemplate:...`.
+
+    The helper:
+      1. Short-circuits on empty input (no sf call).
+      2. Parses `unpackaged.zip` from the retrieve dir via stdlib
+         `zipfile` + `xml.etree.ElementTree`.
+      3. Extracts developerName/masterLabel/activeVersionIdentifier/
+         templateVersions[*].content/inputs[*].
+      4. Returns `{}` on SfCliError (non-fatal — main.py's call site
+         logs an `_unresolved[]` entry).
+      5. Skips files whose XML fails to parse; sibling templates still
+         surface.
+    """
+
+    def _run_retrieve_writes_zip(self, files: dict):
+        """Build a mock `_run_retrieve` side_effect that writes an
+        unpackaged.zip into the retrieve dir as the real CLI would.
+
+        `files = {inner_path: xml_bytes}`. `retrieve_prompt_templates`
+        wipes the retrieve dir before invoking the subprocess, so the zip
+        MUST be created by the mock (the retrieve dir is always the
+        `--target-metadata-dir` argv element)."""
+        import zipfile
+
+        def _side_effect(argv, timeout):
+            target_dir = Path(argv[argv.index("--target-metadata-dir") + 1])
+            target_dir.mkdir(parents=True, exist_ok=True)
+            zip_path = target_dir / "unpackaged.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                for inner, xml_bytes in files.items():
+                    zf.writestr(inner, xml_bytes)
+            return subprocess.CompletedProcess(
+                argv, returncode=0, stdout='{"status":0,"result":{}}', stderr="",
+            )
+
+        return _side_effect
+
+    def test_empty_input_short_circuits_without_sf_call(self):
+        import metadata_listing  # type: ignore
+        with mock.patch.object(metadata_listing, "_run_retrieve") as mrun, \
+             tempfile.TemporaryDirectory() as d:
+            result = metadata_listing.retrieve_prompt_templates(
+                "org-alias", [], Path(d),
+            )
+        self.assertEqual(result, {})
+        mrun.assert_not_called()
+
+    def test_happy_path_single_template(self):
+        import metadata_listing  # type: ignore
+        xml = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">'
+            b'<developerName>My_Prompt</developerName>'
+            b'<masterLabel>My Prompt</masterLabel>'
+            b'<activeVersionIdentifier>v1</activeVersionIdentifier>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v1</versionIdentifier>'
+            b'<content># ROLE\nHello {{$Input:Query}}</content>'
+            b'<inputs><apiName>Query</apiName><dataType>String</dataType></inputs>'
+            b'</templateVersions>'
+            b'</GenAiPromptTemplate>'
+        )
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            side_effect = self._run_retrieve_writes_zip({
+                "unpackaged/genAiPromptTemplates/My_Prompt.genAiPromptTemplate": xml,
+                "unpackaged/package.xml": b"<Package/>",
+            })
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", side_effect=side_effect,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["My_Prompt"], tmp,
+                )
+        self.assertIn("My_Prompt", result)
+        body = result["My_Prompt"]
+        self.assertEqual(body["developerName"], "My_Prompt")
+        self.assertEqual(body["masterLabel"], "My Prompt")
+        self.assertEqual(body["activeVersionIdentifier"], "v1")
+        self.assertEqual(body["content"], "# ROLE\nHello {{$Input:Query}}")
+        self.assertEqual(
+            body["inputs"], [{"name": "Query", "dataType": "String"}],
+        )
+
+    def test_sf_cli_error_returns_empty_dict(self):
+        """Non-zero exit without auth-pattern stderr is swallowed as
+        non-fatal — caller gets an empty dict."""
+        import metadata_listing  # type: ignore
+        failure = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Error: retrieve blew up",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", return_value=failure,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["Foo"], Path(d),
+                )
+        self.assertEqual(result, {})
+
+    def test_auth_required_reraises(self):
+        """Non-zero exit WITH auth-pattern stderr raises AuthRequired."""
+        import metadata_listing  # type: ignore
+        from sf_cli import AuthRequired  # type: ignore
+        failure = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="",
+            stderr="Error: NoOrgAuthenticationError — login required",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", return_value=failure,
+            ):
+                with self.assertRaises(AuthRequired):
+                    metadata_listing.retrieve_prompt_templates(
+                        "org-alias", ["Foo"], Path(d),
+                    )
+
+    def test_missing_zip_returns_empty_dict(self):
+        import metadata_listing  # type: ignore
+        # _run_retrieve succeeds but leaves no unpackaged.zip on disk.
+        success_no_zip = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"status":0,"result":{}}', stderr="",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", return_value=success_no_zip,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["Foo"], Path(d),
+                )
+        self.assertEqual(result, {})
+
+    def test_multi_version_picks_active(self):
+        import metadata_listing  # type: ignore
+        xml = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">'
+            b'<developerName>Versioned</developerName>'
+            b'<activeVersionIdentifier>v2</activeVersionIdentifier>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v1</versionIdentifier>'
+            b'<content>OLD</content>'
+            b'</templateVersions>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v2</versionIdentifier>'
+            b'<content>ACTIVE</content>'
+            b'</templateVersions>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v3</versionIdentifier>'
+            b'<content>DRAFT</content>'
+            b'</templateVersions>'
+            b'</GenAiPromptTemplate>'
+        )
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            side_effect = self._run_retrieve_writes_zip({
+                "unpackaged/genAiPromptTemplates/Versioned.genAiPromptTemplate": xml,
+            })
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", side_effect=side_effect,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["Versioned"], tmp,
+                )
+        self.assertEqual(result["Versioned"]["content"], "ACTIVE")
+
+    def test_template_with_no_inputs(self):
+        import metadata_listing  # type: ignore
+        xml = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">'
+            b'<developerName>NoInputs</developerName>'
+            b'<activeVersionIdentifier>v1</activeVersionIdentifier>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v1</versionIdentifier>'
+            b'<content>Prompt body</content>'
+            b'</templateVersions>'
+            b'</GenAiPromptTemplate>'
+        )
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            side_effect = self._run_retrieve_writes_zip({
+                "unpackaged/genAiPromptTemplates/NoInputs.genAiPromptTemplate": xml,
+            })
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", side_effect=side_effect,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["NoInputs"], tmp,
+                )
+        self.assertEqual(result["NoInputs"]["inputs"], [])
+
+    def test_xml_parse_failure_skips_file_continues(self):
+        """Malformed XML on one template must not prevent sibling
+        templates from surfacing."""
+        import metadata_listing  # type: ignore
+        good_xml = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">'
+            b'<developerName>GoodTpl</developerName>'
+            b'<activeVersionIdentifier>v1</activeVersionIdentifier>'
+            b'<templateVersions>'
+            b'<versionIdentifier>v1</versionIdentifier>'
+            b'<content>Fine</content>'
+            b'</templateVersions>'
+            b'</GenAiPromptTemplate>'
+        )
+        broken_xml = b"<not valid xml"
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            side_effect = self._run_retrieve_writes_zip({
+                "unpackaged/genAiPromptTemplates/GoodTpl.genAiPromptTemplate": good_xml,
+                "unpackaged/genAiPromptTemplates/Broken.genAiPromptTemplate": broken_xml,
+            })
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", side_effect=side_effect,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["GoodTpl", "Broken"], tmp,
+                )
+        self.assertIn("GoodTpl", result)
+        self.assertNotIn("Broken", result)
+
+    def test_stale_retrieve_dir_contents_wiped(self):
+        """A prior invocation's `unpackaged.zip` must not be trusted if
+        this run's sf call fails before writing a new one."""
+        import metadata_listing  # type: ignore
+        failure = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Error: boom",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            # Plant a stale zip pretending a prior run left it.
+            stale = tmp / "prompt_template_retrieve"
+            stale.mkdir(parents=True, exist_ok=True)
+            (stale / "unpackaged.zip").write_bytes(b"stale")
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", return_value=failure,
+            ):
+                result = metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["Foo"], tmp,
+                )
+        self.assertEqual(result, {})
+        # Stale file should have been nuked before the sf call.
+        self.assertFalse((stale / "unpackaged.zip").exists())
+
+    def test_retrieve_builds_one_metadata_flag_per_name(self):
+        """Live proof (2026-05-05): `sf project retrieve start` treats a
+        comma-joined `--metadata TypeA:A,TypeA:B` as ONE malformed member
+        name and silently produces a package-xml-only zip. The fix is to
+        repeat `--metadata` once per template. Lock that shape in."""
+        import metadata_listing  # type: ignore
+        captured_argv: list[list[str]] = []
+
+        def _capture(argv, timeout):
+            captured_argv.append(list(argv))
+            return subprocess.CompletedProcess(
+                argv, returncode=0,
+                stdout='{"status":0,"result":{}}', stderr="",
+            )
+
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(
+                metadata_listing, "_run_retrieve", side_effect=_capture,
+            ):
+                metadata_listing.retrieve_prompt_templates(
+                    "org-alias", ["A", "B", "C"], Path(d),
+                )
+
+        self.assertEqual(len(captured_argv), 1)
+        argv = captured_argv[0]
+        self.assertEqual(argv.count("--metadata"), 3)
+        # Each `--metadata` flag MUST be followed by a single
+        # `GenAiPromptTemplate:<name>` — never a comma-joined string.
+        for name in ("A", "B", "C"):
+            spec = f"GenAiPromptTemplate:{name}"
+            idx = argv.index(spec)
+            self.assertEqual(argv[idx - 1], "--metadata")
+            self.assertNotIn(",", spec)
+
+
+class CollectPromptTemplateNamesTests(unittest.TestCase):
+    """Gap C: `_collect_prompt_template_names` walks topics + plannerActions
+    and returns the set of DeveloperNames that should be passed to
+    `retrieve_prompt_templates`. Defensive against residual 0hf-Ids
+    (normalization missed) so the retrieve CLI doesn't get a malformed
+    spec."""
+
+    def test_collects_topic_action_names(self):
+        bundle = {
+            "topics": [{
+                "actions": [
+                    {"invocationTarget": "Foo_Tpl",
+                     "invocationTargetType": "GenAiPromptTemplate"},
+                    {"invocationTarget": "Bar_Tpl",
+                     "invocationTargetType": "generatePromptResponse"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        names = main._collect_prompt_template_names(bundle)
+        self.assertEqual(names, {"Foo_Tpl", "Bar_Tpl"})
+
+    def test_collects_planner_action_names(self):
+        bundle = {
+            "topics": [],
+            "plannerActions": [
+                {"invocationTarget": "Planner_Tpl",
+                 "invocationTargetType": "GenAiPromptTemplate"},
+            ],
+        }
+        names = main._collect_prompt_template_names(bundle)
+        self.assertEqual(names, {"Planner_Tpl"})
+
+    def test_skips_non_prompt_ttype(self):
+        bundle = {
+            "topics": [{
+                "actions": [
+                    {"invocationTarget": "MyFlow",
+                     "invocationTargetType": "flow"},
+                    {"invocationTarget": "MyApex",
+                     "invocationTargetType": "apex"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        names = main._collect_prompt_template_names(bundle)
+        self.assertEqual(names, set())
+
+    def test_skips_residual_0hf_id_targets(self):
+        """If normalization missed an Id (template not in org
+        list-metadata), don't send a malformed spec to retrieve."""
+        bundle = {
+            "topics": [{
+                "actions": [
+                    {"invocationTarget": "0hfUv0000021mCjIAI",
+                     "invocationTargetType": "GenAiPromptTemplate"},
+                    {"invocationTarget": "Clean_Tpl",
+                     "invocationTargetType": "GenAiPromptTemplate"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        names = main._collect_prompt_template_names(bundle)
+        self.assertEqual(names, {"Clean_Tpl"})
+
+
+class PromptTemplateBodyAttachmentTests(unittest.TestCase):
+    """Gap C: `_stamp_prompt_template_bodies` attaches retrieved body
+    fields onto matching PROMPT_TEMPLATE leaves. Unmatched leaves get
+    `_body_available = False` so the renderer can distinguish a failed
+    retrieve from a successfully-empty body."""
+
+    def test_stamps_body_onto_matching_leaf(self):
+        tree = {
+            "root": {
+                "kind": "BOT_DEFINITION",
+                "children": [{
+                    "kind": "TOPIC", "api_name": "T",
+                    "children": [{
+                        "kind": "GEN_AI_FUNCTION", "api_name": "F",
+                        "children": [{
+                            "kind": "PROMPT_TEMPLATE", "api_name": "Tpl",
+                        }],
+                    }],
+                }],
+            },
+        }
+        bodies = {
+            "Tpl": {
+                "developerName": "Tpl",
+                "masterLabel": "Template One",
+                "activeVersionIdentifier": "v1",
+                "content": "Prompt body",
+                "inputs": [{"name": "Q", "dataType": "String"}],
+            },
+        }
+        main._stamp_prompt_template_bodies(tree["root"], bodies)
+        leaf = tree["root"]["children"][0]["children"][0]["children"][0]
+        self.assertEqual(leaf["master_label"], "Template One")
+        self.assertEqual(leaf["content"], "Prompt body")
+        self.assertEqual(leaf["inputs"], [{"name": "Q", "dataType": "String"}])
+        self.assertTrue(leaf["_body_available"])
+
+    def test_unmatched_leaf_gets_body_available_false(self):
+        tree = {
+            "root": {
+                "kind": "BOT_DEFINITION",
+                "children": [{
+                    "kind": "PROMPT_TEMPLATE", "api_name": "Missing",
+                }],
+            },
+        }
+        main._stamp_prompt_template_bodies(tree["root"], {})
+        self.assertFalse(tree["root"]["children"][0]["_body_available"])
+        self.assertNotIn("content", tree["root"]["children"][0])
+
+    def test_does_not_touch_non_prompt_leaves(self):
+        tree = {
+            "root": {
+                "kind": "BOT_DEFINITION",
+                "children": [
+                    {"kind": "APEX", "api_name": "Cls"},
+                    {"kind": "FLOW", "api_name": "Flw"},
+                ],
+            },
+        }
+        main._stamp_prompt_template_bodies(
+            tree["root"], {"Cls": {"content": "x"}, "Flw": {"content": "y"}},
+        )
+        # Neither APEX nor FLOW leaves gain body fields.
+        self.assertNotIn("content", tree["root"]["children"][0])
+        self.assertNotIn("_body_available", tree["root"]["children"][0])
+        self.assertNotIn("content", tree["root"]["children"][1])
+        self.assertNotIn("_body_available", tree["root"]["children"][1])
+
+
+class TreeChildOrderingTests(unittest.TestCase):
+    """Schema 3.1 (2026-05-05) pins deterministic child ordering at the
+    tree's single source of truth (`finalize.sort_tree_in_place`) so
+    downstream readers see a byte-stable order regardless of Builder
+    reorder operations or SOQL result-set sequencing.
+
+    Contract:
+    - `BOT_DEFINITION.children`: TOPIC nodes first (alpha, case-insensitive);
+      non-topic plannerActions follow as a distinct trailing group.
+    - Each TOPIC's children: alpha by api_name, case-insensitive.
+    - FLOW children untouched — flow-actionCall order is semantically
+      the author's execution sequence.
+    """
+
+    def _sort(self, root: dict) -> dict:
+        from finalize import sort_tree_in_place
+        sort_tree_in_place(root)
+        return root
+
+    def test_topics_sorted_alphabetical_case_insensitive(self):
+        root = {
+            "kind": "BOT_DEFINITION",
+            "api_name": "Bot",
+            "children": [
+                {"kind": "TOPIC", "api_name": "Zeta", "children": []},
+                {"kind": "TOPIC", "api_name": "alpha", "children": []},
+                {"kind": "TOPIC", "api_name": "Mike", "children": []},
+            ],
+        }
+        self._sort(root)
+        names = [c["api_name"] for c in root["children"]]
+        self.assertEqual(names, ["alpha", "Mike", "Zeta"])
+
+    def test_topics_precede_planner_level_actions(self):
+        """Non-topic plannerAction children (e.g. a GEN_AI_FUNCTION hung
+        directly off the planner, no parent TOPIC) MUST render after all
+        TOPIC children, regardless of api_name ordering. The "planner-
+        level actions are a distinct trailing group" convention is load-
+        bearing for humans scanning the rendered tree."""
+        root = {
+            "kind": "BOT_DEFINITION",
+            "api_name": "Bot",
+            "children": [
+                # Non-topic node with an api_name that would sort FIRST
+                # alphabetically — the tier rule must override alpha.
+                {"kind": "GEN_AI_FUNCTION", "api_name": "aaa_action", "children": []},
+                {"kind": "TOPIC", "api_name": "Zeta", "children": []},
+                {"kind": "TOPIC", "api_name": "Mike", "children": []},
+            ],
+        }
+        self._sort(root)
+        kinds = [c["kind"] for c in root["children"]]
+        self.assertEqual(kinds, ["TOPIC", "TOPIC", "GEN_AI_FUNCTION"])
+        # Alpha within the TOPIC tier is preserved.
+        self.assertEqual(root["children"][0]["api_name"], "Mike")
+        self.assertEqual(root["children"][1]["api_name"], "Zeta")
+
+    def test_topic_children_sorted_alphabetical(self):
+        root = {
+            "kind": "BOT_DEFINITION",
+            "api_name": "Bot",
+            "children": [
+                {
+                    "kind": "TOPIC", "api_name": "OnlyTopic",
+                    "children": [
+                        {"kind": "GEN_AI_FUNCTION", "api_name": "Zebra"},
+                        {"kind": "GEN_AI_FUNCTION", "api_name": "apple"},
+                        {"kind": "GEN_AI_FUNCTION", "api_name": "Mango"},
+                    ],
+                },
+            ],
+        }
+        self._sort(root)
+        kids = root["children"][0]["children"]
+        self.assertEqual(
+            [c["api_name"] for c in kids],
+            ["apple", "Mango", "Zebra"],
+        )
+
+    def test_flow_children_order_preserved(self):
+        """FLOW actionCall order is the flow author's execution sequence.
+        sort_tree_in_place does NOT descend into FLOW children."""
+        root = {
+            "kind": "BOT_DEFINITION",
+            "api_name": "Bot",
+            "children": [
+                {
+                    "kind": "TOPIC", "api_name": "T",
+                    "children": [
+                        {
+                            "kind": "GEN_AI_FUNCTION", "api_name": "Fn",
+                            "children": [
+                                {
+                                    "kind": "FLOW", "api_name": "ParentFlow",
+                                    "children": [
+                                        {"kind": "APEX", "api_name": "zzz"},
+                                        {"kind": "APEX", "api_name": "aaa"},
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        self._sort(root)
+        flow = root["children"][0]["children"][0]["children"][0]
+        self.assertEqual(
+            [c["api_name"] for c in flow["children"]],
+            ["zzz", "aaa"],
+        )
+
+    def test_empty_children_noop(self):
+        root = {"kind": "BOT_DEFINITION", "api_name": "Bot", "children": []}
+        self._sort(root)
+        self.assertEqual(root["children"], [])
+
+    def test_missing_root_noop(self):
+        """Defensive — a degenerate tree shouldn't raise."""
+        from finalize import sort_tree_in_place
+        sort_tree_in_place(None)  # type: ignore[arg-type]
+        sort_tree_in_place({})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parallel_retrieve.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parallel_retrieve.py
@@ -1,0 +1,131 @@
+"""Tests for parallel_retrieve.fetch_bodies_parallel uses as_completed
+with (ok, result_or_exc) tuples — one failure MUST NOT abort the whole run.
+`executor.map()` would raise on first failure and silently cancel the rest;
+the whole point of this module is to never do that.
+"""
+from __future__ import annotations
+
+import threading
+import unittest
+import urllib.error
+
+from . import _bootstrap  # noqa: F401
+
+import parallel_retrieve  # type: ignore
+
+
+class AllSucceedTests(unittest.TestCase):
+    def test_five_out_of_five_ok(self):
+        tasks = [lambda i=i: i * 10 for i in range(5)]
+        results = parallel_retrieve.fetch_bodies_parallel(tasks, max_workers=5)
+        self.assertEqual(len(results), 5)
+        for ok, _ in results:
+            self.assertTrue(ok)
+        # Order is preserved: results[i] corresponds to tasks[i].
+        self.assertEqual([r for _, r in results], [0, 10, 20, 30, 40])
+
+
+class OneFailureTests(unittest.TestCase):
+    def test_four_ok_one_fail(self):
+        def boom():
+            raise RuntimeError("task-3-failed")
+
+        tasks = [
+            lambda: "a",
+            lambda: "b",
+            lambda: "c",
+            boom,
+            lambda: "e",
+        ]
+        results = parallel_retrieve.fetch_bodies_parallel(tasks, max_workers=3)
+        self.assertEqual(len(results), 5)
+        oks = [r[0] for r in results]
+        self.assertEqual(oks, [True, True, True, False, True])
+        # The failure slot carries the RuntimeError object, not a string.
+        self.assertIsInstance(results[3][1], RuntimeError)
+        self.assertIn("task-3-failed", str(results[3][1]))
+
+    def test_function_does_not_raise_on_failure(self):
+        """Top-level contract: one bad task does NOT abort the run."""
+        tasks = [lambda: 1, lambda: (_ for _ in ()).throw(ValueError("x"))]
+        # Must not raise.
+        results = parallel_retrieve.fetch_bodies_parallel(tasks, max_workers=2)
+        self.assertEqual(len(results), 2)
+
+
+class AllFailTests(unittest.TestCase):
+    def test_all_failures_function_still_returns(self):
+        def fail(n):
+            raise RuntimeError(f"task-{n}")
+
+        tasks = [lambda n=i: fail(n) for i in range(5)]
+        results = parallel_retrieve.fetch_bodies_parallel(tasks, max_workers=5)
+        self.assertEqual(len(results), 5)
+        for ok, exc in results:
+            self.assertFalse(ok)
+            self.assertIsInstance(exc, RuntimeError)
+
+
+class ExceptionIdentityPreservedTests(unittest.TestCase):
+    """Boundary: we must return the SAME exception object so
+    callers can run it through `rest_client.redact_error` at log time.
+    Auto-stringifying here would strip structured attrs (HTTPError.code,
+    .headers) and potentially leak tokens before redaction runs."""
+
+    def test_httperror_object_identity_preserved(self):
+        # HTTPError with a body containing a bearer token — caller is
+        # responsible for redacting at log time; we must not stringify.
+        sentinel_body = b'{"access_token":"eyJtok.secret"}'
+        exc = urllib.error.HTTPError(
+            url="https://example.com/x",
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        # Stash the body where a caller could read it later.
+        exc.body_bytes = sentinel_body  # type: ignore[attr-defined]
+
+        def raises():
+            raise exc
+
+        results = parallel_retrieve.fetch_bodies_parallel([raises], max_workers=1)
+        self.assertEqual(len(results), 1)
+        ok, returned_exc = results[0]
+        self.assertFalse(ok)
+        # Identity check — the SAME object came back.
+        self.assertIs(returned_exc, exc)
+        # Structured attrs are intact for downstream triage.
+        self.assertEqual(returned_exc.code, 429)
+        self.assertEqual(returned_exc.body_bytes, sentinel_body)
+
+
+class MaxWorkersOneSerializesTests(unittest.TestCase):
+    def test_max_workers_one_ordering_deterministic(self):
+        """With max_workers=1, tasks run one at a time — ordering is fully
+        deterministic (and matches input order since results are indexed).
+        """
+        order_seen: list[int] = []
+        lock = threading.Lock()
+
+        def make_task(n):
+            def task():
+                with lock:
+                    order_seen.append(n)
+                return n
+            return task
+
+        tasks = [make_task(i) for i in range(10)]
+        results = parallel_retrieve.fetch_bodies_parallel(tasks, max_workers=1)
+        self.assertEqual([r for _, r in results], list(range(10)))
+        # Serialized execution: tasks ran in submission order.
+        self.assertEqual(order_seen, list(range(10)))
+
+
+class EmptyTasksTests(unittest.TestCase):
+    def test_empty_list_returns_empty_list(self):
+        self.assertEqual(parallel_retrieve.fetch_bodies_parallel([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parse_bundle.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parse_bundle.py
@@ -1,0 +1,400 @@
+"""Tests for ``parse_bundle`` — Bot.bot + GenAiPlannerBundle parsing.
+
+Covers the four public functions:
+
+- ``classify_generation``    pure str → str
+- ``extract_planner_name``   reads bots/*.bot from a tmp WORK_DIR
+- ``extract_bundle``         reads genAiPlannerBundles/*.genAiPlannerBundle
+- ``atomic_write``           tmp-file + os.replace semantics
+
+All filesystem fixtures are constructed inline under ``tmp_path`` — no
+external fixture files needed. XML mirrors the real Salesforce metadata
+shape (sf: namespace) so the parser exercises its real code path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import parse_bundle  # type: ignore
+
+
+SF_NS = "http://soap.sforce.com/2006/04/metadata"
+
+
+def _bot_xml(version: str, planner_name: str | None = "MyPlanner") -> str:
+    """Minimal Bot.bot XML with one botVersions block.
+
+    If ``planner_name`` is None, omit the <conversationDefinitionPlanners>
+    block — caller can use this to exercise the empty-planner branch.
+    """
+    cdp_block = (
+        f"""    <conversationDefinitionPlanners>
+      <genAiPlannerName>{planner_name}</genAiPlannerName>
+    </conversationDefinitionPlanners>"""
+        if planner_name is not None
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Bot xmlns="{SF_NS}">
+  <botVersions>
+    <fullName>{version}</fullName>
+{cdp_block}
+  </botVersions>
+</Bot>
+"""
+
+
+def _bundle_xml(
+    *,
+    planner_type: str = "Atlas__Reasoning",
+    description: str = "demo",
+    master_label: str = "Demo",
+    topics: list[dict] | None = None,
+    planner_actions: list[dict] | None = None,
+) -> str:
+    """Build a genAiPlannerBundle XML body.
+
+    Each topic dict supports keys ``name``, ``actions`` (list of dicts with
+    keys ``name``, ``invocationTarget``, ``invocationTargetType``).
+    """
+    topics = topics or []
+    planner_actions = planner_actions or []
+
+    def _topic_xml(t: dict) -> str:
+        actions = "".join(
+            f"""    <localActions>
+      <developerName>{a['name']}</developerName>
+      <invocationTarget>{a.get('invocationTarget', '')}</invocationTarget>
+      <invocationTargetType>{a.get('invocationTargetType', '')}</invocationTargetType>
+    </localActions>
+"""
+            for a in t.get("actions", [])
+        )
+        return f"""  <localTopics>
+    <developerName>{t['name']}</developerName>
+    <masterLabel>{t.get('masterLabel', '')}</masterLabel>
+    <canEscalate>{str(t.get('canEscalate', False)).lower()}</canEscalate>
+{actions}  </localTopics>
+"""
+
+    def _planner_action_xml(a: dict) -> str:
+        return f"""  <plannerActions>
+    <developerName>{a['name']}</developerName>
+    <invocationTarget>{a.get('invocationTarget', '')}</invocationTarget>
+    <invocationTargetType>{a.get('invocationTargetType', '')}</invocationTargetType>
+  </plannerActions>
+"""
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<GenAiPlannerBundle xmlns="{SF_NS}">
+  <plannerType>{planner_type}</plannerType>
+  <description>{description}</description>
+  <masterLabel>{master_label}</masterLabel>
+{''.join(_topic_xml(t) for t in topics)}{''.join(_planner_action_xml(a) for a in planner_actions)}</GenAiPlannerBundle>
+"""
+
+
+# -----------------------------------------------------------------------------
+# classify_generation — pure str → str
+# -----------------------------------------------------------------------------
+
+
+class ClassifyGenerationTests(unittest.TestCase):
+
+    def test_aicopilot_prefix_classifies_as_classic(self):
+        self.assertEqual(parse_bundle.classify_generation("AiCopilot__Foo"), "classic")
+
+    def test_atlas_prefix_classifies_as_nga(self):
+        self.assertEqual(parse_bundle.classify_generation("Atlas__Reasoning"), "nga")
+
+    def test_unknown_prefix_classifies_as_unknown(self):
+        self.assertEqual(parse_bundle.classify_generation("SomethingElse"), "unknown")
+
+    def test_empty_string_classifies_as_unknown(self):
+        self.assertEqual(parse_bundle.classify_generation(""), "unknown")
+
+    def test_none_classifies_as_unknown(self):
+        self.assertEqual(parse_bundle.classify_generation(None), "unknown")  # type: ignore[arg-type]
+
+
+# -----------------------------------------------------------------------------
+# extract_planner_name — reads bots/*.bot under WORK_DIR
+# -----------------------------------------------------------------------------
+
+
+class ExtractPlannerNameTests(unittest.TestCase):
+
+    def _setup_bot(self, tmp: Path, version: str, planner_name: str | None = "MyPlanner") -> Path:
+        bots_dir = tmp / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+        bots_dir.mkdir(parents=True)
+        bot_file = bots_dir / "MyAgent.bot"
+        bot_file.write_text(_bot_xml(version, planner_name))
+        return tmp
+
+    def test_returns_planner_name_when_botversion_matches(self):
+        with TemporaryDirectory() as t:
+            tmp = self._setup_bot(Path(t), "v1", "MyPlanner")
+            self.assertEqual(parse_bundle.extract_planner_name(tmp, "v1"), "MyPlanner")
+
+    def test_returns_empty_when_botversion_does_not_match(self):
+        with TemporaryDirectory() as t:
+            tmp = self._setup_bot(Path(t), "v1", "MyPlanner")
+            self.assertEqual(parse_bundle.extract_planner_name(tmp, "v99"), "")
+
+    def test_returns_empty_when_no_planner_block(self):
+        # Bot has the right version but no <conversationDefinitionPlanners>
+        with TemporaryDirectory() as t:
+            tmp = self._setup_bot(Path(t), "v1", planner_name=None)
+            self.assertEqual(parse_bundle.extract_planner_name(tmp, "v1"), "")
+
+    def test_returns_empty_when_bots_dir_missing(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)  # no sf_meta/wave1_bot/...
+            self.assertEqual(parse_bundle.extract_planner_name(tmp, "v1"), "")
+
+    def test_returns_empty_when_xml_is_malformed(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            bots_dir = tmp / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+            bots_dir.mkdir(parents=True)
+            (bots_dir / "Broken.bot").write_text("<<<not xml>>>")
+            self.assertEqual(parse_bundle.extract_planner_name(tmp, "v1"), "")
+
+    def test_falls_back_to_plannerName_then_fullName(self):
+        # Build a bot with sf:plannerName instead of sf:genAiPlannerName.
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            bots_dir = tmp / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+            bots_dir.mkdir(parents=True)
+            (bots_dir / "Fallback.bot").write_text(f"""<?xml version="1.0" encoding="UTF-8"?>
+<Bot xmlns="{SF_NS}">
+  <botVersions>
+    <fullName>v1</fullName>
+    <conversationDefinitionPlanners>
+      <plannerName>FallbackPlanner</plannerName>
+    </conversationDefinitionPlanners>
+  </botVersions>
+</Bot>
+""")
+            self.assertEqual(
+                parse_bundle.extract_planner_name(tmp, "v1"),
+                "FallbackPlanner",
+            )
+
+
+# -----------------------------------------------------------------------------
+# extract_bundle — reads genAiPlannerBundles/*.genAiPlannerBundle
+# -----------------------------------------------------------------------------
+
+
+class ExtractBundleTests(unittest.TestCase):
+
+    def _setup_bundle(self, tmp: Path, body: str, dirname: str = "MyPlanner") -> None:
+        bundle_dir = (
+            tmp / "sf_meta" / "wave1_bundle" / "unpackaged" / "genAiPlannerBundles" / dirname
+        )
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "MyPlanner.genAiPlannerBundle").write_text(body)
+
+    def test_returns_skeleton_when_planner_dir_missing(self):
+        with TemporaryDirectory() as t:
+            out = parse_bundle.extract_bundle(Path(t), "MyPlanner")
+        self.assertEqual(out["topics"], [])
+        self.assertEqual(out["plannerActions"], [])
+        self.assertEqual(out["plannerType"], None)
+        self.assertEqual(out["plannerName"], "MyPlanner")
+        self.assertEqual(out["generation"], "unknown")
+
+    def test_extracts_planner_type_description_and_master_label(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            self._setup_bundle(tmp, _bundle_xml(
+                planner_type="Atlas__Reasoning",
+                description="My agent",
+                master_label="My Agent",
+            ))
+            out = parse_bundle.extract_bundle(tmp, "MyPlanner")
+        self.assertEqual(out["plannerType"], "Atlas__Reasoning")
+        self.assertEqual(out["description"], "My agent")
+        self.assertEqual(out["masterLabel"], "My Agent")
+        self.assertEqual(out["generation"], "nga")
+
+    def test_extracts_topics_with_localActions(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            self._setup_bundle(tmp, _bundle_xml(topics=[{
+                "name": "Greetings",
+                "masterLabel": "Greetings",
+                "actions": [
+                    {"name": "Hello", "invocationTarget": "say_hello",
+                     "invocationTargetType": "apex"},
+                    {"name": "Bye", "invocationTarget": "say_bye",
+                     "invocationTargetType": "apex"},
+                ],
+            }]))
+            out = parse_bundle.extract_bundle(tmp, "MyPlanner")
+        self.assertEqual(len(out["topics"]), 1)
+        self.assertEqual(out["topics"][0]["name"], "Greetings")
+        self.assertEqual(len(out["topics"][0]["actions"]), 2)
+        self.assertEqual(out["topics"][0]["actions"][0]["name"], "Hello")
+        self.assertEqual(out["topics"][0]["actions"][0]["invocationTargetType"], "apex")
+
+    def test_extracts_plannerActions_classic_shape(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            self._setup_bundle(tmp, _bundle_xml(
+                planner_type="AiCopilot__Foo",
+                planner_actions=[
+                    {"name": "Search", "invocationTarget": "search",
+                     "invocationTargetType": "flow"},
+                ],
+            ))
+            out = parse_bundle.extract_bundle(tmp, "MyPlanner")
+        self.assertEqual(out["generation"], "classic")
+        self.assertEqual(len(out["plannerActions"]), 1)
+        self.assertEqual(out["plannerActions"][0]["name"], "Search")
+
+    def test_skips_topic_without_developerName(self):
+        # Build XML where one topic has no <developerName> — should be dropped.
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            broken = f"""<?xml version="1.0" encoding="UTF-8"?>
+<GenAiPlannerBundle xmlns="{SF_NS}">
+  <plannerType>Atlas__Reasoning</plannerType>
+  <localTopics>
+    <masterLabel>NoName</masterLabel>
+  </localTopics>
+  <localTopics>
+    <developerName>Good</developerName>
+  </localTopics>
+</GenAiPlannerBundle>
+"""
+            self._setup_bundle(tmp, broken)
+            out = parse_bundle.extract_bundle(tmp, "MyPlanner")
+        self.assertEqual(len(out["topics"]), 1)
+        self.assertEqual(out["topics"][0]["name"], "Good")
+
+    def test_returns_skeleton_when_xml_is_malformed(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            self._setup_bundle(tmp, "<<<broken>>>")
+            out = parse_bundle.extract_bundle(tmp, "MyPlanner")
+        # Malformed → no fields populated, but skeleton shape preserved.
+        self.assertEqual(out["topics"], [])
+        self.assertEqual(out["plannerActions"], [])
+        self.assertEqual(out["plannerType"], None)
+
+
+# -----------------------------------------------------------------------------
+# atomic_write — tmp-file + os.replace
+# -----------------------------------------------------------------------------
+
+
+class AtomicWriteTests(unittest.TestCase):
+
+    def test_writes_content_to_target_path(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.txt"
+            parse_bundle.atomic_write(target, "hello\n")
+            self.assertEqual(target.read_text(), "hello\n")
+
+    def test_overwrites_existing_file(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.txt"
+            target.write_text("old")
+            parse_bundle.atomic_write(target, "new")
+            self.assertEqual(target.read_text(), "new")
+
+    def test_no_tmp_file_left_behind_after_success(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.txt"
+            parse_bundle.atomic_write(target, "x")
+            # the .tmp sibling should NOT remain
+            tmp_sibling = target.with_suffix(target.suffix + ".tmp")
+            self.assertFalse(tmp_sibling.exists())
+
+
+# -----------------------------------------------------------------------------
+# main() — orchestration via env vars
+# -----------------------------------------------------------------------------
+
+
+class MainTests(unittest.TestCase):
+
+    def _setup_full_workdir(self, tmp: Path) -> None:
+        # Bot file
+        bots_dir = tmp / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+        bots_dir.mkdir(parents=True)
+        (bots_dir / "MyAgent.bot").write_text(_bot_xml("v1", "MyPlanner"))
+        # Bundle file
+        bundle_dir = (
+            tmp / "sf_meta" / "wave1_bundle" / "unpackaged"
+            / "genAiPlannerBundles" / "MyPlanner"
+        )
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "MyPlanner.genAiPlannerBundle").write_text(_bundle_xml())
+
+    def test_main_writes_bundle_parsed_json_and_returns_zero(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            self._setup_full_workdir(tmp)
+            old = dict(os.environ)
+            os.environ["WORK_DIR"] = str(tmp)
+            os.environ["AGENT_VERSION"] = "v1"
+            try:
+                rc = parse_bundle.main()
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+            self.assertEqual(rc, 0)
+            parsed = json.loads((tmp / "_bundle_parsed.json").read_text())
+            self.assertEqual(parsed["plannerName"], "MyPlanner")
+            self.assertEqual(parsed["plannerType"], "Atlas__Reasoning")
+            self.assertEqual(parsed["generation"], "nga")
+            # _agent_generation.txt is newline-terminated for shell sourcing
+            self.assertEqual(
+                (tmp / "_agent_generation.txt").read_text(), "nga\n"
+            )
+
+    def test_main_returns_one_when_env_missing(self):
+        # Both WORK_DIR and AGENT_VERSION required; remove WORK_DIR.
+        old = dict(os.environ)
+        os.environ.pop("WORK_DIR", None)
+        os.environ["AGENT_VERSION"] = "v1"
+        try:
+            rc = parse_bundle.main()
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+        self.assertEqual(rc, 1)
+
+    def test_main_emits_empty_skeleton_when_planner_unresolved(self):
+        # Bot file has no <conversationDefinitionPlanners> → planner_name == ""
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            bots_dir = tmp / "sf_meta" / "wave1_bot" / "unpackaged" / "bots"
+            bots_dir.mkdir(parents=True)
+            (bots_dir / "MyAgent.bot").write_text(_bot_xml("v1", planner_name=None))
+            old = dict(os.environ)
+            os.environ["WORK_DIR"] = str(tmp)
+            os.environ["AGENT_VERSION"] = "v1"
+            try:
+                rc = parse_bundle.main()
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+            self.assertEqual(rc, 0)
+            parsed = json.loads((tmp / "_bundle_parsed.json").read_text())
+            self.assertIsNone(parsed["plannerName"])
+            self.assertEqual(parsed["topics"], [])
+            self.assertEqual((tmp / "_agent_generation.txt").read_text(), "unknown\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave.py
@@ -1,0 +1,644 @@
+"""Tests for parse_wave BFS + inflate uses (kind, canonical_name)
+tuple-keyed visited tracking. A flat per-name visited set would silently
+drop the second of two same-named different-kind nodes (Flow Foo + Apex Foo),
+and would infinite-loop / depth-cap on self-cycles without annotation.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import parse_wave  # type: ignore
+
+
+class BfsStepTupleKeyingTests(unittest.TestCase):
+    """Same-name, different-kind refs must not collide."""
+
+    def test_flow_and_apex_same_name_are_distinct(self):
+        pending = {k: set() for k in parse_wave._BFS_KINDS}
+        visited = {k: set() for k in parse_wave._BFS_KINDS}
+        new_refs = {"FLOW": {"Foo"}, "APEX": {"Foo"}}
+
+        merged, cycles = parse_wave.bfs_step(pending, visited, new_refs)
+
+        self.assertIn("Foo", merged["FLOW"])
+        self.assertIn("Foo", merged["APEX"])
+        self.assertEqual(cycles, [])
+
+    def test_already_visited_ref_skipped_and_recorded_as_cycle(self):
+        pending = {k: set() for k in parse_wave._BFS_KINDS}
+        visited = {k: set() for k in parse_wave._BFS_KINDS}
+        visited["FLOW"] = {"Foo"}  # simulate prior wave visit
+        new_refs = {"FLOW": {"Foo", "Bar"}}
+
+        merged, cycles = parse_wave.bfs_step(pending, visited, new_refs)
+
+        self.assertNotIn("Foo", merged["FLOW"])  # filtered out
+        self.assertIn("Bar", merged["FLOW"])
+        self.assertIn(("FLOW", "Foo"), cycles)
+
+    def test_cross_type_cycle_is_distinct(self):
+        """Flow Foo visited does not mask Apex Foo on the same wave."""
+        pending = {k: set() for k in parse_wave._BFS_KINDS}
+        visited = {k: set() for k in parse_wave._BFS_KINDS}
+        visited["FLOW"] = {"Foo"}
+        new_refs = {"FLOW": {"Foo"}, "APEX": {"Foo"}}
+
+        merged, cycles = parse_wave.bfs_step(pending, visited, new_refs)
+
+        self.assertEqual(merged["FLOW"], set())  # Foo is visited
+        self.assertEqual(merged["APEX"], {"Foo"})  # distinct kind → keeps
+        self.assertIn(("FLOW", "Foo"), cycles)
+        self.assertNotIn(("APEX", "Foo"), cycles)
+
+    def test_empty_initial_pending_terminates(self):
+        pending = {k: set() for k in parse_wave._BFS_KINDS}
+        visited = {k: set() for k in parse_wave._BFS_KINDS}
+        merged, cycles = parse_wave.bfs_step(pending, visited, {})
+        self.assertEqual(cycles, [])
+        for k in parse_wave._BFS_KINDS:
+            self.assertEqual(merged[k], set())
+
+    def test_unknown_kind_raises(self):
+        """unknown BFS kinds raise ValueError — bfs_step is an
+        internal API and a typo in a caller is a programming error, not a
+        runtime condition we can silently paper over. Silent-drop produced
+        false confidence: the ref was never fetched and no log mentioned it.
+        """
+        pending = {k: set() for k in parse_wave._BFS_KINDS}
+        visited = {k: set() for k in parse_wave._BFS_KINDS}
+        new_refs = {"NOT_A_KIND": {"X"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            parse_wave.bfs_step(pending, visited, new_refs)
+
+        self.assertIn("unknown BFS kind", ctx.exception.args[0])
+
+
+class InflateCycleDetectionTests(unittest.TestCase):
+    """`inflate_flow_leaf` must terminate on self-cycles and annotate
+    `_cycle_back_to` on the repeat node."""
+
+    def test_self_cycle_flow_a_calls_subflow_a(self):
+        """Flow A → subflow A — one real node + a stub child with cycle tag."""
+        flow_children = {
+            "A": [
+                {"kind": "FLOW", "element_name": "recurse", "api_name": "A"},
+            ],
+        }
+        leaf = {"kind": "FLOW", "api_name": "A", "children": []}
+
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+
+        self.assertEqual(len(leaf["children"]), 1)
+        child = leaf["children"][0]
+        self.assertEqual(child["kind"], "FLOW")
+        self.assertEqual(child["api_name"], "A")
+        self.assertEqual(child.get("_cycle_back_to"), "FLOW:A")
+        # Must NOT have expanded children on the cycle stub.
+        self.assertEqual(child.get("children", []), [])
+
+    def test_cross_type_cycle_flow_a_to_apex_b_to_flow_a(self):
+        """Flow A → Apex B (leaf) → nothing (Apex doesn't recurse in inflate).
+
+        The inflate layer only descends through FLOW→FLOW. A cycle through
+        Apex would be caught at the BFS layer (bfs_step), not here. This
+        test confirms the inflate layer doesn't misclassify a FLOW→APEX
+        edge as a cycle and doesn't over-recurse on it.
+        """
+        flow_children = {
+            "A": [
+                {"kind": "APEX", "element_name": "callApex", "api_name": "B"},
+            ],
+        }
+        leaf = {"kind": "FLOW", "api_name": "A", "children": []}
+
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+
+        self.assertEqual(len(leaf["children"]), 1)
+        self.assertEqual(leaf["children"][0]["kind"], "APEX")
+        self.assertNotIn("_cycle_back_to", leaf["children"][0])
+
+    def test_three_layer_linear_graph_fully_expanded(self):
+        """A → B → C — each Flow visited once, no false cycle tags."""
+        flow_children = {
+            "A": [{"kind": "FLOW", "element_name": "callB", "api_name": "B"}],
+            "B": [{"kind": "FLOW", "element_name": "callC", "api_name": "C"}],
+            "C": [],
+        }
+        leaf = {"kind": "FLOW", "api_name": "A", "children": []}
+
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+
+        # A has one child: B
+        self.assertEqual(len(leaf["children"]), 1)
+        b = leaf["children"][0]
+        self.assertEqual(b["api_name"], "B")
+        self.assertNotIn("_cycle_back_to", b)
+        # B has one child: C
+        self.assertEqual(len(b["children"]), 1)
+        c = b["children"][0]
+        self.assertEqual(c["api_name"], "C")
+        self.assertNotIn("_cycle_back_to", c)
+        # C has no children (empty list in flow_children)
+        self.assertEqual(c.get("children", []), [])
+
+    def test_sibling_flows_sharing_target_not_cross_contaminated(self):
+        """If Flow X is called by two different siblings, both sibling
+        branches must fully expand X — not prune the second as a cycle.
+
+        Frozenset path-visited semantics protect this: siblings don't see
+        each other's descent. A mutable shared set would cause the second
+        sibling to treat X as a cycle.
+        """
+        flow_children = {
+            "Root": [
+                {"kind": "FLOW", "element_name": "a", "api_name": "Sib1"},
+                {"kind": "FLOW", "element_name": "b", "api_name": "Sib2"},
+            ],
+            "Sib1": [{"kind": "FLOW", "element_name": "shared", "api_name": "Shared"}],
+            "Sib2": [{"kind": "FLOW", "element_name": "shared", "api_name": "Shared"}],
+            "Shared": [],
+        }
+        leaf = {"kind": "FLOW", "api_name": "Root", "children": []}
+
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+
+        self.assertEqual(len(leaf["children"]), 2)
+        for sib in leaf["children"]:
+            # Each sibling must have Shared as a fully-expanded child —
+            # NOT a cycle stub.
+            self.assertEqual(len(sib["children"]), 1)
+            shared = sib["children"][0]
+            self.assertEqual(shared["api_name"], "Shared")
+            self.assertNotIn("_cycle_back_to", shared)
+
+    def test_empty_flow_children_returns_immediately(self):
+        """No data for this leaf → preserve existing children (no-op)."""
+        leaf = {"kind": "FLOW", "api_name": "X", "children": [{"kind": "APEX", "api_name": "Y"}]}
+        parse_wave.inflate_flow_leaf(leaf, {})  # empty map
+        # Preserved unchanged
+        self.assertEqual(leaf["children"], [{"kind": "APEX", "api_name": "Y"}])
+
+    def test_non_flow_leaf_ignored(self):
+        """Only FLOW kind is inflated."""
+        leaf = {"kind": "APEX", "api_name": "X"}
+        parse_wave.inflate_flow_leaf(leaf, {"X": [{"kind": "FLOW", "api_name": "Z"}]})
+        self.assertNotIn("children", leaf)
+
+
+class CycleKeyTests(unittest.TestCase):
+    """Unit test for the tuple-key helper — safety net on schema drift."""
+
+    def test_tuple_shape(self):
+        self.assertEqual(
+            parse_wave._cycle_key({"kind": "FLOW", "api_name": "Foo"}),
+            ("FLOW", "Foo"),
+        )
+
+    def test_missing_kind_or_name_safe(self):
+        self.assertEqual(parse_wave._cycle_key({}), ("", ""))
+
+
+def _linear_flow_chain(names: list[str]) -> dict:
+    """Build a flow_children graph: FLOW[i] → FLOW[i+1], last flow has no kids.
+
+    Returns the `flow_children` mapping that inflate_flow_leaf consumes.
+    """
+    graph: dict = {}
+    for i, n in enumerate(names):
+        if i + 1 < len(names):
+            graph[n] = [
+                {"kind": "FLOW", "element_name": f"call_{names[i+1]}",
+                 "api_name": names[i+1]},
+            ]
+        else:
+            graph[n] = []
+    return graph
+
+
+class DepthCapPartialTests(unittest.TestCase):
+    """`MAX_BFS_DEPTH` is a defensive guard,
+    not a functional chain-depth limit. Fixtures here push past the cap
+    to prove it still terminates and still populates `pending_out` when
+    it trips. Cycle semantics live in per-branch ancestor tracking and
+    are covered by `test_per_branch_visited.py`.
+    """
+
+    def _deep_linear_names(self, n: int) -> list[str]:
+        return [f"F{i}" for i in range(1, n + 1)]
+
+    def test_chain_under_cap_fully_expanded(self):
+        """A linear chain shorter than `MAX_BFS_DEPTH` fully expands with
+        no pending. Prior to the revision this used a 5-flow chain; with
+        a defensive cap of 20, 5 is trivially under-cap but the shape of
+        the assertion is unchanged.
+        """
+        names = ["F1", "F2", "F3", "F4", "F5"]
+        graph = _linear_flow_chain(names)
+        leaf = {"kind": "FLOW", "api_name": "F1", "children": []}
+        pending: dict[str, set[str]] = {k: set() for k in parse_wave._BFS_KINDS}
+
+        parse_wave.inflate_flow_leaf(leaf, graph, pending_out=pending)
+
+        node = leaf
+        for expected in names[1:]:
+            kids = node.get("children", [])
+            self.assertEqual(len(kids), 1, f"expected one child under {node['api_name']}")
+            self.assertEqual(kids[0]["api_name"], expected)
+            node = kids[0]
+        self.assertEqual(node.get("children", []), [])
+
+        for k in parse_wave._BFS_KINDS:
+            self.assertEqual(pending[k], set())
+
+    def test_chain_at_exact_cap_trips_and_records_pending(self):
+        """A linear chain of MAX_BFS_DEPTH+1 unique flows trips the
+        defensive cap: the last flow must NOT be expanded AND must land
+        in `pending_out["FLOW"]`. This is the only functional invariant
+        of the cap after the revision.
+        """
+        n = parse_wave.MAX_BFS_DEPTH + 1
+        names = self._deep_linear_names(n)
+        graph = _linear_flow_chain(names)
+        leaf = {"kind": "FLOW", "api_name": names[0], "children": []}
+        pending: dict[str, set[str]] = {k: set() for k in parse_wave._BFS_KINDS}
+
+        parse_wave.inflate_flow_leaf(leaf, graph, pending_out=pending)
+
+        # Walk down to the flow at `MAX_BFS_DEPTH - 1` index (last one
+        # before the cap trips on its child). All prior flows must have
+        # been fully expanded.
+        node = leaf
+        for expected in names[1:parse_wave.MAX_BFS_DEPTH]:
+            kids = node.get("children", [])
+            self.assertEqual(len(kids), 1)
+            self.assertEqual(kids[0]["api_name"], expected)
+            node = kids[0]
+
+        # The last flow in the chain (the (MAX_BFS_DEPTH+1)-th) must be
+        # in pending_out.
+        self.assertIn(names[-1], pending["FLOW"])
+
+    def test_deep_chain_with_tail_self_loop_terminates_via_cycle_detection(self):
+        """Long chain with a self-loop at the tail terminates via
+        per-branch cycle detection (the revised primitive), NOT the
+        defensive cap. The self-loop flow appears once with children
+        expanded, its self-reference annotated `_cycle_back_to`.
+        """
+        # Chain of 7 unique flows, each pointing to the next, then the
+        # last one points at itself — 7 is well under the cap of 20 so
+        # this proves cycle detection, not depth, terminates the walk.
+        names = ["F1", "F2", "F3", "F4", "F5", "F6", "F7"]
+        graph = _linear_flow_chain(names)
+        # Rewrite F7 to self-loop instead of empty.
+        graph["F7"] = [{"kind": "FLOW", "api_name": "F7", "element_name": "self"}]
+
+        leaf = {"kind": "FLOW", "api_name": "F1", "children": []}
+        pending: dict[str, set[str]] = {k: set() for k in parse_wave._BFS_KINDS}
+
+        # Must not hang / recurse infinitely.
+        parse_wave.inflate_flow_leaf(leaf, graph, pending_out=pending)
+
+        # Walk to F7.
+        node = leaf
+        for expected in names[1:]:
+            node = node["children"][0]
+            self.assertEqual(node["api_name"], expected)
+
+        # F7 has ONE child — the cycle-annotated self-reference.
+        f7_kids = node.get("children", [])
+        self.assertEqual(len(f7_kids), 1)
+        self.assertEqual(f7_kids[0]["api_name"], "F7")
+        self.assertEqual(f7_kids[0]["_cycle_back_to"], "FLOW:F7")
+        self.assertEqual(
+            f7_kids[0]["_truncated"],
+            {"reason": "cycle", "target": "FLOW:F7"},
+        )
+
+        # Nothing in pending — cycle is annotated, not pended.
+        self.assertEqual(pending["FLOW"], set())
+
+    def test_chain_under_cap_with_legacy_pending_none(self):
+        """Callers pre-dating pass no `pending_out`. An under-cap
+        chain still expands fully — no crash on `None`, no spurious
+        truncation. The pre-revision form of this test asserted cap=5
+        behavior; now it asserts that a short chain expands cleanly when
+        the cap plays no role.
+        """
+        names = ["F1", "F2", "F3", "F4", "F5", "F6"]
+        graph = _linear_flow_chain(names)
+        leaf = {"kind": "FLOW", "api_name": "F1", "children": []}
+
+        # No pending_out — legacy call shape. Must not crash.
+        parse_wave.inflate_flow_leaf(leaf, graph)
+
+        # All flows expanded to the terminal leaf.
+        node = leaf
+        for expected in names[1:]:
+            kids = node.get("children", [])
+            self.assertEqual(len(kids), 1, f"{node['api_name']} should have one child")
+            self.assertEqual(kids[0]["api_name"], expected)
+            node = kids[0]
+        self.assertEqual(node.get("children", []), [])
+
+    def test_partial_and_unresolved_coexist(self):
+        """_unresolved + _partial-reason must both be reported.
+
+        Simulate: finalize_cap drains some pending into _unresolved, but
+        depth-cap already set _partial_reason=max-depth-cap. Finalize must
+        NOT clobber the depth-cap reason.
+        """
+        tree = {
+            "_partial": True,
+            "_partial_reason": "max-depth-cap",
+            "_pending_fetches": {
+                "FLOW": ["LateFlow"],
+                "APEX": [],
+                "PROMPT_TEMPLATE": [],
+                "STANDARD_ACTION": [],
+            },
+            "_unresolved": [{"kind": "APEX", "api_name": "PriorUnresolved",
+                             "reason": "resolve_invocation_target failed"}],
+        }
+
+        parse_wave.finalize_cap(tree)
+
+        # Pending drained into unresolved.
+        self.assertEqual(tree["_pending_fetches"]["FLOW"], [])
+        self.assertEqual(len(tree["_unresolved"]), 2)
+        # Depth-cap reason preserved (NOT overwritten by max-wave-depth).
+        self.assertEqual(tree["_partial_reason"], "max-depth-cap")
+        self.assertTrue(tree["_partial"])
+
+
+class MaxBfsDepthConstantTests(unittest.TestCase):
+    """`MAX_BFS_DEPTH` is a defensive guard,
+    not a functional chain-depth limit. The constant must match
+    `scripts/config.py::MAX_BFS_DEPTH` exactly (duplicated intentionally
+    — see comment there on the "no intra-skill imports" convention).
+    """
+
+    def test_max_bfs_depth_matches_config(self):
+        """Cross-module consistency. If someone bumps one literal they
+        must bump the other."""
+        import config  # type: ignore
+        self.assertEqual(parse_wave.MAX_BFS_DEPTH, config.MAX_BFS_DEPTH)
+
+    def test_max_bfs_depth_is_defensive_not_functional(self):
+        """The cap should be comfortably larger than any realistic
+        production flow-chain depth, so that per-branch cycle detection
+        — not the cap — terminates the walk in practice. `>= 15` is a
+        loose sanity bound; if someone quietly tightens it below 15
+        they're probably reintroducing the shared-utility-flow bug."""
+        self.assertGreaterEqual(parse_wave.MAX_BFS_DEPTH, 15)
+
+    def test_legacy_alias_tracks_new_constant(self):
+        """MAX_INFLATE_DEPTH is retained as an alias."""
+        self.assertEqual(parse_wave.MAX_INFLATE_DEPTH, parse_wave.MAX_BFS_DEPTH)
+
+
+class PublicSymbolPromotionTests(unittest.TestCase):
+    """`_BFS_KINDS` and `_empty_kind_sets` were
+    promoted to public names (`BFS_KINDS`, `empty_kind_sets`) so the
+    in-process `main.py` orchestrator doesn't have to reach across the
+    leading-underscore boundary that closed for `redact_text`.
+    The underscore forms remain as deprecated aliases for one more minor
+    version.
+    """
+
+    def test_public_bfs_kinds_importable(self):
+        """`parse_wave.BFS_KINDS` exists, is a tuple, and carries the
+        expected four tokens in the same order as before promotion.
+        """
+        self.assertTrue(hasattr(parse_wave, "BFS_KINDS"))
+        self.assertIsInstance(parse_wave.BFS_KINDS, tuple)
+        self.assertEqual(
+            parse_wave.BFS_KINDS,
+            ("FLOW", "APEX", "PROMPT_TEMPLATE", "STANDARD_ACTION"),
+        )
+
+    def test_public_empty_kind_sets_importable_and_callable(self):
+        """`parse_wave.empty_kind_sets()` returns a fresh {kind: set()}
+        mapping keyed by every BFS_KINDS entry. Each call yields an
+        independent dict — callers must not share buckets across waves.
+        """
+        self.assertTrue(hasattr(parse_wave, "empty_kind_sets"))
+        d1 = parse_wave.empty_kind_sets()
+        d2 = parse_wave.empty_kind_sets()
+        self.assertEqual(set(d1.keys()), set(parse_wave.BFS_KINDS))
+        for kind in parse_wave.BFS_KINDS:
+            self.assertEqual(d1[kind], set())
+        # Independence: mutating one must not affect the other.
+        d1["FLOW"].add("X")
+        self.assertEqual(d2["FLOW"], set())
+
+    def test_underscore_aliases_still_work_for_backcompat(self):
+        """Legacy `_BFS_KINDS` / `_empty_kind_sets` imports continue to
+        resolve. They are deprecated but not yet removed — existing
+        tests and any external callers must keep working through the
+        migration window.
+        """
+        self.assertTrue(hasattr(parse_wave, "_BFS_KINDS"))
+        self.assertTrue(hasattr(parse_wave, "_empty_kind_sets"))
+        # Same object (alias, not a copy) so equality holds structurally.
+        self.assertIs(parse_wave._BFS_KINDS, parse_wave.BFS_KINDS)
+        self.assertIs(parse_wave._empty_kind_sets, parse_wave.empty_kind_sets)
+
+
+class FetchableKindsTests(unittest.TestCase):
+    """STANDARD_ACTION is declared-only, never fetched.
+    Must stay out of `_pending_fetches` even though it remains a BFS kind
+    for tree counts + visited dedup."""
+
+    def test_fetchable_kinds_excludes_standard_action(self):
+        """FETCHABLE_KINDS = (FLOW, APEX, PROMPT_TEMPLATE). STANDARD_ACTION
+        must be in BFS_KINDS (tree bookkeeping) but NOT in
+        FETCHABLE_KINDS (body-fetch eligibility)."""
+        self.assertIn("STANDARD_ACTION", parse_wave.BFS_KINDS)
+        self.assertNotIn("STANDARD_ACTION", parse_wave.FETCHABLE_KINDS)
+        self.assertEqual(
+            parse_wave.FETCHABLE_KINDS,
+            ("FLOW", "APEX", "PROMPT_TEMPLATE"),
+        )
+
+    def test_build_root_children_skips_standard_action_refs(self):
+        """A GenAiFunction whose unwrap is STANDARD_ACTION must NOT land
+        in new_refs. Before this fix, `streamKnowledgeSearch` landed in
+        `new_refs["STANDARD_ACTION"]` → merged into pending → never
+        visited → surfaced in _pending_fetches (pollution)."""
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [{
+                    "name": "A1",
+                    "invocationTarget": "streamKnowledgeSearch",
+                    "invocationTargetType": "standardInvocableAction",
+                }],
+            }],
+            "plannerActions": [],
+        }
+        visited = parse_wave.empty_kind_sets()
+        aux_visited: set = set()
+        children, new_refs = parse_wave.build_root_children(
+            bundle, visited, aux_visited,
+        )
+        # Children list is built normally — tree still has the leaf.
+        self.assertEqual(len(children), 1)
+        # But new_refs["STANDARD_ACTION"] is empty → nothing to pend on.
+        self.assertEqual(new_refs["STANDARD_ACTION"], set())
+        self.assertEqual(new_refs["FLOW"], set())
+        self.assertEqual(new_refs["APEX"], set())
+        self.assertEqual(new_refs["PROMPT_TEMPLATE"], set())
+
+    def test_build_root_children_still_captures_flow_apex_prompt_refs(self):
+        """Positive control — fetchable kinds still accumulate into
+        new_refs. The FOLLOWUP-2 gate is on STANDARD_ACTION only."""
+        bundle = {
+            "topics": [{
+                "name": "T",
+                "actions": [
+                    {"name": "F1", "invocationTarget": "FlowA",
+                     "invocationTargetType": "flow"},
+                    {"name": "A1", "invocationTarget": "ApexA",
+                     "invocationTargetType": "apex"},
+                    {"name": "P1", "invocationTarget": "PromptA",
+                     "invocationTargetType": "generatePromptResponse"},
+                ],
+            }],
+            "plannerActions": [],
+        }
+        visited = parse_wave.empty_kind_sets()
+        aux_visited: set = set()
+        _, new_refs = parse_wave.build_root_children(
+            bundle, visited, aux_visited,
+        )
+        self.assertIn("FlowA", new_refs["FLOW"])
+        self.assertIn("ApexA", new_refs["APEX"])
+        self.assertIn("PromptA", new_refs["PROMPT_TEMPLATE"])
+        self.assertEqual(new_refs["STANDARD_ACTION"], set())
+
+
+class UnifiedTruncationAnnotationTests(unittest.TestCase):
+    """both cycle and max-depth code paths annotate truncated
+    nodes with the unified `_truncated = {reason, target}` sub-object.
+    `_cycle_back_to` is preserved as a deprecated alias (backcompat)."""
+
+    def test_truncation_constants_are_exposed(self):
+        """Public constants let consumers match on strings without
+        duplicating the literal values."""
+        self.assertEqual(parse_wave.TRUNCATION_CYCLE, "cycle")
+        self.assertEqual(parse_wave.TRUNCATION_MAX_DEPTH, "max-depth")
+        self.assertIn(
+            parse_wave.TRUNCATION_CYCLE, parse_wave.TRUNCATION_REASONS,
+        )
+        self.assertIn(
+            parse_wave.TRUNCATION_MAX_DEPTH, parse_wave.TRUNCATION_REASONS,
+        )
+
+    def test_cycle_emits_unified_truncated_and_legacy_alias(self):
+        """Cycle annotations carry BOTH the unified `_truncated` and the
+        legacy `_cycle_back_to` string (same target). Consumers that
+        haven't migrated still work; new consumers read one field."""
+        flow_children = {
+            # A simple A → A self-cycle inside one expansion.
+            "A": [{"kind": "FLOW", "api_name": "A", "element_name": "loop"}],
+        }
+        leaf = {"kind": "FLOW", "api_name": "A", "children": []}
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+
+        # Find the cycle-annotated child (second encounter of A).
+        kids = leaf.get("children") or []
+        self.assertEqual(len(kids), 1)
+        cycle_node = kids[0]
+
+        # Unified annotation present.
+        self.assertIn("_truncated", cycle_node)
+        self.assertEqual(
+            cycle_node["_truncated"],
+            {"reason": "cycle", "target": "FLOW:A"},
+        )
+
+        # Legacy annotation still present for backcompat.
+        self.assertEqual(cycle_node["_cycle_back_to"], "FLOW:A")
+
+    def test_depth_cap_emits_unified_truncated_on_leaf(self):
+        """When MAX_BFS_DEPTH trips, the truncated FLOW leaf picks up
+        `_truncated = {reason: 'max-depth', target: 'FLOW:<name>'}`.
+        Before the leaf carried no per-node signal at all — only
+        the tree-level `_partial_reason` and the `pending_out`
+        accumulator identified it.
+
+        2026-05-03: since the cap was bumped from 5 to 20 (defensive
+        guard, not functional limit), the chain here is built
+        programmatically at `MAX_BFS_DEPTH + 1` unique flows so the
+        test tracks the constant instead of hard-coding chain length.
+        """
+        n = parse_wave.MAX_BFS_DEPTH + 1  # one past the cap
+        names = [f"F{i}" for i in range(n)]
+        flow_children: dict[str, list[dict]] = {}
+        for i, name in enumerate(names):
+            if i + 1 < n:
+                flow_children[name] = [{
+                    "kind": "FLOW",
+                    "api_name": names[i + 1],
+                    "element_name": "sub",
+                }]
+            else:
+                flow_children[name] = []
+
+        root = {"kind": "FLOW", "api_name": names[0], "children": []}
+        pending_out = parse_wave.empty_kind_sets()
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending_out)
+
+        # Walk down the chain to the terminal (unreached) flow.
+        def walk(n, name):
+            if n.get("api_name") == name:
+                return n
+            for c in n.get("children") or []:
+                found = walk(c, name)
+                if found:
+                    return found
+            return None
+
+        tail = walk(root, names[-1])
+        self.assertIsNotNone(tail, f"{names[-1]} should appear as a leaf in the tree")
+
+        # Unified annotation on the depth-capped leaf.
+        self.assertIn("_truncated", tail)
+        self.assertEqual(
+            tail["_truncated"],
+            {"reason": "max-depth", "target": f"FLOW:{names[-1]}"},
+        )
+
+        # The capped leaf should NOT also carry _cycle_back_to — this
+        # is a depth-cap, not a cycle.
+        self.assertNotIn("_cycle_back_to", tail)
+
+        # pending_out still picks up the unreached name — existing
+        # contract preserved.
+        self.assertIn(names[-1], pending_out["FLOW"])
+
+    def test_non_flow_leaf_depth_cap_no_annotation(self):
+        """The cap is scoped to FLOW leaves. Non-FLOW leaves at
+        cap depth are just no-op returns — no spurious `_truncated`."""
+        flow_children = {
+            "X": [{"kind": "APEX", "api_name": "SomeApex"}],
+        }
+        # Build an APEX leaf that we try to "inflate" at depth = MAX.
+        # inflate_flow_leaf with a non-FLOW leaf at depth >= MAX does
+        # nothing and emits no annotation.
+        leaf = {"kind": "APEX", "api_name": "SomeApex"}
+        pending_out = parse_wave.empty_kind_sets()
+        parse_wave.inflate_flow_leaf(
+            leaf, flow_children,
+            depth=parse_wave.MAX_BFS_DEPTH,
+            pending_out=pending_out,
+        )
+        self.assertNotIn("_truncated", leaf)
+        self.assertEqual(pending_out["FLOW"], set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_classifiers.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_classifiers.py
@@ -1,0 +1,224 @@
+"""Tests for ``parse_wave`` classifiers + BFS step helper.
+
+Targets the high-density branch surface in ``classify_bundle_action``
+(Flow / Apex / PromptTemplate / StandardAction / Unknown) and
+``classify_action_call`` (apex / generatePromptResponse / other / empty).
+Plus the central ``bfs_step`` helper that drives wave-level fetches.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import parse_wave  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# classify_bundle_action — every branch
+# -----------------------------------------------------------------------------
+
+
+class ClassifyBundleActionTests(unittest.TestCase):
+
+    def test_no_target_returns_none_pair(self):
+        unwraps, leaf = parse_wave.classify_bundle_action({
+            "invocationTarget": "",
+            "invocationTargetType": "flow",
+        })
+        self.assertIsNone(unwraps)
+        self.assertIsNone(leaf)
+
+    def test_flow_branch(self):
+        unwraps, leaf = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyFlow",
+            "invocationTargetType": "flow",
+        })
+        self.assertEqual(unwraps["kind"], "FLOW")
+        self.assertEqual(unwraps["api_name"], "MyFlow")
+        self.assertEqual(leaf["children"], [])
+
+    def test_apex_branch(self):
+        unwraps, leaf = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyClass.method",
+            "invocationTargetType": "apex",
+        })
+        self.assertEqual(unwraps["kind"], "APEX")
+        self.assertEqual(leaf["api_name"], "MyClass.method")
+
+    def test_prompt_template_via_generatepromptresponse(self):
+        unwraps, _ = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyPrompt",
+            "invocationTargetType": "generatepromptresponse",
+        })
+        self.assertEqual(unwraps["kind"], "PROMPT_TEMPLATE")
+
+    def test_prompt_template_via_prompt_prefix(self):
+        unwraps, _ = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyPrompt",
+            "invocationTargetType": "prompt-template",
+        })
+        self.assertEqual(unwraps["kind"], "PROMPT_TEMPLATE")
+
+    def test_prompt_template_via_genai_prefix(self):
+        unwraps, _ = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyPrompt",
+            "invocationTargetType": "genaifunction",
+        })
+        self.assertEqual(unwraps["kind"], "PROMPT_TEMPLATE")
+
+    def test_standard_invocable_action_branch(self):
+        unwraps, leaf = parse_wave.classify_bundle_action({
+            "invocationTarget": "createRecord",
+            "invocationTargetType": "standardinvocableaction",
+        })
+        self.assertEqual(unwraps["kind"], "STANDARD_ACTION")
+        self.assertEqual(unwraps["invocation_type"], "standardinvocableaction")
+        self.assertEqual(leaf["api_name"], "createRecord")
+
+    def test_unknown_action_type_falls_to_unknown(self):
+        unwraps, leaf = parse_wave.classify_bundle_action({
+            "invocationTarget": "MysteryAction",
+            "invocationTargetType": "MYSTERY",
+        })
+        self.assertEqual(unwraps["kind"], "UNKNOWN")
+        self.assertEqual(unwraps["invocation_type"], "mystery")  # lowercased
+        self.assertEqual(leaf["kind"], "UNKNOWN")
+
+    def test_invocationTargetType_missing_normalizes_to_empty_string(self):
+        unwraps, _ = parse_wave.classify_bundle_action({
+            "invocationTarget": "MyAction",
+            # no invocationTargetType — coerced to ""
+        })
+        self.assertEqual(unwraps["kind"], "UNKNOWN")
+        self.assertEqual(unwraps["invocation_type"], "")
+
+
+# -----------------------------------------------------------------------------
+# classify_action_call — every branch
+# -----------------------------------------------------------------------------
+
+
+class ClassifyActionCallTests(unittest.TestCase):
+
+    def test_apex_branch(self):
+        out = parse_wave.classify_action_call("apex", "MyClass", "callA")
+        self.assertEqual(out["kind"], "APEX")
+        self.assertEqual(out["api_name"], "MyClass")
+        self.assertEqual(out["element_name"], "callA")
+
+    def test_generate_prompt_response_branch(self):
+        out = parse_wave.classify_action_call(
+            "generatePromptResponse", "MyPrompt", "callB",
+        )
+        self.assertEqual(out["kind"], "PROMPT_TEMPLATE")
+        self.assertEqual(out["api_name"], "MyPrompt")
+
+    def test_other_action_type_falls_to_standard_action(self):
+        out = parse_wave.classify_action_call("emailAlert", "MyAlert", "callC")
+        self.assertEqual(out["kind"], "STANDARD_ACTION")
+        self.assertEqual(out["invocation_type"], "emailAlert")
+        self.assertEqual(out["api_name"], "MyAlert")
+
+    def test_other_action_type_uses_action_type_when_name_missing(self):
+        out = parse_wave.classify_action_call("emailAlert", "", "callC")
+        self.assertEqual(out["api_name"], "emailAlert")
+
+    def test_empty_action_type_falls_to_unknown(self):
+        out = parse_wave.classify_action_call("", "MyName", "callD")
+        self.assertEqual(out["kind"], "UNKNOWN")
+        self.assertEqual(out["api_name"], "MyName")
+
+    def test_unknown_with_no_name_falls_to_question_mark(self):
+        out = parse_wave.classify_action_call("", "", "callE")
+        self.assertEqual(out["api_name"], "?")
+
+
+# -----------------------------------------------------------------------------
+# bfs_step — pure helper
+# -----------------------------------------------------------------------------
+
+
+class BfsStepTests(unittest.TestCase):
+
+    def test_new_refs_added_to_pending(self):
+        pending = parse_wave.empty_kind_sets()
+        visited = parse_wave.empty_kind_sets()
+        new_refs = {
+            "FLOW": {"FlowA", "FlowB"},
+            "APEX": {"ApexA"},
+            "PROMPT_TEMPLATE": set(),
+            "STANDARD_ACTION": set(),
+        }
+        merged, cycles = parse_wave.bfs_step(pending, visited, new_refs)
+        self.assertEqual(merged["FLOW"], {"FlowA", "FlowB"})
+        self.assertEqual(merged["APEX"], {"ApexA"})
+        self.assertEqual(cycles, [])
+
+    def test_visited_refs_recorded_as_cycles(self):
+        pending = parse_wave.empty_kind_sets()
+        visited = parse_wave.empty_kind_sets()
+        visited["FLOW"].add("FlowA")
+        new_refs = {
+            "FLOW": {"FlowA", "FlowB"},
+            "APEX": set(), "PROMPT_TEMPLATE": set(), "STANDARD_ACTION": set(),
+        }
+        merged, cycles = parse_wave.bfs_step(pending, visited, new_refs)
+        self.assertEqual(merged["FLOW"], {"FlowB"})
+        self.assertIn(("FLOW", "FlowA"), cycles)
+
+    def test_cross_kind_same_name_stays_distinct(self):
+        pending = parse_wave.empty_kind_sets()
+        visited = parse_wave.empty_kind_sets()
+        new_refs = {
+            "FLOW": {"Foo"}, "APEX": {"Foo"},
+            "PROMPT_TEMPLATE": set(), "STANDARD_ACTION": set(),
+        }
+        merged, _ = parse_wave.bfs_step(pending, visited, new_refs)
+        self.assertEqual(merged["FLOW"], {"Foo"})
+        self.assertEqual(merged["APEX"], {"Foo"})
+
+    def test_existing_pending_preserved_via_merge(self):
+        pending = parse_wave.empty_kind_sets()
+        pending["FLOW"].add("FlowExisting")
+        visited = parse_wave.empty_kind_sets()
+        new_refs = {
+            "FLOW": {"FlowNew"},
+            "APEX": set(), "PROMPT_TEMPLATE": set(), "STANDARD_ACTION": set(),
+        }
+        merged, _ = parse_wave.bfs_step(pending, visited, new_refs)
+        self.assertEqual(merged["FLOW"], {"FlowExisting", "FlowNew"})
+
+    def test_unknown_kind_raises(self):
+        pending = parse_wave.empty_kind_sets()
+        visited = parse_wave.empty_kind_sets()
+        with self.assertRaises(ValueError) as ctx:
+            parse_wave.bfs_step(
+                pending, visited,
+                {"BOGUS_KIND": {"x"}},
+            )
+        self.assertIn("unknown BFS kind", str(ctx.exception))
+
+
+# -----------------------------------------------------------------------------
+# empty_kind_sets — fresh dict per call
+# -----------------------------------------------------------------------------
+
+
+class EmptyKindSetsTests(unittest.TestCase):
+
+    def test_returns_one_set_per_BFS_KIND(self):
+        out = parse_wave.empty_kind_sets()
+        self.assertEqual(set(out.keys()), set(parse_wave.BFS_KINDS))
+        for v in out.values():
+            self.assertEqual(v, set())
+
+    def test_each_call_returns_fresh_dict(self):
+        a = parse_wave.empty_kind_sets()
+        a["FLOW"].add("x")
+        b = parse_wave.empty_kind_sets()
+        self.assertEqual(b["FLOW"], set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_helpers.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_helpers.py
@@ -1,0 +1,380 @@
+"""Tests for ``parse_wave`` standalone helpers — non-classifier surface.
+
+Covers:
+- ``compute_stats``        node count + depth + per-kind counter
+- ``finalize_cap``         drains pending → unresolved + sets partial
+- ``atomic_write_json``    tmp + os.replace
+- ``init_tree``            bundle + bot_def shape
+- ``harvest_waves``        Flow XML walking with subflows + actionCalls
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import parse_wave  # type: ignore
+
+
+_FLOW_NS = "http://soap.sforce.com/2006/04/metadata"
+
+
+# -----------------------------------------------------------------------------
+# compute_stats
+# -----------------------------------------------------------------------------
+
+
+class ComputeStatsTests(unittest.TestCase):
+
+    def test_empty_root_returns_zero_counts(self):
+        n, d, counts = parse_wave.compute_stats({})
+        self.assertEqual(n, 0)
+        self.assertEqual(d, 0)
+        self.assertEqual(counts, {})
+
+    def test_single_node_counts_kind(self):
+        n, d, counts = parse_wave.compute_stats({"kind": "BOT_DEFINITION"})
+        self.assertEqual(n, 1)
+        self.assertEqual(counts["BOT_DEFINITION"], 1)
+        self.assertEqual(d, 0)
+
+    def test_nested_tree_returns_max_depth(self):
+        root = {
+            "kind": "BOT_DEFINITION",
+            "children": [
+                {"kind": "TOPIC", "children": [
+                    {"kind": "FLOW", "children": [
+                        {"kind": "APEX"},
+                    ]},
+                ]},
+                {"kind": "STANDARD_ACTION"},
+            ],
+        }
+        n, d, counts = parse_wave.compute_stats(root)
+        self.assertEqual(n, 5)
+        self.assertEqual(d, 3)
+        self.assertEqual(counts["BOT_DEFINITION"], 1)
+        self.assertEqual(counts["TOPIC"], 1)
+        self.assertEqual(counts["FLOW"], 1)
+        self.assertEqual(counts["APEX"], 1)
+        self.assertEqual(counts["STANDARD_ACTION"], 1)
+
+
+# -----------------------------------------------------------------------------
+# finalize_cap
+# -----------------------------------------------------------------------------
+
+
+class FinalizeCapTests(unittest.TestCase):
+
+    def test_drains_pending_into_unresolved(self):
+        tree = {
+            "_pending_fetches": {
+                "FLOW": ["FlowA", "FlowB"],
+                "APEX": ["ClassA"],
+                "PROMPT_TEMPLATE": [], "STANDARD_ACTION": [],
+            },
+            "_unresolved": [],
+        }
+        out = parse_wave.finalize_cap(tree)
+        self.assertEqual(len(out["_unresolved"]), 3)
+        # Pending wiped per-kind
+        for kind in parse_wave.BFS_KINDS:
+            self.assertEqual(out["_pending_fetches"][kind], [])
+        # _partial flipped
+        self.assertTrue(out["_partial"])
+        self.assertEqual(out["_partial_reason"], "max-wave-depth")
+
+    def test_does_not_overwrite_existing_partial_reason(self):
+        tree = {
+            "_pending_fetches": {"FLOW": ["FlowA"], "APEX": [],
+                                  "PROMPT_TEMPLATE": [], "STANDARD_ACTION": []},
+            "_unresolved": [],
+            "_partial_reason": "max-depth-cap",  # earlier-set, more specific
+        }
+        out = parse_wave.finalize_cap(tree)
+        # Reason kept; depth-cap wins priority over wave-depth.
+        self.assertEqual(out["_partial_reason"], "max-depth-cap")
+
+    def test_no_pending_no_changes(self):
+        tree = {
+            "_pending_fetches": {k: [] for k in parse_wave.BFS_KINDS},
+            "_unresolved": [],
+            "_partial": False,
+            "_partial_reason": None,
+        }
+        out = parse_wave.finalize_cap(tree)
+        self.assertEqual(out["_unresolved"], [])
+        # Nothing drained, _partial untouched
+        self.assertFalse(out["_partial"])
+
+    def test_unresolved_entry_shape(self):
+        tree = {
+            "_pending_fetches": {"FLOW": ["FlowA"], "APEX": [],
+                                  "PROMPT_TEMPLATE": [], "STANDARD_ACTION": []},
+            "_unresolved": [],
+        }
+        out = parse_wave.finalize_cap(tree)
+        entry = out["_unresolved"][0]
+        self.assertEqual(entry["kind"], "FLOW")
+        self.assertEqual(entry["api_name"], "FlowA")
+        self.assertEqual(entry["reason"], "max-wave-depth exceeded")
+
+
+# -----------------------------------------------------------------------------
+# atomic_write_json
+# -----------------------------------------------------------------------------
+
+
+class AtomicWriteJsonTests(unittest.TestCase):
+
+    def test_writes_indented_json(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.json"
+            parse_wave.atomic_write_json(target, {"a": 1, "b": [1, 2]})
+            data = json.loads(target.read_text())
+        self.assertEqual(data, {"a": 1, "b": [1, 2]})
+
+    def test_overwrites_existing(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.json"
+            target.write_text("old")
+            parse_wave.atomic_write_json(target, {"new": True})
+            data = json.loads(target.read_text())
+        self.assertEqual(data, {"new": True})
+
+    def test_no_tmp_left_behind(self):
+        with TemporaryDirectory() as t:
+            target = Path(t) / "out.json"
+            parse_wave.atomic_write_json(target, {"x": 1})
+            tmp_sibling = target.with_suffix(target.suffix + ".tmp")
+        self.assertFalse(tmp_sibling.exists())
+
+
+# -----------------------------------------------------------------------------
+# init_tree
+# -----------------------------------------------------------------------------
+
+
+class InitTreeTests(unittest.TestCase):
+
+    def _setup_env(self, **overrides) -> dict:
+        defaults = {
+            "AGENT_API_NAME": "DemoAgent",
+            "AGENT_VERSION": "v3",
+            "BOT_ID": "0Xx000000000ABC",
+            "BOT_MASTER_LABEL": "Demo Agent",
+            "VERSION_AUTO_PICKED": "false",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def _run(self, *, work_dir: Path, env: dict, bundle: dict) -> dict:
+        old = dict(os.environ)
+        try:
+            os.environ.update(env)
+            return parse_wave.init_tree(work_dir, bundle)
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+
+    def test_initial_tree_shape(self):
+        with TemporaryDirectory() as t:
+            tree = self._run(
+                work_dir=Path(t),
+                env=self._setup_env(),
+                bundle={"generation": "nga", "plannerName": "MyPlanner",
+                        "plannerType": "Atlas__Reasoning"},
+            )
+        self.assertEqual(tree["_schema_version"], "3.1")
+        self.assertEqual(tree["agent"]["api_name"], "DemoAgent")
+        self.assertEqual(tree["agent"]["version"], "v3")
+        self.assertEqual(tree["agent"]["generation"], "nga")
+        self.assertEqual(tree["agent"]["planner_name"], "MyPlanner")
+        self.assertEqual(tree["root"]["kind"], "BOT_DEFINITION")
+        self.assertEqual(tree["root"]["children"], [])
+        self.assertTrue(tree["_partial"])
+        self.assertIsNone(tree["_partial_reason"])
+        # _pending_fetches has all 4 BFS kinds
+        for kind in parse_wave.BFS_KINDS:
+            self.assertIn(kind, tree["_pending_fetches"])
+
+    def test_pulls_bot_definition_metadata_from_disk(self):
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            (work_dir / "_bot_definition.json").write_text(json.dumps({
+                "result": {"records": [{
+                    "DeveloperName": "DemoAgent",
+                    "MasterLabel": "Demo (from disk)",
+                    "Description": "via _bot_definition.json",
+                    "AgentType": "Internal",
+                    "Type": "AiCopilot",
+                    "AgentTemplate": "TPL",
+                    "BotSource": "AgentforceAgentCopilot",
+                }]},
+            }))
+            tree = self._run(
+                work_dir=work_dir,
+                env=self._setup_env(),
+                bundle={"generation": "classic"},
+            )
+        # MasterLabel from _bot_definition.json wins over env
+        self.assertEqual(tree["agent"]["master_label"], "Demo (from disk)")
+        self.assertEqual(tree["agent"]["description"], "via _bot_definition.json")
+        self.assertEqual(tree["agent"]["agent_type"], "Internal")
+
+    def test_version_auto_picked_flag_propagates(self):
+        with TemporaryDirectory() as t:
+            tree = self._run(
+                work_dir=Path(t),
+                env=self._setup_env(VERSION_AUTO_PICKED="true"),
+                bundle={"generation": "nga"},
+            )
+        self.assertTrue(tree["agent"]["_version_auto_picked"])
+
+
+# -----------------------------------------------------------------------------
+# harvest_waves
+# -----------------------------------------------------------------------------
+
+
+def _flow_xml(*, name: str, action_calls: list[dict] | None = None,
+              subflows: list[str] | None = None) -> str:
+    """Build a minimal Flow XML body."""
+    acs = "".join(
+        f"""  <actionCalls>
+    <name>{ac['name']}</name>
+    <actionType>{ac['actionType']}</actionType>
+    <actionName>{ac['actionName']}</actionName>
+  </actionCalls>
+"""
+        for ac in (action_calls or [])
+    )
+    subs = "".join(
+        f"""  <subflows>
+    <name>sub_{i}</name>
+    <flowName>{fn}</flowName>
+  </subflows>
+"""
+        for i, fn in enumerate(subflows or [])
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="{_FLOW_NS}">
+  <fullName>{name}</fullName>
+{acs}{subs}</Flow>
+"""
+
+
+class HarvestWavesTests(unittest.TestCase):
+
+    def _setup_wave(self, work_dir: Path, *, flow_files: dict[str, str],
+                    apex_class_names: list[str] | None = None,
+                    prompt_template_names: list[str] | None = None) -> None:
+        """Plant a wave1/unpackaged/{flows,classes,genAiPromptTemplates}/
+        directory tree under work_dir/sf_meta/."""
+        wave = work_dir / "sf_meta" / "wave1" / "unpackaged"
+        flows_dir = wave / "flows"
+        flows_dir.mkdir(parents=True)
+        for filename, body in flow_files.items():
+            (flows_dir / filename).write_text(body)
+        if apex_class_names:
+            classes_dir = wave / "classes"
+            classes_dir.mkdir()
+            for n in apex_class_names:
+                (classes_dir / f"{n}.cls-meta.xml").write_text("<x/>")
+        if prompt_template_names:
+            prompt_dir = wave / "genAiPromptTemplates"
+            prompt_dir.mkdir()
+            for n in prompt_template_names:
+                (prompt_dir / f"{n}.genAiPromptTemplate").write_text("<x/>")
+
+    def test_returns_empty_when_no_sf_meta(self):
+        with TemporaryDirectory() as t:
+            flow_children, vis, pend, cycles = parse_wave.harvest_waves(Path(t))
+        self.assertEqual(flow_children, {})
+        self.assertEqual(cycles, [])
+        for v in vis.values():
+            self.assertEqual(v, set())
+
+    def test_harvests_flow_action_calls_and_subflows(self):
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            self._setup_wave(work_dir, flow_files={
+                "MainFlow.flow": _flow_xml(
+                    name="MainFlow",
+                    action_calls=[
+                        {"name": "callA", "actionType": "apex",
+                         "actionName": "MyClass"},
+                        {"name": "callB", "actionType": "generatePromptResponse",
+                         "actionName": "MyPrompt"},
+                    ],
+                    subflows=["NestedFlow"],
+                ),
+            })
+            flow_children, visited, pending, _cycles = parse_wave.harvest_waves(work_dir)
+        # MainFlow visited
+        self.assertIn("MainFlow", visited["FLOW"])
+        # Apex + prompt-template + nested flow ref harvested into pending
+        self.assertIn("MyClass", pending["APEX"])
+        self.assertIn("MyPrompt", pending["PROMPT_TEMPLATE"])
+        self.assertIn("NestedFlow", pending["FLOW"])
+        # MainFlow's children include the apex + prompt-template + subflow
+        self.assertEqual(len(flow_children["MainFlow"]), 3)
+
+    def test_apex_classes_marked_visited(self):
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            self._setup_wave(
+                work_dir,
+                flow_files={"F.flow": _flow_xml(name="F")},
+                apex_class_names=["AlreadyApex"],
+            )
+            _, visited, _, _ = parse_wave.harvest_waves(work_dir)
+        self.assertIn("AlreadyApex", visited["APEX"])
+
+    def test_prompt_templates_marked_visited(self):
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            self._setup_wave(
+                work_dir,
+                flow_files={"F.flow": _flow_xml(name="F")},
+                prompt_template_names=["AlreadyPrompt"],
+            )
+            _, visited, _, _ = parse_wave.harvest_waves(work_dir)
+        self.assertIn("AlreadyPrompt", visited["PROMPT_TEMPLATE"])
+
+    def test_already_visited_apex_pruned_from_pending(self):
+        """When pass-2/3 marks an Apex class visited AFTER pass-1 routed it
+        into pending, the post-pass prune drops it from pending."""
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            self._setup_wave(work_dir,
+                             flow_files={"F.flow": _flow_xml(
+                                 name="F",
+                                 action_calls=[{
+                                     "name": "callA", "actionType": "apex",
+                                     "actionName": "ClassX",
+                                 }],
+                             )},
+                             apex_class_names=["ClassX"])
+            _, visited, pending, _ = parse_wave.harvest_waves(work_dir)
+        self.assertIn("ClassX", visited["APEX"])
+        # Pruned because already-visited (Apex class file present this wave)
+        self.assertNotIn("ClassX", pending["APEX"])
+
+    def test_malformed_flow_xml_returns_empty_children(self):
+        with TemporaryDirectory() as t:
+            work_dir = Path(t)
+            self._setup_wave(work_dir, flow_files={
+                "Broken.flow": "<<<not xml>>>",
+            })
+            flow_children, _, _, _ = parse_wave.harvest_waves(work_dir)
+        self.assertEqual(flow_children["Broken"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_main.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_parse_wave_main.py
@@ -1,0 +1,347 @@
+"""Tests for ``parse_wave.main`` orchestrator + tree-walking helpers.
+
+Covers:
+- ``walk_and_inflate``        recursive Flow inflation
+- ``inflate_flow_leaf``       cycle + depth-cap behavior
+- ``build_root_children``     bundle → root children + new_refs
+- ``main`` (full path)        env-driven pipeline against a tmp WORK_DIR
+- ``main --finalize-cap``     drain pending → unresolved
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import parse_wave  # type: ignore
+
+
+_FLOW_NS = "http://soap.sforce.com/2006/04/metadata"
+
+
+# -----------------------------------------------------------------------------
+# walk_and_inflate
+# -----------------------------------------------------------------------------
+
+
+class WalkAndInflateTests(unittest.TestCase):
+
+    def test_no_op_for_non_FLOW_non_GEN_AI_FUNCTION_node(self):
+        node = {"kind": "TOPIC", "api_name": "T1", "children": []}
+        flow_children: dict = {}
+        # Should not raise; should not mutate.
+        parse_wave.walk_and_inflate(node, flow_children)
+        self.assertEqual(node["children"], [])
+
+    def test_inflates_flow_leaf_under_gen_ai_function(self):
+        # GEN_AI_FUNCTION wraps a FLOW leaf — walker recurses into it.
+        node = {
+            "kind": "GEN_AI_FUNCTION",
+            "api_name": "GAF1",
+            "children": [{"kind": "FLOW", "api_name": "MyFlow", "children": []}],
+        }
+        flow_children = {"MyFlow": [
+            {"kind": "APEX", "element_name": "callA", "api_name": "MyClass"},
+        ]}
+        parse_wave.walk_and_inflate(node, flow_children)
+        # FLOW leaf got inflated with the APEX child
+        flow_leaf = node["children"][0]
+        self.assertEqual(len(flow_leaf["children"]), 1)
+        self.assertEqual(flow_leaf["children"][0]["kind"], "APEX")
+
+    def test_recursively_walks_through_topic_to_inflate_flow(self):
+        # Walker should descend through TOPIC/non-special nodes too.
+        node = {
+            "kind": "BOT_DEFINITION", "api_name": "Agent",
+            "children": [{
+                "kind": "TOPIC", "api_name": "T1",
+                "children": [{
+                    "kind": "GEN_AI_FUNCTION", "api_name": "GAF1",
+                    "children": [{"kind": "FLOW", "api_name": "DeepFlow",
+                                  "children": []}],
+                }],
+            }],
+        }
+        flow_children = {"DeepFlow": [
+            {"kind": "APEX", "element_name": "callA", "api_name": "DeepClass"},
+        ]}
+        parse_wave.walk_and_inflate(node, flow_children)
+        # DeepFlow got the APEX child
+        deep_flow = node["children"][0]["children"][0]["children"][0]
+        self.assertEqual(deep_flow["children"][0]["api_name"], "DeepClass")
+
+    def test_pending_out_collects_depth_cap_truncations(self):
+        # Build a chain longer than MAX_BFS_DEPTH so the cap trips.
+        # Generate 25 flows that each subflow into the next.
+        flow_children: dict = {}
+        for i in range(25):
+            next_name = f"F{i+1}" if i < 24 else None
+            kids = []
+            if next_name:
+                kids.append({"kind": "FLOW", "element_name": f"sub_{i}",
+                             "api_name": next_name})
+            flow_children[f"F{i}"] = kids
+        node = {"kind": "FLOW", "api_name": "F0", "children": []}
+        pending: dict = parse_wave.empty_kind_sets()
+        parse_wave.walk_and_inflate(node, flow_children, pending_out=pending)
+        # Some subflow ended up in pending due to the depth cap (>= MAX_BFS_DEPTH).
+        self.assertTrue(any(pending[k] for k in parse_wave.BFS_KINDS))
+
+
+# -----------------------------------------------------------------------------
+# inflate_flow_leaf — cycle detection
+# -----------------------------------------------------------------------------
+
+
+class InflateFlowLeafCycleTests(unittest.TestCase):
+
+    def test_self_recursion_marked_as_cycle(self):
+        # Flow A subflows back to A itself → cycle.
+        flow_children = {"A": [
+            {"kind": "FLOW", "element_name": "self", "api_name": "A"},
+        ]}
+        leaf = {"kind": "FLOW", "api_name": "A", "children": []}
+        parse_wave.inflate_flow_leaf(leaf, flow_children)
+        # The recursive child got annotated with _truncated.
+        kid = leaf["children"][0]
+        self.assertIn("_truncated", kid)
+        self.assertEqual(kid["_truncated"]["reason"],
+                         parse_wave.TRUNCATION_CYCLE)
+
+    def test_unknown_flow_no_inflation(self):
+        # leaf.api_name not in flow_children → nothing to inflate.
+        leaf = {"kind": "FLOW", "api_name": "Missing", "children": []}
+        parse_wave.inflate_flow_leaf(leaf, {})
+        self.assertEqual(leaf["children"], [])
+
+
+# -----------------------------------------------------------------------------
+# build_root_children
+# -----------------------------------------------------------------------------
+
+
+class BuildRootChildrenTests(unittest.TestCase):
+
+    def test_topics_become_root_children(self):
+        bundle = {
+            "topics": [
+                {"name": "Greetings", "actions": [
+                    {"name": "Hello", "invocationTarget": "MyFlow",
+                     "invocationTargetType": "flow"},
+                ]},
+            ],
+        }
+        visited = parse_wave.empty_kind_sets()
+        aux: set = set()
+        children, new_refs = parse_wave.build_root_children(bundle, visited, aux)
+        self.assertEqual(len(children), 1)
+        self.assertEqual(children[0]["kind"], "TOPIC")
+        self.assertEqual(children[0]["api_name"], "Greetings")
+        # GEN_AI_FUNCTION wrapping the action
+        self.assertEqual(children[0]["children"][0]["kind"], "GEN_AI_FUNCTION")
+        # FLOW ref harvested into new_refs
+        self.assertIn("MyFlow", new_refs["FLOW"])
+        # Topic + action recorded in aux_visited
+        self.assertIn(("TOPIC", "Greetings"), aux)
+        self.assertIn(("GEN_AI_FUNCTION", "Hello"), aux)
+
+    def test_skips_already_visited_refs(self):
+        bundle = {
+            "topics": [{"name": "T", "actions": [
+                {"name": "A1", "invocationTarget": "FlowA",
+                 "invocationTargetType": "flow"},
+            ]}],
+        }
+        visited = parse_wave.empty_kind_sets()
+        visited["FLOW"].add("FlowA")
+        aux: set = set()
+        _, new_refs = parse_wave.build_root_children(bundle, visited, aux)
+        # FlowA already visited → not added to new_refs
+        self.assertNotIn("FlowA", new_refs["FLOW"])
+
+    def test_standard_action_does_not_pollute_new_refs(self):
+        # STANDARD_ACTION is declared-only, must NOT
+        # land in new_refs (would pollute _pending_fetches).
+        bundle = {
+            "topics": [{"name": "T", "actions": [
+                {"name": "A1", "invocationTarget": "createRecord",
+                 "invocationTargetType": "standardinvocableaction"},
+            ]}],
+        }
+        visited = parse_wave.empty_kind_sets()
+        aux: set = set()
+        _, new_refs = parse_wave.build_root_children(bundle, visited, aux)
+        self.assertNotIn("createRecord", new_refs["STANDARD_ACTION"])
+
+    def test_empty_bundle_returns_empty_children(self):
+        children, new_refs = parse_wave.build_root_children(
+            {}, parse_wave.empty_kind_sets(), set(),
+        )
+        self.assertEqual(children, [])
+        for v in new_refs.values():
+            self.assertEqual(v, set())
+
+
+# -----------------------------------------------------------------------------
+# main() — happy path + finalize-cap branch
+# -----------------------------------------------------------------------------
+
+
+def _setup_workdir(tmp: Path, *, bundle: dict | None = None) -> Path:
+    """Plant a WORK_DIR with _bundle_parsed.json + minimal sf_meta layout."""
+    work_dir = tmp / "work"
+    work_dir.mkdir()
+    bundle = bundle or {
+        "plannerName": "MyPlanner",
+        "plannerType": "Atlas__Reasoning",
+        "generation": "nga",
+        "topics": [{"name": "Greetings", "actions": [
+            {"name": "SayHi", "invocationTarget": "GreetingsFlow",
+             "invocationTargetType": "flow"},
+        ]}],
+    }
+    (work_dir / "_bundle_parsed.json").write_text(json.dumps(bundle))
+    # Empty sf_meta is fine — harvest_waves returns empty when missing.
+    return work_dir
+
+
+def _run_main(*, work_dir: Path, argv_extra: list[str] | None = None,
+              env_extra: dict | None = None) -> int:
+    """Invoke parse_wave.main with controlled env + argv."""
+    saved_env = dict(os.environ)
+    saved_argv = list(parse_wave.sys.argv)
+    try:
+        os.environ.update({
+            "WORK_DIR": str(work_dir),
+            "AGENT_API_NAME": "DemoAgent",
+            "AGENT_VERSION": "v3",
+            "BOT_ID": "0Xx000000000ABC",
+            "BOT_MASTER_LABEL": "Demo Agent",
+            "VERSION_AUTO_PICKED": "false",
+        })
+        if env_extra:
+            os.environ.update(env_extra)
+        parse_wave.sys.argv = ["parse_wave.py", *(argv_extra or [])]
+        return parse_wave.main()
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
+        parse_wave.sys.argv = saved_argv
+
+
+class MainHappyPathTests(unittest.TestCase):
+
+    def test_main_writes_declared_action_tree_json(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = _setup_workdir(tmp)
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                rc = _run_main(work_dir=work_dir)
+            self.assertEqual(rc, 0)
+            tree_path = work_dir / "declared_action_tree.json"
+            self.assertTrue(tree_path.is_file())
+            tree = json.loads(tree_path.read_text())
+            # Tree has the expected shape
+            self.assertEqual(tree["_schema_version"], "3.1")
+            self.assertEqual(tree["agent"]["api_name"], "DemoAgent")
+            self.assertEqual(tree["root"]["kind"], "BOT_DEFINITION")
+            # One topic became a root child
+            kinds = [c["kind"] for c in tree["root"]["children"]]
+            self.assertIn("TOPIC", kinds)
+
+    def test_main_records_pending_for_unfetched_flow(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = _setup_workdir(tmp)
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                _run_main(work_dir=work_dir)
+            tree = json.loads(
+                (work_dir / "declared_action_tree.json").read_text()
+            )
+        # GreetingsFlow not on disk → in _pending_fetches.FLOW
+        self.assertIn("GreetingsFlow", tree["_pending_fetches"]["FLOW"])
+        self.assertTrue(tree["_partial"])
+        # _partial_reason on first run uses setdefault(); init_tree set it
+        # to None already, so setdefault is a no-op. Expected behavior:
+        # subsequent runs (e.g. finalize_cap or wave-merge) populate it.
+        self.assertIsNone(tree["_partial_reason"])
+
+    def test_main_returns_one_when_work_dir_env_missing(self):
+        saved_env = dict(os.environ)
+        try:
+            for k in ("WORK_DIR", "AGENT_API_NAME", "AGENT_VERSION"):
+                os.environ.pop(k, None)
+            with mock.patch.object(parse_wave.sys, "argv", ["parse_wave.py"]):
+                with mock.patch.object(parse_wave.sys, "stderr"):
+                    rc = parse_wave.main()
+        finally:
+            os.environ.clear()
+            os.environ.update(saved_env)
+        self.assertEqual(rc, 1)
+
+    def test_main_returns_one_when_bundle_missing(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = tmp / "work"
+            work_dir.mkdir()
+            # No _bundle_parsed.json
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                rc = _run_main(work_dir=work_dir)
+        self.assertEqual(rc, 1)
+
+    def test_main_reparses_existing_tree(self):
+        # Two-pass: first run creates the tree, second re-uses it.
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = _setup_workdir(tmp)
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                _run_main(work_dir=work_dir)
+                # Second invocation should load + augment without crashing
+                rc = _run_main(work_dir=work_dir)
+        self.assertEqual(rc, 0)
+
+
+class MainFinalizeCapTests(unittest.TestCase):
+
+    def test_finalize_cap_drains_pending_into_unresolved(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = _setup_workdir(tmp)
+            # First run produces a tree with pending FLOW=GreetingsFlow.
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                _run_main(work_dir=work_dir)
+                # --finalize-cap drains pending → unresolved
+                rc = _run_main(
+                    work_dir=work_dir, argv_extra=["--finalize-cap"],
+                )
+            self.assertEqual(rc, 0)
+            tree = json.loads(
+                (work_dir / "declared_action_tree.json").read_text()
+            )
+            # All buckets emptied
+            for kind in parse_wave.BFS_KINDS:
+                self.assertEqual(tree["_pending_fetches"][kind], [])
+            # GreetingsFlow now in _unresolved
+            api_names = [u["api_name"] for u in tree["_unresolved"]]
+            self.assertIn("GreetingsFlow", api_names)
+
+    def test_finalize_cap_with_no_existing_tree_is_noop(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            work_dir = tmp / "work"
+            work_dir.mkdir()
+            with mock.patch.object(parse_wave.sys, "stderr"):
+                rc = _run_main(
+                    work_dir=work_dir, argv_extra=["--finalize-cap"],
+                )
+        # No tree file → noop, exit 0.
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_per_branch_visited.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_per_branch_visited.py
@@ -1,0 +1,244 @@
+"""2026-05-03 revision: `inflate_flow_leaf` uses a per-branch ancestor
+path set (`visited_in_path`) for cycle detection. The defensive
+`MAX_BFS_DEPTH` cap is preserved as a last-resort termination guard
+but is no longer the primitive that prevents runaway recursion.
+
+The bug this regression suite prevents: shared utility flows such as
+`handleFlowFault` appear on every real Agentforce flow's fault path.
+Under the old `MAX_BFS_DEPTH = 5` behaviour the utility showed up in
+`_pending_fetches["FLOW"]` with `PARTIAL_REASON=max-depth-cap` on any
+moderately nested tree (e.g. `AGNT_Baz_Qux →
+handleFlowFault`), even though `handleFlowFault` was trivially
+expandable. Per-branch path-set semantics fix this: the same flow on
+two sibling branches is NOT a cycle, only an ancestor-chain recurrence
+is.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import parse_wave  # type: ignore
+
+
+def _find_all(node: dict, api_name: str) -> list[dict]:
+    """Collect every node in `node`'s subtree whose `api_name` matches."""
+    found: list[dict] = []
+    if node.get("api_name") == api_name:
+        found.append(node)
+    for c in node.get("children", []) or []:
+        found.extend(_find_all(c, api_name))
+    return found
+
+
+class SharedUtilityFlowExpansionTests(unittest.TestCase):
+    """Direct repro of the real-org `handleFlowFault` bug.
+
+    Parent flow has two sibling children, each of which invokes the
+    same utility flow. Both utility instances must expand fully.
+    """
+
+    def test_shared_utility_flow_expands_on_every_branch(self):
+        # parent -> [childA, childB]; childA -> utility; childB -> utility
+        # utility itself calls a leaf apex (so we can assert `utility`
+        # got fully inflated with a child, not just a stub).
+        flow_children = {
+            "parent": [
+                {"kind": "FLOW", "api_name": "childA", "element_name": "call_A"},
+                {"kind": "FLOW", "api_name": "childB", "element_name": "call_B"},
+            ],
+            "childA": [
+                {"kind": "FLOW", "api_name": "utility", "element_name": "call_util"},
+            ],
+            "childB": [
+                {"kind": "FLOW", "api_name": "utility", "element_name": "call_util"},
+            ],
+            "utility": [
+                {"kind": "APEX", "api_name": "XCSF_FlowFaultMessage", "element_name": "log"},
+            ],
+        }
+        root = {"kind": "FLOW", "api_name": "parent", "children": []}
+        pending = parse_wave.empty_kind_sets()
+
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending)
+
+        utilities = _find_all(root, "utility")
+        self.assertEqual(
+            len(utilities), 2,
+            "utility should appear once on each sibling branch",
+        )
+
+        # Both utility instances must have expanded children (the apex
+        # leaf). The regression shape was: first branch expanded, second
+        # either in `_pending_fetches` or emitted as an empty-children
+        # stub due to depth-cap or false-cycle pruning.
+        for i, u in enumerate(utilities):
+            kids = u.get("children", [])
+            self.assertEqual(
+                len(kids), 1,
+                f"utility instance {i} should have 1 expanded child, got {kids}",
+            )
+            self.assertEqual(kids[0]["api_name"], "XCSF_FlowFaultMessage")
+            self.assertNotIn("_truncated", u)
+            self.assertNotIn("_cycle_back_to", u)
+
+        # Critically: nothing pending. Shared-utility expansion must not
+        # leak into `_pending_fetches`.
+        self.assertEqual(pending["FLOW"], set())
+
+
+class TrueCycleDetectionTests(unittest.TestCase):
+    """Per-branch path-set must still catch genuine cycles."""
+
+    def test_true_cycle_detected(self):
+        """A -> B -> A: second A is annotated, not recursed into, and
+        not surfaced in `_pending_fetches`."""
+        flow_children = {
+            "A": [{"kind": "FLOW", "api_name": "B", "element_name": "call_B"}],
+            "B": [{"kind": "FLOW", "api_name": "A", "element_name": "call_A"}],
+        }
+        root = {"kind": "FLOW", "api_name": "A", "children": []}
+        pending = parse_wave.empty_kind_sets()
+
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending)
+
+        # A -> B -> A(cycle)
+        b = root["children"][0]
+        self.assertEqual(b["api_name"], "B")
+        a_cycle = b["children"][0]
+        self.assertEqual(a_cycle["api_name"], "A")
+        self.assertEqual(
+            a_cycle["_truncated"],
+            {"reason": "cycle", "target": "FLOW:A"},
+        )
+        self.assertEqual(a_cycle["_cycle_back_to"], "FLOW:A")
+
+        # Cycles live in the tree, not the pending accumulator.
+        self.assertEqual(pending["FLOW"], set())
+
+    def test_self_recursive_flow(self):
+        """A -> A: direct self-cycle is annotated on first recurrence."""
+        flow_children = {
+            "A": [{"kind": "FLOW", "api_name": "A", "element_name": "self_call"}],
+        }
+        root = {"kind": "FLOW", "api_name": "A", "children": []}
+        pending = parse_wave.empty_kind_sets()
+
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending)
+
+        kids = root.get("children", [])
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(kids[0]["api_name"], "A")
+        self.assertEqual(
+            kids[0]["_truncated"],
+            {"reason": "cycle", "target": "FLOW:A"},
+        )
+        self.assertEqual(pending["FLOW"], set())
+
+
+class DeepNonCyclicChainTests(unittest.TestCase):
+    """Linear chains longer than the old `MAX_BFS_DEPTH = 5` must
+    expand fully under the revised semantics. Previously they tripped
+    `PARTIAL_REASON=max-depth-cap`; now they expand cleanly.
+    """
+
+    def test_deep_non_cyclic_chain_fully_expands(self):
+        # A -> B -> C -> D -> E -> F -> G (7 unique flows, depth 6
+        # from the root). Old cap of 5 would have truncated at F;
+        # new cap of 20 doesn't care.
+        names = list("ABCDEFG")
+        flow_children: dict = {}
+        for i, n in enumerate(names):
+            if i + 1 < len(names):
+                flow_children[n] = [{
+                    "kind": "FLOW",
+                    "api_name": names[i + 1],
+                    "element_name": f"call_{names[i + 1]}",
+                }]
+            else:
+                flow_children[n] = []
+
+        root = {"kind": "FLOW", "api_name": "A", "children": []}
+        pending = parse_wave.empty_kind_sets()
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending)
+
+        node = root
+        for expected in names[1:]:
+            kids = node.get("children", [])
+            self.assertEqual(
+                len(kids), 1,
+                f"{node['api_name']} should have expanded child {expected}",
+            )
+            self.assertEqual(kids[0]["api_name"], expected)
+            self.assertNotIn("_truncated", kids[0])
+            node = kids[0]
+
+        # Terminal leaf has no children and carries no truncation
+        # annotation — the cap was never relevant.
+        self.assertEqual(node.get("children", []), [])
+        self.assertNotIn("_truncated", node)
+        self.assertEqual(pending["FLOW"], set())
+
+
+class DefensiveCapStillTerminatesTests(unittest.TestCase):
+    """Pathological chain longer than the defensive cap must still
+    terminate cleanly. This proves the safety net still works even
+    though per-branch cycle detection does the real work in practice.
+    """
+
+    def test_defensive_cap_still_terminates(self):
+        # 25 unique flows, linear — longer than the defensive cap of 20.
+        # Either the tree fully expands (if someone lifts the cap
+        # further) OR it caps at MAX_BFS_DEPTH and annotates the
+        # unreached flow. The test asserts termination and one of
+        # those two well-defined shapes.
+        n = 25
+        names = [f"F{i:02d}" for i in range(n)]
+        flow_children: dict = {}
+        for i, name in enumerate(names):
+            if i + 1 < n:
+                flow_children[name] = [{
+                    "kind": "FLOW",
+                    "api_name": names[i + 1],
+                    "element_name": "sub",
+                }]
+            else:
+                flow_children[name] = []
+
+        root = {"kind": "FLOW", "api_name": names[0], "children": []}
+        pending = parse_wave.empty_kind_sets()
+
+        # Primary assertion: this call terminates and does not recurse
+        # past Python's default recursion limit. If the defensive cap
+        # regresses, this test will hang or raise RecursionError.
+        parse_wave.inflate_flow_leaf(root, flow_children, pending_out=pending)
+
+        # Collect every flow that appears in the tree.
+        def all_api_names(node: dict) -> set[str]:
+            out = {node.get("api_name")}
+            for c in node.get("children", []) or []:
+                out.update(all_api_names(c))
+            return out - {None}
+
+        present = all_api_names(root)
+
+        # At least the first MAX_BFS_DEPTH flows must be present. The
+        # tail may or may not appear depending on where the cap trips.
+        for i in range(parse_wave.MAX_BFS_DEPTH):
+            self.assertIn(
+                names[i], present,
+                f"{names[i]} (index {i}) should be expanded — "
+                f"it's below MAX_BFS_DEPTH={parse_wave.MAX_BFS_DEPTH}",
+            )
+
+        # If any flow is pending, it must be a real descendant (not a
+        # fabricated name) and must carry the max-depth annotation
+        # somewhere in the tree.
+        if pending["FLOW"]:
+            for pending_name in pending["FLOW"]:
+                self.assertIn(pending_name, names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_probe_channels.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_probe_channels.py
@@ -1,0 +1,359 @@
+"""Tests for channel probe TTL (7d), mandatory-field gate,
+runtime invalidate + re-probe.
+
+Every test mocks `sf_cli.run_sf` — no real org calls. Cache dir is
+redirected into a tempdir via monkey-patching `config.PROBE_CACHE_ROOT`
+to keep tests hermetic.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import tempfile
+import time
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+from . import _bootstrap  # noqa: F401
+
+import config  # type: ignore
+import probe_channels  # type: ignore
+
+
+def _fake_describe_ok(fields: list[str]) -> dict:
+    """Shape the sf_cli.run_sf output: success envelope wrapping a fields list."""
+    return {
+        "status": 0,
+        "result": {
+            "fields": [{"name": f, "queryable": True} for f in fields],
+        },
+    }
+
+
+# A "universal" success payload: every mandatory field for every sObject
+# present. Individual tests override for specific sObjects.
+def _all_fields_ok_run_sf(recipe: str, **params: str) -> dict:
+    sobject = params["SOBJECT"]
+    mandatory = probe_channels.MANDATORY_FIELDS.get(sobject, set())
+    # Add a couple of bonus fields so queryable_fields isn't identical to
+    # mandatory_missing-inverse by construction.
+    extra = {"CreatedDate", "LastModifiedDate"}
+    return _fake_describe_ok(sorted(mandatory | extra))
+
+
+class ProbeChannelsCacheTests(unittest.TestCase):
+    """Cache hit / miss / TTL semantics."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._orig_root = config.PROBE_CACHE_ROOT
+        config.PROBE_CACHE_ROOT = Path(self._tmp.name) / "_channel_probe"
+
+    def tearDown(self) -> None:
+        config.PROBE_CACHE_ROOT = self._orig_root
+
+    def test_cache_hit_within_ttl_no_network(self):
+        """A fresh cache file + force_refresh=False → no run_sf calls."""
+        cache_dir = config.build_probe_cache_dir("00D000000000ABC", "v60.0")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / "channels.json"
+        payload = {
+            "_schema": "channels/1",
+            "_built_at_utc": time.time(),  # right now → fresh
+            "status": "OK",
+            "channels": {"BotDefinition": {"queryable_fields": ["Id"],
+                                           "mandatory_missing": [],
+                                           "describe_error": None}},
+        }
+        cache_file.write_text(json.dumps(payload))
+
+        with mock.patch.object(probe_channels, "run_sf") as m:
+            out = probe_channels.probe_channels(
+                "myorg", "00D000000000ABC", "v60.0", force_refresh=False,
+            )
+        self.assertEqual(out["status"], "OK")
+        m.assert_not_called()
+
+    def test_cache_stale_triggers_reprobe(self):
+        """Cached file older than TTL → re-run describes."""
+        cache_dir = config.build_probe_cache_dir("00D000000000ABC", "v60.0")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / "channels.json"
+        stale = {
+            "_schema": "channels/1",
+            "_built_at_utc": time.time() - (8 * 86400),  # 8 days old
+            "status": "OK",
+            "channels": {},
+        }
+        cache_file.write_text(json.dumps(stale))
+
+        with mock.patch.object(probe_channels, "run_sf",
+                               side_effect=_all_fields_ok_run_sf) as m:
+            out = probe_channels.probe_channels(
+                "myorg", "00D000000000ABC", "v60.0", force_refresh=False,
+            )
+        self.assertEqual(out["status"], "OK")
+        # One call per sObject.
+        self.assertEqual(m.call_count, len(probe_channels.ALL_SOBJECTS))
+
+    def test_force_refresh_always_reprobes(self):
+        """force_refresh=True bypasses a fresh cache."""
+        cache_dir = config.build_probe_cache_dir("00D000000000ABC", "v60.0")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / "channels.json"
+        fresh = {
+            "_schema": "channels/1",
+            "_built_at_utc": time.time(),
+            "status": "OK",
+            "channels": {},
+        }
+        cache_file.write_text(json.dumps(fresh))
+
+        with mock.patch.object(probe_channels, "run_sf",
+                               side_effect=_all_fields_ok_run_sf) as m:
+            probe_channels.probe_channels(
+                "myorg", "00D000000000ABC", "v60.0", force_refresh=True,
+            )
+        self.assertEqual(m.call_count, len(probe_channels.ALL_SOBJECTS))
+
+
+class InvalidateAndReprobeTests(unittest.TestCase):
+    """runtime escape valve when SOQL returns INVALID_FIELD."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._orig_root = config.PROBE_CACHE_ROOT
+        config.PROBE_CACHE_ROOT = Path(self._tmp.name) / "_channel_probe"
+
+    def tearDown(self) -> None:
+        config.PROBE_CACHE_ROOT = self._orig_root
+
+    def test_invalidate_deletes_cache_and_reruns(self):
+        cache_dir = config.build_probe_cache_dir("00D000000000ABC", "v60.0")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / "channels.json"
+        cache_file.write_text(json.dumps({
+            "_schema": "channels/1",
+            "_built_at_utc": time.time(),
+            "status": "OK",
+            "channels": {},
+        }))
+
+        with mock.patch.object(probe_channels, "run_sf",
+                               side_effect=_all_fields_ok_run_sf) as m:
+            out = probe_channels.invalidate_and_reprobe(
+                "myorg", "00D000000000ABC", "v60.0",
+            )
+
+        self.assertEqual(out["status"], "OK")
+        self.assertTrue(cache_file.is_file(), "fresh cache must be rewritten")
+        self.assertEqual(m.call_count, len(probe_channels.ALL_SOBJECTS))
+
+    def test_invalidate_tolerates_missing_cache(self):
+        """Cold-path invalidate (no file yet) must not crash."""
+        with mock.patch.object(probe_channels, "run_sf",
+                               side_effect=_all_fields_ok_run_sf):
+            out = probe_channels.invalidate_and_reprobe(
+                "myorg", "00D000000000ABC", "v60.0",
+            )
+        self.assertEqual(out["status"], "OK")
+
+
+class MandatoryFieldGateTests(unittest.TestCase):
+    """Missing mandatory field → status flips to PROBE_FAILED."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._orig_root = config.PROBE_CACHE_ROOT
+        config.PROBE_CACHE_ROOT = Path(self._tmp.name) / "_channel_probe"
+
+    def tearDown(self) -> None:
+        config.PROBE_CACHE_ROOT = self._orig_root
+
+    def test_missing_invocation_target_flags_probe_failed(self):
+        """SF release drops `InvocationTarget` on
+        GenAiFunctionDefinition → probe must surface PROBE_FAILED.
+        """
+
+        def mock_run_sf(recipe: str, **params: str) -> dict:
+            sobject = params["SOBJECT"]
+            mandatory = set(probe_channels.MANDATORY_FIELDS.get(sobject, set()))
+            if sobject == "GenAiFunctionDefinition":
+                # Simulate the schema drift: drop InvocationTarget.
+                mandatory.discard("InvocationTarget")
+            return _fake_describe_ok(sorted(mandatory))
+
+        with mock.patch.object(probe_channels, "run_sf", side_effect=mock_run_sf):
+            out = probe_channels.probe_channels(
+                "myorg", "00D000000000ABC", "v60.0", force_refresh=True,
+            )
+
+        self.assertEqual(out["status"], "PROBE_FAILED")
+        entry = out["channels"]["GenAiFunctionDefinition"]
+        self.assertIn("InvocationTarget", entry["mandatory_missing"])
+        # Other sObjects unaffected.
+        self.assertEqual(
+            out["channels"]["BotDefinition"]["mandatory_missing"], [],
+        )
+
+
+class CacheFilePermissionsTests(unittest.TestCase):
+    """cached channels.json must be 0o600 (owner RW only)."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._orig_root = config.PROBE_CACHE_ROOT
+        config.PROBE_CACHE_ROOT = Path(self._tmp.name) / "_channel_probe"
+
+    def tearDown(self) -> None:
+        config.PROBE_CACHE_ROOT = self._orig_root
+
+    def test_cache_file_is_mode_0o600(self):
+        with mock.patch.object(probe_channels, "run_sf",
+                               side_effect=_all_fields_ok_run_sf):
+            probe_channels.probe_channels(
+                "myorg", "00D000000000ABC", "v60.0", force_refresh=True,
+            )
+        cache_file = (
+            config.build_probe_cache_dir("00D000000000ABC", "v60.0")
+            / "channels.json"
+        )
+        self.assertTrue(cache_file.is_file())
+        mode = stat.S_IMODE(cache_file.stat().st_mode)
+        self.assertEqual(
+            mode, 0o600,
+            f"cache file mode must be 0o600, got 0o{mode:03o} ",
+        )
+
+
+class CacheFreshnessBoundsTests(unittest.TestCase):
+    """`_is_cache_fresh` must reject future timestamps as stale.
+
+    A `_built_at_utc` in the future is a symptom of clock skew (NTP
+    drift after suspend, container clock jump) or cache tampering —
+    either way, we treat it as untrustworthy and force a reprobe.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_future_timestamp_is_not_fresh(self):
+        # Year 3000 → unambiguously future.
+        future_epoch = 32503680000.0
+        cache_file = Path(self._tmp.name) / "channels.json"
+        cache_file.write_text(json.dumps({
+            "_schema": "channels/1",
+            "_built_at_utc": future_epoch,
+            "status": "OK",
+            "channels": {},
+        }))
+        self.assertFalse(
+            probe_channels._is_cache_fresh(cache_file, ttl_days=7),
+            "future _built_at_utc must be rejected as stale",
+        )
+
+    def test_present_timestamp_is_fresh(self):
+        cache_file = Path(self._tmp.name) / "channels.json"
+        cache_file.write_text(json.dumps({
+            "_schema": "channels/1",
+            "_built_at_utc": time.time(),
+            "status": "OK",
+            "channels": {},
+        }))
+        self.assertTrue(probe_channels._is_cache_fresh(cache_file, ttl_days=7))
+
+
+class WriteCacheConcurrencyTests(unittest.TestCase):
+    """concurrent _write_cache calls must not collide on tmp names.
+
+    The prior design used `path.with_suffix(path.suffix + ".tmp")` — a
+    deterministic name shared by every concurrent writer. This test
+    fires N threads that all write the same target path; after the dust
+    settles there must be exactly one final file, no leftover `.tmp`
+    files, and the contents must be valid JSON from ONE of the writers
+    (any of them is acceptable — what matters is integrity).
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_concurrent_writes_no_collision_no_corruption(self):
+        import threading
+
+        target_dir = Path(self._tmp.name) / "probe"
+        target_path = target_dir / "channels.json"
+
+        N = 8
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(N)
+
+        def worker(i: int) -> None:
+            payload = {
+                "_schema": "channels/1",
+                "_built_at_utc": float(i + 1),
+                "status": "OK",
+                "channels": {"writer": {"queryable_fields": [f"w{i}"]}},
+            }
+            barrier.wait()  # maximise contention
+            try:
+                probe_channels._write_cache(target_path, payload)
+            except BaseException as e:  # noqa: BLE001 — thread boundary
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        self.assertEqual(errors, [], f"worker errors: {errors}")
+        self.assertTrue(target_path.is_file())
+
+        # No stray tmp files left behind.
+        leftover = list(target_dir.glob(".channels.*.tmp"))
+        self.assertEqual(
+            leftover, [],
+            f"concurrent writes left tmp leftovers: {leftover}",
+        )
+
+        # Final file is parseable JSON (not a half-written corruption).
+        parsed = json.loads(target_path.read_text())
+        # One of the N payloads won the race; its _built_at_utc is in [1, N].
+        self.assertIn(parsed["_built_at_utc"], [float(i + 1) for i in range(N)])
+
+    def test_parent_dir_permissions_are_0o700(self):
+        """parent dir is normalized to 0o700 after write.
+
+        Even if the directory pre-existed with looser permissions, a
+        successful _write_cache leaves it at 0o700.
+        """
+        target_path = Path(self._tmp.name) / "probe" / "channels.json"
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        # Deliberately widen perms to prove _write_cache narrows them.
+        os.chmod(target_path.parent, 0o755)
+
+        probe_channels._write_cache(target_path, {
+            "_schema": "channels/1",
+            "_built_at_utc": time.time(),
+            "status": "OK",
+            "channels": {},
+        })
+
+        mode = stat.S_IMODE(target_path.parent.stat().st_mode)
+        self.assertEqual(
+            mode, 0o700,
+            f"parent dir mode must be 0o700, got 0o{mode:03o}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_probe_cli_recipes.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_probe_cli_recipes.py
@@ -1,0 +1,185 @@
+"""structural validation of the describe CLI recipes.
+
+Before these recipes shipped, `scripts/probe_channels.py::_describe_sobject`
+called `run_sf("describe_sobject", ...)` / `run_sf("describe_tooling_sobject",
+...)` against YAMLs that didn't exist on disk. Every unit test mocked
+`run_sf`, so the suite stayed green — but the first real invocation would
+have raised `SfCliError: recipe not found`. This module closes that gap
+by loading each YAML via `sf_cli._load_recipe` and asserting the schema
+`sf_cli.run_sf` expects.
+
+Deliberately does NOT invoke `sf sobject describe` — that needs a live
+org. Structural validation only; the wire-level contract is covered by
+the existing probe_channels integration path once the skill ships.
+"""
+from __future__ import annotations
+
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+from . import _bootstrap  # noqa: F401
+
+import sf_cli  # type: ignore
+
+# The test-suite process doesn't run under CLAUDE_PLUGIN_ROOT, so
+# `config.CLI_DIR` resolves to the (absent) `~/.claude/skills/...` path
+# by default. Repoint CLI_DIR at the repo's source-of-truth
+# `assets/cli/` directory — the YAMLs we're validating live there.
+_REPO_CLI_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "assets" / "cli"
+)
+
+
+class DescribeRecipeStructureTests(unittest.TestCase):
+    """Both describe recipes must parse + conform to the run_sf schema."""
+
+    def setUp(self) -> None:
+        # patch the module-level CLI_DIR binding inside sf_cli so
+        # _load_recipe reads from the repo's assets/cli/. `sf_cli`
+        # imported `CLI_DIR` by name at module load, so we must patch
+        # the *local* reference in sf_cli — patching `config.CLI_DIR`
+        # alone would leave the stale import behind.
+        self._patch = mock.patch.object(sf_cli, "CLI_DIR", _REPO_CLI_DIR)
+        self._patch.start()
+        self.addCleanup(self._patch.stop)
+
+    def _load(self, name: str) -> dict:
+        # _load_recipe is the same function run_sf uses at runtime, so if
+        # it parses here it will parse in production. yaml.safe_load + the
+        # mapping-shape guard both run inside _load_recipe .
+        return sf_cli._load_recipe(name)
+
+    # ---- parsing + mapping shape -----------------------------------------
+
+    def test_describe_sobject_parses(self):
+        recipe = self._load("describe_sobject")
+        self.assertIsInstance(recipe, dict)
+        self.assertEqual(recipe.get("name"), "describe_sobject")
+
+    def test_describe_tooling_sobject_parses(self):
+        recipe = self._load("describe_tooling_sobject")
+        self.assertIsInstance(recipe, dict)
+        self.assertEqual(recipe.get("name"), "describe_tooling_sobject")
+
+    # ---- required_params: a list, covers what probe_channels passes -------
+
+    def test_required_params_are_list_of_strings(self):
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                required = recipe.get("required_params")
+                self.assertIsInstance(required, list)
+                self.assertTrue(
+                    all(isinstance(p, str) for p in required),
+                    f"{name}: required_params must be list[str]",
+                )
+                # probe_channels._describe_sobject passes exactly these two.
+                # If the recipe drops either, run_sf will SfCliError before
+                # the subprocess call — so assert both are present.
+                self.assertIn("ORG_ALIAS", required)
+                self.assertIn("SOBJECT", required)
+
+    # ---- argv: a list of strings with both placeholders referenced --------
+
+    def test_argv_is_list_of_strings(self):
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                argv = recipe.get("argv")
+                self.assertIsInstance(argv, list)
+                self.assertGreater(len(argv), 0)
+                self.assertTrue(
+                    all(isinstance(e, str) for e in argv),
+                    f"{name}: argv must be list[str]",
+                )
+
+    def test_argv_references_both_required_placeholders(self):
+        """Every key in required_params must appear as `{{KEY}}` somewhere
+        in argv — otherwise the substitution is a no-op and the caller's
+        input never reaches the CLI. Defensive sanity check, not a
+        functional run.
+        """
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                argv_joined = " ".join(recipe["argv"])
+                for key in recipe.get("required_params") or []:
+                    self.assertIn(
+                        f"{{{{{key}}}}}", argv_joined,
+                        f"{name}: required param {key} not referenced in argv",
+                    )
+
+    # ---- success_check contract -----------------------------------------
+
+    def test_success_check_is_stdout_json_status_zero(self):
+        """run_sf's success-detection code path (in sf_cli.run_sf) assumes
+        `stdout_json_status_zero`. Any other value silently changes the
+        pass/fail contract, so pin it.
+        """
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                self.assertEqual(
+                    recipe.get("success_check"), "stdout_json_status_zero",
+                )
+
+    # ---- timeout is a positive int ---------------------------------------
+
+    def test_timeout_is_positive_int(self):
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                t = recipe.get("timeout_seconds")
+                self.assertIsInstance(t, int)
+                self.assertGreater(t, 0)
+
+    # ---- auth_required_stderr_patterns -----------------------------------
+
+    def test_auth_patterns_cover_the_known_failures(self):
+        """sf CLI surfaces `NoOrgAuthenticationError` for a never-logged-in
+        alias and `AuthInfoError` for a stale/revoked session. Both must
+        classify as AuthRequired, not a generic SfCliError, so the skill
+        can prompt the user to re-login instead of aborting.
+        """
+        for name in ("describe_sobject", "describe_tooling_sobject"):
+            with self.subTest(recipe=name):
+                recipe = self._load(name)
+                patterns = recipe.get("auth_required_stderr_patterns") or []
+                self.assertIn("NoOrgAuthenticationError", patterns)
+                self.assertIn("AuthInfoError", patterns)
+
+    # ---- tooling recipe has --use-tooling-api; data-API recipe does NOT ---
+
+    def test_tooling_recipe_uses_tooling_api_flag(self):
+        recipe = self._load("describe_tooling_sobject")
+        self.assertIn("--use-tooling-api", recipe["argv"])
+
+    def test_data_api_recipe_does_not_use_tooling_api_flag(self):
+        """Separating the two recipes rather than toggling via a param
+        was a deliberate design call (call sites stay explicit). Verify
+        the separation hasn't regressed into a single merged recipe.
+        """
+        recipe = self._load("describe_sobject")
+        self.assertNotIn("--use-tooling-api", recipe["argv"])
+
+    # ---- run_sf missing-param surfacing runs end-to-end through recipe ----
+
+    def test_run_sf_raises_cleanly_when_required_param_absent(self):
+        """This exercises the full load_recipe → required_params check
+        path inside run_sf, with a REAL (on-disk) recipe rather than a
+        mock. If the YAML parses but required_params is malformed, this
+        would surface as something other than SfCliError with a clear
+        'missing required params' message.
+        """
+        with self.assertRaises(sf_cli.SfCliError) as ctx:
+            # Deliberately omit SOBJECT — should raise at the required-
+            # params check, well before subprocess.run. Pass ORG_ALIAS so
+            # we isolate the failure to the missing param.
+            sf_cli.run_sf("describe_sobject", ORG_ALIAS="whatever")
+        self.assertIn("missing required params", str(ctx.exception))
+        self.assertIn("SOBJECT", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_render_architecture.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_render_architecture.py
@@ -1,0 +1,806 @@
+"""Tests for render_architecture.render + load_mermaid.
+
+P2.2-1: exercise every per-generation branch (classic ReAct, classic
+Sequential, NGA ConcurrentMultiAgent, search/BYOP placeholder), the
+_partial / _unresolved / cycle surfaces, and the node-cap behaviour.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401 — sys.path setup
+
+import render_architecture  # type: ignore
+
+# The test-suite process doesn't run under CLAUDE_PLUGIN_ROOT, so
+# `config.MERMAID_DIR` resolves to `~/.claude/skills/.../assets/mermaid`
+# which is absent on the CI / repo host. Repoint the module-local
+# MERMAID_DIR inside render_architecture at the repo's source-of-truth
+# directory — same pattern used by test_probe_cli_recipes for CLI_DIR.
+_REPO_MERMAID_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "assets" / "mermaid"
+)
+
+
+def _classic_react_tree() -> dict:
+    """MyAgent v5 shape — classic ReAct, 2 topics, a handful of
+    children to keep the fixture inline-readable."""
+    return {
+        "_schema_version": "3.0",
+        "agent": {
+            "api_name": "MyAgent",
+            "version": "v5",
+            "master_label": "Xero support AI",
+            "description": "External-facing service agent.",
+            "agent_type": "EinsteinAgentKind",
+            "type": "ExternalCopilot",
+            "agent_template": "SvcCopilotTmpl__EinsteinAgentKind",
+            "bot_source": "None",
+            "generation": "classic",
+            "planner_name": "MyAgent_v2_v3_v4_v5",
+            "planner_type": "AiCopilot__ReAct",
+            "bot_id": "0XxXx00000000FdKAI",
+        },
+        "root": {
+            "kind": "BOT_DEFINITION",
+            "api_name": "MyAgent",
+            "children": [
+                {
+                    "kind": "TOPIC",
+                    "api_name": "Customer_Q_A",
+                    "children": [
+                        {
+                            "kind": "GEN_AI_FUNCTION",
+                            "api_name": "Find_Articles",
+                            "unwraps_to": {"kind": "FLOW",
+                                           "api_name": "Find_Public_Articles"},
+                            "children": [
+                                {
+                                    "kind": "FLOW",
+                                    "api_name": "Find_Public_Articles",
+                                    "children": [
+                                        {"kind": "APEX",
+                                         "api_name": "KnowledgeRetriever"},
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "kind": "TOPIC",
+                    "api_name": "Escalation",
+                    "children": [
+                        {
+                            "kind": "GEN_AI_FUNCTION",
+                            "api_name": "Escalate",
+                            "unwraps_to": {"kind": "APEX",
+                                           "api_name": "EscalateAction"},
+                            "children": [
+                                {"kind": "APEX", "api_name": "EscalateAction"},
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        "node_count": 8,
+        "depth": 4,
+        "_partial": False,
+        "_pending_fetches": {"Flow": [], "ApexClass": [], "GenAiPromptTemplate": []},
+        "_unresolved": [],
+        "_kind_counts": {
+            "BOT_DEFINITION": 1,
+            "TOPIC": 2,
+            "GEN_AI_FUNCTION": 2,
+            "FLOW": 1,
+            "APEX": 2,
+        },
+    }
+
+
+def _nga_tree() -> dict:
+    t = _classic_react_tree()
+    t["agent"]["generation"] = "nga"
+    t["agent"]["planner_name"] = "Atlas__ConcurrentMultiAgentOrchestration"
+    t["agent"]["planner_type"] = "Atlas__ConcurrentMultiAgentOrchestration"
+    return t
+
+
+def _sequential_tree() -> dict:
+    """Zero-topic Sequential planner (classic)."""
+    return {
+        "_schema_version": "3.0",
+        "agent": {
+            "api_name": "KAMAgent",
+            "version": "v5",
+            "generation": "classic",
+            "planner_name": "KAM_Planner",
+            "planner_type": "AiCopilot__SequentialPlannerIntentClassifier",
+        },
+        "root": {
+            "kind": "BOT_DEFINITION",
+            "api_name": "KAMAgent",
+            "children": [
+                {
+                    "kind": "GEN_AI_FUNCTION",
+                    "api_name": "SalesPlay",
+                    "children": [],
+                },
+            ],
+        },
+        "node_count": 2,
+        "depth": 1,
+        "_partial": False,
+        "_pending_fetches": {},
+        "_unresolved": [],
+        "_kind_counts": {"BOT_DEFINITION": 1, "GEN_AI_FUNCTION": 1},
+    }
+
+
+def _write_tree(tmp: Path, tree: dict) -> Path:
+    p = tmp / "metadata_tree.json"
+    p.write_text(json.dumps(tree))
+    return p
+
+
+class _RenderTestBase(unittest.TestCase):
+    """Shared setup: patch MERMAID_DIR at the renderer binding + tmp dir.
+
+    Every test that invokes `render_architecture.render` or
+    `render_architecture.load_mermaid` needs the MERMAID_DIR redirected
+    at the repo's `assets/mermaid/` (the `~/.claude/skills/...` install
+    path doesn't exist in the test environment). Patching here keeps
+    each per-branch TestCase focused on behaviour.
+    """
+
+    def setUp(self) -> None:
+        self._patch = mock.patch.object(
+            render_architecture, "MERMAID_DIR", _REPO_MERMAID_DIR,
+        )
+        self._patch.start()
+        self.addCleanup(self._patch.stop)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+
+class RenderClassicReActTests(_RenderTestBase):
+    def test_all_eight_sections_present(self):
+        tree_path = _write_tree(self.tmp, _classic_react_tree())
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        # Section headers 2..8 all present; H1 covers section 1.
+        # Invocation sequence (formerly section 3) was removed from the
+        # default pipeline in 2026-05 — the heuristic was not trusted.
+        # Planner state machine (formerly section 6) was also removed in
+        # 2026-05. Both `_render_invocation_sequence` and
+        # `_render_planner_state` stay callable for a future re-enable;
+        # see `test_nga_invocation_sequence_has_orchestrator_lane` and
+        # `test_nga_state_diagram_has_par_and_block`.
+        self.assertIn("# Architecture", text)
+        for heading in (
+            "## 2. Anatomy summary",
+            "## 3. Action tree",
+            "## 4. Topic anatomy",
+            "## 5. Action catalog",
+            "## 6. Data flow / context propagation",
+            "## 7. Flow / Apex / Prompt catalogs",
+            "## 8. Unresolved refs + artifact pointers",
+        ):
+            self.assertIn(heading, text)
+        # Explicit regression guard: the retired sections must NOT appear.
+        self.assertNotIn("## 3. Invocation sequence", text)
+        self.assertNotIn("Invocation sequence", text)
+        self.assertNotIn("Planner state machine", text)
+
+    def test_two_mermaid_diagrams_rendered(self):
+        tree_path = _write_tree(self.tmp, _classic_react_tree())
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        # each diagram-kind keyword must appear as a bare
+        # non-comment line inside exactly one fenced block. Keywords in
+        # prose inside `%%` comments are now harmless (Mermaid parses
+        # them as comments at render time), so we don't policework the
+        # comment contents — we only require a real keyword line.
+        # sequenceDiagram was removed from the default pipeline in 2026-05
+        # along with the Invocation sequence section; stateDiagram-v2
+        # was removed the same cycle along with Planner state machine.
+        import re
+        blocks = re.findall(r"```mermaid\n(.*?)\n```", text, re.DOTALL)
+        keywords = {"flowchart TB", "flowchart LR"}
+        seen_keywords: set[str] = set()
+        for b in blocks:
+            for ln in b.splitlines():
+                stripped = ln.strip()
+                if stripped.startswith("%%"):
+                    continue
+                if stripped in keywords:
+                    seen_keywords.add(stripped)
+        self.assertEqual(seen_keywords, keywords)
+        # Regression: sequenceDiagram and stateDiagram-v2 must NOT appear
+        # in the default render.
+        for b in blocks:
+            for ln in b.splitlines():
+                stripped = ln.strip()
+                if stripped.startswith("%%"):
+                    continue
+                self.assertNotEqual(stripped, "sequenceDiagram")
+                self.assertNotEqual(stripped, "stateDiagram-v2")
+        # Every block must be fully substituted — no stray `{{PARAM}}`
+        # tokens left behind. removed the `{{...}}` from
+        # comment headers precisely to make this invariant hold.
+        for b in blocks:
+            self.assertNotIn("{{", b)
+            self.assertNotIn("}}", b)
+        # No dependency graph when _unresolved is empty.
+        self.assertNotIn("## Dependency graph", text)
+
+    def test_react_state_machine_not_in_default_render(self):
+        # Planner state machine was retired from the default pipeline in
+        # 2026-05. Thought/Action/Observation states are emitted by
+        # `_render_planner_state` which is still tested directly but not
+        # wired into `render`.
+        tree_path = _write_tree(self.tmp, _classic_react_tree())
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertNotIn("Thought", text)
+        self.assertNotIn("Action --> Observation", text)
+
+
+class RenderNgaTests(_RenderTestBase):
+    def test_nga_state_diagram_has_par_and_block(self):
+        # `_render_planner_state` was removed from the default render
+        # pipeline in 2026-05, but the function + mermaid template are
+        # retained so the feature can be re-enabled by uncommenting one
+        # line in `render`. This test exercises the function directly to
+        # keep the NGA par/and-block behaviour covered.
+        tree = _nga_tree()
+        rendered = render_architecture._render_planner_state(
+            tree["agent"], "nga",
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        # par/and block marker is the `--` separator inside an `Orchestration`
+        # state nest. Also confirm the lanes differ from ReAct.
+        self.assertIn("state Orchestration", rendered)
+        self.assertIn("--", rendered)
+        self.assertIn("SubAgentA", rendered)
+        self.assertIn("SubAgentB", rendered)
+        # ReAct-specific states must NOT appear.
+        self.assertNotIn("Thought", rendered)
+
+    def test_nga_invocation_sequence_has_orchestrator_lane(self):
+        # `_render_invocation_sequence` was removed from the default
+        # render pipeline in 2026-05 (heuristic distrusted), but the
+        # function + mermaid template are retained so the feature can
+        # be re-enabled by uncommenting one line in `render`. This test
+        # exercises the function directly to keep the behaviour covered.
+        tree = _nga_tree()
+        walker = render_architecture._TreeWalker(tree)
+        walker.walk()
+        rendered = render_architecture._render_invocation_sequence(
+            tree, tree["agent"], walker,
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        self.assertIn("participant Orchestrator", rendered)
+        self.assertIn("participant SubAgent", rendered)
+
+
+class RenderSequentialTests(_RenderTestBase):
+    def test_sequential_zero_topic_produces_empty_topic_section(self):
+        tree_path = _write_tree(self.tmp, _sequential_tree())
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("_No topics defined", text)
+        # Sequential state machine uses Classify -> Execute, but the
+        # Planner state machine section was retired from the default
+        # pipeline in 2026-05 — exercise the helper directly instead.
+        rendered = render_architecture._render_planner_state(
+            _sequential_tree()["agent"], "classic",
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        self.assertIn("Classify --> Execute", rendered)
+
+    def test_sequential_does_not_emit_react_states(self):
+        tree_path = _write_tree(self.tmp, _sequential_tree())
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertNotIn("Thought", text)
+        self.assertNotIn("Orchestration", text)
+
+
+class RenderPartialTreeTests(_RenderTestBase):
+    def test_partial_true_emits_health_callout(self):
+        tree = _classic_react_tree()
+        tree["_partial"] = True
+        tree["_partial_reason"] = "flow-metadata-timeout"
+        tree["_pending_fetches"] = {"FLOW": ["Foo", "Bar"], "APEX": []}
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("**Health: PARTIAL.**", text)
+        self.assertIn("flow-metadata-timeout", text)
+        self.assertIn("Pending fetches: 2", text)
+
+    def test_missing_planner_name_emits_warn(self):
+        tree = _classic_react_tree()
+        tree["agent"]["planner_name"] = None
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("`planner_name` missing", text)
+
+
+class RenderUnresolvedAndCyclesTests(_RenderTestBase):
+    def test_unresolved_renders_dependency_graph(self):
+        tree = _classic_react_tree()
+        tree["_unresolved"] = [
+            {"kind": "FLOW", "api_name": "Missing_Flow",
+             "reason": "not-in-org"},
+        ]
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("## Dependency graph", text)
+        self.assertIn("Missing_Flow", text)
+        # Section 8 renders the unresolved row in its table.
+        self.assertIn("not-in-org", text)
+
+    def test_cycle_annotation_renders_dotted_back_edge(self):
+        tree = _classic_react_tree()
+        # Inject a _cycle_back_to annotation on the Find_Public_Articles flow.
+        tree["root"]["children"][0]["children"][0]["children"][0][
+            "_cycle_back_to"] = "Find_Public_Articles"
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        # Dotted back-edge syntax `-.->` plus the `cycle_back_to:` label.
+        self.assertIn("-.->", text)
+        self.assertIn("cycle_back_to", text)
+
+
+class RenderNodeCapTests(_RenderTestBase):
+    def _large_tree(self, n_actions: int) -> dict:
+        tree = _classic_react_tree()
+        # Overwrite the second topic with a fan-out of n_actions children.
+        big_topic = {
+            "kind": "TOPIC",
+            "api_name": "Mega_Topic",
+            "children": [
+                {
+                    "kind": "GEN_AI_FUNCTION",
+                    "api_name": f"Action_{i:03d}",
+                    "children": [
+                        {"kind": "APEX", "api_name": f"ApexClass_{i:03d}"},
+                    ],
+                }
+                for i in range(n_actions)
+            ],
+        }
+        tree["root"]["children"] = [big_topic]
+        tree["_kind_counts"] = {
+            "BOT_DEFINITION": 1,
+            "TOPIC": 1,
+            "GEN_AI_FUNCTION": n_actions,
+            "APEX": n_actions,
+        }
+        return tree
+
+    def test_flowchart_cap_exceeded_emits_placeholder(self):
+        # 250 actions + 250 apex + 1 topic + 1 bot = 502 nodes > 200 cap.
+        tree = self._large_tree(250)
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("[diagram truncated: flowchart", text)
+        self.assertIn("exceed cap of 200", text)
+        # Top-5 fan-out line present.
+        self.assertIn("Top 5 nodes by fan-out", text)
+        # Mega_Topic shows up as a top fan-out node.
+        self.assertIn("Mega_Topic", text)
+
+    def test_react_30_topics_does_not_false_trip_sequence_cap(self):
+        # pre-fix, msg_count was computed as
+        # `2 * len(topics) + len(actions) + 2`, which for 30 topics
+        # yields 62+ > cap=60. But ReAct only samples topics[:5], so
+        # the rendered sequence has ~14 messages — nowhere near the
+        # cap. Assert the diagram renders, no truncation placeholder.
+        # 2026-05: `_render_invocation_sequence` is no longer wired
+        # into `render`; invoke it directly so the cap math stays
+        # covered.
+        tree = _classic_react_tree()
+        topics = [
+            {
+                "kind": "TOPIC",
+                "api_name": f"Topic_{i:02d}",
+                "children": [
+                    {"kind": "GEN_AI_FUNCTION",
+                     "api_name": f"Action_{i:02d}"},
+                ],
+            }
+            for i in range(30)
+        ]
+        tree["root"]["children"] = topics
+        tree["_kind_counts"] = {
+            "BOT_DEFINITION": 1, "TOPIC": 30, "GEN_AI_FUNCTION": 30,
+        }
+        walker = render_architecture._TreeWalker(tree)
+        walker.walk()
+        rendered = render_architecture._render_invocation_sequence(
+            tree, tree["agent"], walker,
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        self.assertNotIn("[diagram truncated: sequenceDiagram", rendered)
+        self.assertIn("sequenceDiagram", rendered)
+        # Sampling at :5 means exactly 5 topics show up in the messages.
+        # Topic_00..Topic_04 must appear; Topic_05 must not.
+        self.assertIn("Topic_04", rendered)
+        self.assertNotIn("Topic_05", rendered)
+
+    def test_sequence_cap_trips_on_actually_rendered_overflow(self):
+        # construct a scenario where the rendered message
+        # list truly exceeds the cap. We use a tiny cap (5) rather than
+        # fabricating 60+ NGA messages — the test's intent is "cap math
+        # is evaluated against the rendered list", not "cap=60 is
+        # specifically correct".
+        # 2026-05: invoke `_render_invocation_sequence` directly since
+        # the section was retired from the default pipeline.
+        tree = _classic_react_tree()
+        walker = render_architecture._TreeWalker(tree)
+        walker.walk()
+        caps = dict(render_architecture.DEFAULT_MAX_MERMAID_NODES)
+        caps["sequenceDiagram"] = 3
+        rendered = render_architecture._render_invocation_sequence(
+            tree, tree["agent"], walker, caps,
+        )
+        self.assertIn("[diagram truncated: sequenceDiagram", rendered)
+        self.assertIn("exceed cap of 3", rendered)
+
+
+class RenderLoadMermaidTests(_RenderTestBase):
+    def test_nested_placeholder_in_value_logs_warning(self):
+        with self.assertLogs(render_architecture.logger, level="WARNING") as cm:
+            out = render_architecture.load_mermaid(
+                "invocation_sequence",
+                PARTICIPANTS="participant {{NESTED}}",
+                MESSAGES="User->>+Planner: x",
+            )
+        self.assertTrue(any("nested placeholder" in m for m in cm.output))
+        # Still renders — the nested token is left as-is (no second pass).
+        self.assertIn("{{NESTED}}", out)
+
+    def test_missing_template_raises_filenotfounderror_without_path(self):
+        with self.assertRaises(FileNotFoundError) as ctx:
+            render_architecture.load_mermaid("nonexistent_template_zzz")
+        msg = str(ctx.exception)
+        self.assertIn("nonexistent_template_zzz", msg)
+        # Hygiene: absolute SKILL_ROOT path must not bleed through.
+        self.assertNotIn("/assets/mermaid", msg)
+
+    def test_traversal_name_rejected_without_absolute_path_leak(self):
+        # The hygiene contract is that the absolute MERMAID_DIR path
+        # must not appear in the error text — echoing the caller's
+        # own input back (which here happens to contain `/etc/passwd`)
+        # is fine; that's information the caller already had.
+        with self.assertRaises(FileNotFoundError) as ctx:
+            render_architecture.load_mermaid("../../../etc/passwd")
+        msg = str(ctx.exception)
+        self.assertNotIn(str(_REPO_MERMAID_DIR), msg)
+        # Also must not leak the default install path under ~/.claude.
+        self.assertNotIn("/.claude/skills/", msg)
+
+    def test_non_string_param_raises_typeerror(self):
+        with self.assertRaises(TypeError):
+            render_architecture.load_mermaid(
+                "invocation_sequence",
+                PARTICIPANTS=None,  # type: ignore[arg-type]
+                MESSAGES="x",
+            )
+
+    def test_leading_comment_block_preserved_but_not_substituted(self):
+        # the `%%` header comments in the shipped templates
+        # are kept in rendered output (Mermaid ignores `%%` lines at
+        # render time). The prior _strip_leading_comment_block workaround
+        # was a misdiagnosis — the real bug was templates documenting
+        # placeholders as `{{NAME}}` inside `%%` comments, causing
+        # load_mermaid's str.replace to substitute them.
+        out = render_architecture.load_mermaid(
+            "action_tree", SUBGRAPHS="SG_INJECTED", EDGES="EDGES_INJECTED",
+        )
+        # Header comments survive.
+        self.assertTrue(out.startswith("%%"))
+        # `%%` lines must not have been corrupted by substitution.
+        for ln in out.splitlines():
+            if ln.startswith("%%"):
+                self.assertNotIn("SG_INJECTED", ln)
+                self.assertNotIn("EDGES_INJECTED", ln)
+        # Diagram-kind keyword still present on its own bare line.
+        self.assertIn("\nflowchart TB", "\n" + out)
+        # Placeholders in the body were substituted exactly once.
+        self.assertIn("SG_INJECTED", out)
+        self.assertIn("EDGES_INJECTED", out)
+
+
+class RenderEmptyAndSearchTests(_RenderTestBase):
+    def test_empty_bot_definition_renders_without_crash(self):
+        tree = {
+            "_schema_version": "3.0",
+            "agent": {
+                "api_name": "Empty",
+                "version": "v1",
+                "generation": "classic",
+                "planner_type": "AiCopilot__ReAct",
+                "planner_name": "Empty_Planner",
+            },
+            "root": {"kind": "BOT_DEFINITION", "api_name": "Empty",
+                     "children": []},
+            "node_count": 1,
+            "depth": 0,
+            "_partial": False,
+            "_unresolved": [],
+            "_kind_counts": {"BOT_DEFINITION": 1},
+        }
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+        self.assertIn("_No topics defined", text)
+        self.assertIn("_No actions declared._", text)
+        self.assertIn("_No backing artifacts in tree._", text)
+
+    def test_search_generation_skips_state_diagram(self):
+        # Planner state machine was retired from the default render in
+        # 2026-05. Exercise `_render_planner_state` directly to keep the
+        # search-generation prose-placeholder branch covered.
+        tree = _classic_react_tree()
+        tree["agent"]["generation"] = "search"
+        tree["agent"]["planner_type"] = "custom_search_Apex"
+        rendered = render_architecture._render_planner_state(
+            tree["agent"], "search",
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        self.assertIn("Custom planner", rendered)
+        self.assertNotIn("stateDiagram-v2", rendered)
+
+    def test_byop_generation_skips_state_diagram(self):
+        # Same 2026-05 retirement — exercise the helper directly.
+        tree = _classic_react_tree()
+        tree["agent"]["generation"] = "byop"
+        rendered = render_architecture._render_planner_state(
+            tree["agent"], "byop",
+            dict(render_architecture.DEFAULT_MAX_MERMAID_NODES),
+        )
+        self.assertIn("Custom planner", rendered)
+
+
+class RenderPromptCatalogTests(_RenderTestBase):
+    """Section-7 'Prompt templates' sub-section shape.
+
+    Flows and Apex classes each get an H4 per entry with a fenced
+    signature block. Prompts were historically rendered as a bare bullet
+    list (just names) which left the reader with no indication of what
+    each prompt does. We now mirror the flow/apex shape: H4 heading,
+    optional `Type:` line, optional signature fence, `_Details not
+    captured._` fallback when the walker has no metadata on the node.
+    Wave B doesn't yet stamp prompt signatures — the renderer just has
+    to be ready for when it does."""
+
+    def _tree_with_prompts(self, prompt_nodes: list[dict]) -> dict:
+        """Wrap two prompt nodes under a TOPIC -> GEN_AI_FUNCTION so the
+        walker indexes them into `walker.prompts`."""
+        tree = _classic_react_tree()
+        tree["root"]["children"].append({
+            "kind": "TOPIC",
+            "api_name": "PromptTopic",
+            "children": [
+                {
+                    "kind": "GEN_AI_FUNCTION",
+                    "api_name": "UsePrompts",
+                    "children": prompt_nodes,
+                },
+            ],
+        })
+        return tree
+
+    def test_prompt_h4_per_entry_with_type_and_fallback(self):
+        r"""Two prompts: one with `prompt_type` set, one without. Both
+        get H4 headings. The typed one shows ``Type: `flex```; the
+        bare one shows `_Details not captured._`."""
+        tree = self._tree_with_prompts([
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "DraftReply",
+                "prompt_type": "flex",
+                "children": [],
+            },
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "SummarizeThread",
+                "children": [],
+            },
+        ])
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+
+        self.assertIn("### Prompt templates", text)
+        # Both prompts render as H4, not as bare bullets.
+        self.assertIn("#### `DraftReply`", text)
+        self.assertIn("#### `SummarizeThread`", text)
+        self.assertNotIn("- `DraftReply`", text)
+        self.assertNotIn("- `SummarizeThread`", text)
+        # Typed prompt surfaces its Type line.
+        self.assertIn("- Type: `flex`", text)
+        # Untyped prompt (no signature either) falls back honestly.
+        # Locate the SummarizeThread block and confirm its body.
+        import re
+        m = re.search(
+            r"#### `SummarizeThread`\n\n(.*?)(?:\n#### |\n### |\n## |\Z)",
+            text, re.DOTALL,
+        )
+        self.assertIsNotNone(m, "SummarizeThread prompt block not found")
+        self.assertIn("_Details not captured._", m.group(1))
+
+    def test_prompt_with_signature_renders_fenced_block(self):
+        """When a prompt node carries a `signature` (future Wave B
+        stamp), the renderer emits it inside a fenced code block, same
+        shape used for flows/apex."""
+        tree = self._tree_with_prompts([
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "ClassifyIntent",
+                "prompt_type": "genAiPromptTemplate",
+                "signature": "in: userUtterance: String | out: intent: String",
+                "children": [],
+            },
+        ])
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+
+        self.assertIn("#### `ClassifyIntent`", text)
+        self.assertIn("- Type: `genAiPromptTemplate`", text)
+        # Fenced signature block present.
+        self.assertIn(
+            "```\nin: userUtterance: String | out: intent: String\n```",
+            text,
+        )
+        # No fallback when we have either type or sig.
+        import re
+        m = re.search(
+            r"#### `ClassifyIntent`\n\n(.*?)(?:\n#### |\n### |\n## |\Z)",
+            text, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        self.assertNotIn("_Details not captured._", m.group(1))
+
+
+class RenderPromptTemplateBodyTests(_RenderTestBase):
+    """Gap C (2026-05-05): prompt template bodies retrieved via
+    `retrieve_prompt_templates` are stamped onto PROMPT_TEMPLATE leaves
+    as `master_label`, `content`, `inputs`, `_body_available`. The
+    renderer emits:
+      - `_Label: <master_label>_` blurb
+      - `**Inputs**:` bulleted list
+      - fenced `text` code block for the content
+      - `_Body not retrieved._` when `_body_available` is False and no
+        other details are available
+    """
+
+    def _tree_with_prompts(self, prompt_nodes: list[dict]) -> dict:
+        tree = _classic_react_tree()
+        tree["root"]["children"].append({
+            "kind": "TOPIC",
+            "api_name": "PromptTopic",
+            "children": [
+                {
+                    "kind": "GEN_AI_FUNCTION",
+                    "api_name": "UsePrompts",
+                    "children": prompt_nodes,
+                },
+            ],
+        })
+        return tree
+
+    def test_body_rendered_with_label_inputs_and_fenced_content(self):
+        tree = self._tree_with_prompts([
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "AGNT_US_Q_A_with_Site_Scraping",
+                "master_label": "AGNT - US Q&A with Site Scraping",
+                "content": "# ROLE & OBJECTIVE\nAnswer the customer question.",
+                "inputs": [
+                    {"name": "Query", "dataType": "String"},
+                    {"name": "Site", "dataType": "String"},
+                ],
+                "_body_available": True,
+                "children": [],
+            },
+        ])
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+
+        self.assertIn(
+            "#### `AGNT_US_Q_A_with_Site_Scraping`", text,
+        )
+        self.assertIn("_Label: AGNT - US Q&A with Site Scraping_", text)
+        self.assertIn("**Inputs**:", text)
+        self.assertIn("- `Query`: `String`", text)
+        self.assertIn("- `Site`: `String`", text)
+        # Fenced content block uses `text` language hint.
+        self.assertIn(
+            "```text\n# ROLE & OBJECTIVE\nAnswer the customer question.\n```",
+            text,
+        )
+        self.assertNotIn("_Details not captured._", text)
+        self.assertNotIn("_Body not retrieved._", text)
+
+    def test_body_unavailable_falls_back_honestly(self):
+        tree = self._tree_with_prompts([
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "MissingTpl",
+                "_body_available": False,
+                "children": [],
+            },
+        ])
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+
+        self.assertIn("#### `MissingTpl`", text)
+        import re
+        m = re.search(
+            r"#### `MissingTpl`\n\n(.*?)(?:\n#### |\n### |\n## |\Z)",
+            text, re.DOTALL,
+        )
+        self.assertIsNotNone(m)
+        block = m.group(1)
+        self.assertIn("_Body not retrieved._", block)
+        # No content fence; no Inputs block.
+        self.assertNotIn("```text", block)
+        self.assertNotIn("**Inputs**:", block)
+
+    def test_inputs_without_datatype_still_render(self):
+        """Older templates may omit <dataType> on <inputs>. Render the
+        name alone rather than crashing or dropping the input."""
+        tree = self._tree_with_prompts([
+            {
+                "kind": "PROMPT_TEMPLATE",
+                "api_name": "LegacyTpl",
+                "content": "body",
+                "inputs": [{"name": "Query"}],
+                "_body_available": True,
+                "children": [],
+            },
+        ])
+        tree_path = _write_tree(self.tmp, tree)
+        out = self.tmp / "architecture.md"
+        render_architecture.render(tree_path, out)
+        text = out.read_text()
+
+        self.assertIn("**Inputs**:", text)
+        self.assertIn("- `Query`", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_bot.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_bot.py
@@ -1,0 +1,203 @@
+"""Tests for ``resolve_bot`` — Bot + version resolution helpers + main flow.
+
+Covers the small pure helpers (``scrub``, ``natural_key``,
+``emit_error_block``) plus a happy-path ``main`` end-to-end with
+``subprocess.run`` mocked.
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import resolve_bot  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# scrub
+# -----------------------------------------------------------------------------
+
+
+class ScrubTests(unittest.TestCase):
+
+    def test_strips_dangerous_shell_chars(self):
+        # ` $ " \\ \r \t \0 \n all stripped; safe chars kept verbatim.
+        self.assertEqual(
+            resolve_bot.scrub("hello`bad$\"" + "\n" + "world"),
+            "hellobadworld",
+        )
+
+    def test_strips_carriage_return_and_tab(self):
+        self.assertEqual(resolve_bot.scrub("a\tb\rc"), "abc")
+
+    def test_returns_empty_string_for_none(self):
+        self.assertEqual(resolve_bot.scrub(None), "")
+
+    def test_coerces_non_strings(self):
+        self.assertEqual(resolve_bot.scrub(42), "42")
+
+    def test_passes_safe_chars_through(self):
+        self.assertEqual(resolve_bot.scrub("Customer_Support_Agent"),
+                         "Customer_Support_Agent")
+
+
+# -----------------------------------------------------------------------------
+# natural_key — version sorting
+# -----------------------------------------------------------------------------
+
+
+class NaturalKeyTests(unittest.TestCase):
+
+    def test_sorts_v10_after_v9(self):
+        keys = ["v9", "v10", "v2", "v1"]
+        keys.sort(key=resolve_bot.natural_key, reverse=True)
+        self.assertEqual(keys, ["v10", "v9", "v2", "v1"])
+
+    def test_handles_none_and_empty_string(self):
+        # Both should be safe (empty list)
+        self.assertEqual(resolve_bot.natural_key(""), [""])
+        self.assertEqual(resolve_bot.natural_key(None), [""])
+
+
+# -----------------------------------------------------------------------------
+# emit_error_block — terminal RESULT block + sys.exit
+# -----------------------------------------------------------------------------
+
+
+class EmitErrorBlockTests(unittest.TestCase):
+
+    def test_emits_result_block_and_exits_one(self):
+        old_env = dict(os.environ)
+        os.environ["AGENT_API_NAME"] = "MyAgent"
+        os.environ["ORG_ID_15"] = "00D000000000000"
+        os.environ["ORG_ID_18"] = "00D000000000000EAA"
+        os.environ.pop("ERROR_TEE", None)
+        try:
+            with mock.patch.object(resolve_bot.sys, "stdout") as out:
+                with self.assertRaises(SystemExit) as ctx:
+                    resolve_bot.emit_error_block(
+                        "AGENT_NOT_FOUND", "details here", {"AVAILABLE_BOTS": "A,B"},
+                    )
+            self.assertEqual(ctx.exception.code, 1)
+            written = "".join(c.args[0] for c in out.write.call_args_list)
+            self.assertIn("STATUS=AGENT_NOT_FOUND", written)
+            self.assertIn("ERROR_DETAIL=details here", written)
+            self.assertIn("AGENT_API_NAME=MyAgent", written)
+            self.assertIn("AVAILABLE_BOTS=A,B", written)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
+    def test_writes_error_tee_when_env_set(self):
+        with TemporaryDirectory() as t:
+            tee_path = Path(t) / "subdir" / "tee.txt"
+            old_env = dict(os.environ)
+            os.environ["ERROR_TEE"] = str(tee_path)
+            os.environ["AGENT_API_NAME"] = "MyAgent"
+            os.environ["ORG_ID_15"] = "x"
+            os.environ["ORG_ID_18"] = "y"
+            try:
+                with mock.patch.object(resolve_bot.sys, "stdout"):
+                    with self.assertRaises(SystemExit):
+                        resolve_bot.emit_error_block("X", "y", {})
+                # tee_path got the same content
+                self.assertTrue(tee_path.is_file())
+                self.assertIn("STATUS=X", tee_path.read_text())
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+
+
+# -----------------------------------------------------------------------------
+# main — happy path with mocked sf data query
+# -----------------------------------------------------------------------------
+
+
+def _versions_payload() -> str:
+    return json.dumps({
+        "result": {
+            "records": [
+                {"DeveloperName": "v3", "Status": "Active",
+                 "BotDefinitionId": "0Xx000000000ABC",
+                 "BotDefinition": {"DeveloperName": "MyAgent",
+                                   "MasterLabel": "My Agent"}},
+                {"DeveloperName": "v2", "Status": "Inactive",
+                 "BotDefinitionId": "0Xx000000000ABC",
+                 "BotDefinition": {"DeveloperName": "MyAgent",
+                                   "MasterLabel": "My Agent"}},
+            ],
+        },
+    })
+
+
+def _bot_def_payload() -> str:
+    return json.dumps({
+        "result": {
+            "records": [
+                {"DeveloperName": "MyAgent", "MasterLabel": "My Agent",
+                 "Description": "demo", "AgentType": "Internal",
+                 "Type": "AiCopilot", "AgentTemplate": "T",
+                 "BotSource": "AgentforceAgentCopilot"},
+            ],
+        },
+    })
+
+
+class MainTests(unittest.TestCase):
+
+    def _run_main(self, *, agent_version: str = "") -> tuple[int, str]:
+        old_env = dict(os.environ)
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            os.environ["ORG_ALIAS"] = "my-org"
+            os.environ["AGENT_API_NAME"] = "MyAgent"
+            os.environ["WORK_DIR"] = str(tmp)
+            os.environ["AGENT_VERSION"] = agent_version
+
+            calls: list = []
+
+            def fake_run(argv, **kw):
+                # Two distinct sf data queries: BotVersion then BotDefinition
+                calls.append(argv)
+                if "BotVersion" in argv[-1]:
+                    return SimpleNamespace(returncode=0, stdout=_versions_payload(), stderr="")
+                if "BotDefinition" in argv[-1]:
+                    return SimpleNamespace(returncode=0, stdout=_bot_def_payload(), stderr="")
+                return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+            stdout_buf: list[str] = []
+
+            try:
+                with mock.patch.object(resolve_bot.subprocess, "run", side_effect=fake_run):
+                    with mock.patch.object(resolve_bot.sys, "stdout") as out:
+                        out.write = lambda s: stdout_buf.append(s)
+                        rc = resolve_bot.main()
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+        return rc, "".join(stdout_buf)
+
+    def test_main_succeeds_with_auto_pick(self):
+        rc, written = self._run_main()
+        self.assertEqual(rc, 0)
+        # v3 is Active and lexically highest → auto-picked
+        self.assertIn("AGENT_VERSION=v3", written)
+        self.assertIn("VERSION_AUTO_PICKED=true", written)
+        self.assertIn("BOT_FOUND=true", written)
+        self.assertIn("BOT_ID=0Xx000000000ABC", written)
+
+    def test_main_succeeds_with_explicit_version_match(self):
+        rc, written = self._run_main(agent_version="v2")
+        self.assertEqual(rc, 0)
+        self.assertIn("AGENT_VERSION=v2", written)
+        self.assertIn("VERSION_AUTO_PICKED=false", written)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_creds.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_creds.py
@@ -1,0 +1,157 @@
+"""Tests for ``main._resolve_creds`` — the two-path access-token retrieval
+introduced for forcedotcom/cli#3560 (sf CLI v2 redaction, effective
+2026-05-27).
+
+Path 1 (primary): ``sf org auth show-access-token --json --no-prompt``
+                  via the ``show_access_token`` recipe.
+Path 2 (fallback): ``sf org display`` payload with
+                   ``SF_TEMP_SHOW_SECRETS=true`` env var.
+
+We mock ``run_sf`` (not subprocess) since these tests target the
+orchestration logic in ``main.py``, not the recipe loader. The recipe
+loader and subprocess env injection have their own coverage in
+``test_sf_cli.py``.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import main  # type: ignore
+from sf_cli import AuthRequired, SfCliError  # type: ignore
+
+
+REDACTED_TOKEN = "[REDACTED] Use 'sf org auth show-access-token' to view"
+
+
+def _display_payload(*, instance_url="https://example.salesforce.com",
+                     access_token="TOKEN_FROM_DISPLAY"):
+    return {"result": {
+        "instanceUrl": instance_url,
+        "accessToken": access_token,
+    }}
+
+
+def _show_token_payload(*, access_token="TOKEN_FROM_SHOW"):
+    return {"result": {"accessToken": access_token}}
+
+
+class ResolveCredsTests(unittest.TestCase):
+    """Cover every branch of the two-path retrieval."""
+
+    def _route(self, *, primary_payload=None, primary_exc=None,
+               display_payload=None):
+        """Build a ``run_sf`` side-effect that dispatches by recipe name."""
+        display = display_payload or _display_payload()
+        primary = primary_payload or _show_token_payload()
+
+        def fake_run_sf(name, **params):
+            if name == "org_display":
+                return display
+            if name == "show_access_token":
+                if primary_exc is not None:
+                    raise primary_exc
+                return primary
+            raise AssertionError(f"unexpected recipe: {name}")
+
+        return fake_run_sf
+
+    def test_primary_path_returns_show_token(self):
+        """Happy path — dedicated command returns a clean token."""
+        with mock.patch.object(main, "run_sf", side_effect=self._route()):
+            url, token = main._resolve_creds("my-org")
+        self.assertEqual(url, "https://example.salesforce.com")
+        self.assertEqual(token, "TOKEN_FROM_SHOW")
+
+    def test_primary_unknown_falls_back_to_display(self):
+        """Older sf CLI without the dedicated command surfaces SfCliError;
+        we fall back to the display payload's accessToken."""
+        with mock.patch.object(
+            main, "run_sf",
+            side_effect=self._route(
+                primary_exc=SfCliError("sf CLI 'show_access_token' failed"),
+            ),
+        ):
+            url, token = main._resolve_creds("my-org")
+        self.assertEqual(url, "https://example.salesforce.com")
+        self.assertEqual(token, "TOKEN_FROM_DISPLAY")
+
+    def test_primary_returns_redacted_token_falls_back(self):
+        """Edge case: dedicated command runs cleanly but returns the
+        placeholder string. Treat as failure and use the display fallback."""
+        with mock.patch.object(
+            main, "run_sf",
+            side_effect=self._route(
+                primary_payload=_show_token_payload(access_token=REDACTED_TOKEN),
+            ),
+        ):
+            _, token = main._resolve_creds("my-org")
+        self.assertEqual(token, "TOKEN_FROM_DISPLAY")
+
+    def test_primary_returns_empty_token_falls_back(self):
+        """Empty string from the dedicated command also triggers fallback."""
+        with mock.patch.object(
+            main, "run_sf",
+            side_effect=self._route(
+                primary_payload=_show_token_payload(access_token=""),
+            ),
+        ):
+            _, token = main._resolve_creds("my-org")
+        self.assertEqual(token, "TOKEN_FROM_DISPLAY")
+
+    def test_both_paths_redacted_raises_authrequired(self):
+        """If both paths come back redacted/empty, surface AuthRequired
+        rather than handing the placeholder to downstream Tooling/REST
+        callers (which would 401 with INVALID_AUTH_HEADER)."""
+        with mock.patch.object(
+            main, "run_sf",
+            side_effect=self._route(
+                primary_payload=_show_token_payload(access_token=REDACTED_TOKEN),
+                display_payload=_display_payload(access_token=REDACTED_TOKEN),
+            ),
+        ):
+            with self.assertRaises(AuthRequired) as ctx:
+                main._resolve_creds("my-org")
+        self.assertIn("could not retrieve a usable access token", str(ctx.exception))
+
+    def test_missing_instance_url_raises_authrequired(self):
+        """display returning empty instanceUrl is a hard failure — no
+        amount of token-juggling helps if we can't talk to the org."""
+        with mock.patch.object(
+            main, "run_sf",
+            side_effect=self._route(
+                display_payload=_display_payload(instance_url=""),
+            ),
+        ):
+            with self.assertRaises(AuthRequired) as ctx:
+                main._resolve_creds("my-org")
+        self.assertIn("instanceUrl", str(ctx.exception))
+
+    def test_primary_path_recipe_name_is_show_access_token(self):
+        """Tripwire — the primary call MUST go through the
+        ``show_access_token`` recipe. Without it the patch silently
+        regresses to the env-var-only path on sf CLI versions that
+        already shipped the dedicated command."""
+        recipes_called: list[str] = []
+
+        def fake_run_sf(name, **params):
+            recipes_called.append(name)
+            if name == "org_display":
+                return _display_payload()
+            if name == "show_access_token":
+                return _show_token_payload()
+            raise AssertionError(f"unexpected recipe: {name}")
+
+        with mock.patch.object(main, "run_sf", side_effect=fake_run_sf):
+            main._resolve_creds("my-org")
+
+        self.assertIn("show_access_token", recipes_called)
+        # And the alias was passed through:
+        # (We don't capture params here, but the recipe loader enforces
+        # required_params at run_sf time — see test_sf_cli.py.)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_invocation_target.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_resolve_invocation_target.py
@@ -1,0 +1,145 @@
+"""Tests for resolve_invocation_target.resolve_target_id never raises,
+and `resolve_or_unresolved` records unknown prefixes + invalid shapes into
+`_unresolved[]` so the wave orchestrator can keep running when Salesforce
+ships a new NGA target type.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import resolve_invocation_target as rit  # type: ignore
+
+
+# A valid-shape Salesforce Id is 15 or 18 alphanumeric chars. Prefixes below
+# are chosen to avoid collision with _PREFIX_MAP so they exercise the
+# "unknown prefix" path.
+_APEX_ID_15 = "01p0000000ABC12"
+_APEX_ID_18 = "01p0000000ABC12AAA"
+_FLOW_DEF_ID_15 = "3000000000XYZ99"
+_FLOW_VER_ID_15 = "3010000000XYZ99"
+_PROMPT_ID_15 = "0hf0000000QRS77"
+_UNKNOWN_PREFIX_ID_15 = "0aN000000000XYZ"
+
+
+class KnownPrefixTests(unittest.TestCase):
+    def test_apex_prefix(self):
+        self.assertEqual(rit.resolve_target_id(_APEX_ID_15), ("apex", "tooling_soql"))
+
+    def test_flow_definition_prefix(self):
+        self.assertEqual(
+            rit.resolve_target_id(_FLOW_DEF_ID_15),
+            ("flow_definition", "tooling_soql"),
+        )
+
+    def test_flow_version_prefix(self):
+        self.assertEqual(
+            rit.resolve_target_id(_FLOW_VER_ID_15),
+            ("flow_version", "tooling_soql"),
+        )
+
+    def test_prompt_template_prefix(self):
+        self.assertEqual(
+            rit.resolve_target_id(_PROMPT_ID_15),
+            ("prompt_template", "retrieve_required"),
+        )
+
+    def test_eighteen_char_id_works(self):
+        self.assertEqual(
+            rit.resolve_target_id(_APEX_ID_18),
+            ("apex", "tooling_soql"),
+        )
+
+
+class UnknownPrefixTests(unittest.TestCase):
+    def test_resolve_target_id_never_raises(self):
+        # Unknown prefix → ("unknown", "skip"), no exception.
+        self.assertEqual(
+            rit.resolve_target_id(_UNKNOWN_PREFIX_ID_15),
+            ("unknown", "skip"),
+        )
+
+    def test_resolve_or_unresolved_records_unknown_prefix(self):
+        unresolved: list[dict] = []
+        result = rit.resolve_or_unresolved(_UNKNOWN_PREFIX_ID_15, unresolved)
+        self.assertEqual(result, ("unknown", "skip"))
+        self.assertEqual(len(unresolved), 1)
+        entry = unresolved[0]
+        self.assertEqual(entry["id"], _UNKNOWN_PREFIX_ID_15)
+        self.assertEqual(entry["reason"], "unknown-id-prefix:0aN")
+
+    def test_known_prefix_does_not_touch_unresolved(self):
+        unresolved: list[dict] = []
+        result = rit.resolve_or_unresolved(_APEX_ID_15, unresolved)
+        self.assertEqual(result, ("apex", "tooling_soql"))
+        self.assertEqual(unresolved, [])
+
+
+class InvalidShapeTests(unittest.TestCase):
+    def test_empty_string(self):
+        unresolved: list[dict] = []
+        result = rit.resolve_or_unresolved("", unresolved)
+        self.assertEqual(result, ("unknown", "skip"))
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["reason"], "invalid-id-format")
+        self.assertEqual(unresolved[0]["id"], "")
+
+    def test_none_coerced_via_str(self):
+        unresolved: list[dict] = []
+        result = rit.resolve_or_unresolved(None, unresolved)
+        self.assertEqual(result, ("unknown", "skip"))
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["reason"], "invalid-id-format")
+        self.assertEqual(unresolved[0]["id"], "None")
+
+    def test_wrong_length_is_invalid(self):
+        # A 10-char id-like string is not 15 or 18 — invalid shape, not
+        # an unknown prefix.
+        unresolved: list[dict] = []
+        rit.resolve_or_unresolved("01pABC1234", unresolved)
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["reason"], "invalid-id-format")
+
+    def test_bad_chars_rejected(self):
+        # 15-char length but contains punctuation — not an Id shape.
+        unresolved: list[dict] = []
+        rit.resolve_or_unresolved("01p!!!!!!!!!!99", unresolved)
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["reason"], "invalid-id-format")
+
+    def test_short_string_is_invalid(self):
+        unresolved: list[dict] = []
+        rit.resolve_or_unresolved("ab", unresolved)
+        self.assertEqual(len(unresolved), 1)
+        self.assertEqual(unresolved[0]["reason"], "invalid-id-format")
+
+
+class RegisteredPrefixesTests(unittest.TestCase):
+    def test_exact_membership(self):
+        self.assertEqual(
+            rit.REGISTERED_PREFIXES,
+            frozenset({"01p", "300", "301", "0hf"}),
+        )
+
+    def test_is_frozenset(self):
+        """Immutable so callers can't accidentally corrupt the table."""
+        self.assertIsInstance(rit.REGISTERED_PREFIXES, frozenset)
+
+
+class ResolveTargetIdRobustnessTests(unittest.TestCase):
+    """`resolve_target_id` is the lower-level helper — it must also never
+    raise, even on garbage input."""
+
+    def test_none_input(self):
+        self.assertEqual(rit.resolve_target_id(None), ("unknown", "skip"))  # type: ignore[arg-type]
+
+    def test_empty_string(self):
+        self.assertEqual(rit.resolve_target_id(""), ("unknown", "skip"))
+
+    def test_too_short(self):
+        self.assertEqual(rit.resolve_target_id("ab"), ("unknown", "skip"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_rest_client.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_rest_client.py
@@ -1,0 +1,1253 @@
+"""Tests for  (cross-host redirect strips Authorization) and
+ (redact_error scrubs bearer tokens).
+
+adds: `retry_on_401` decorator + `tooling_query` / `data_query`
+helpers. Tests cover both the HTTP-401 and the INVALID_SESSION_ID-in-body
+code paths, as well as the non-auth-error propagation guarantee.
+"""
+from __future__ import annotations
+
+import email.message
+import email.utils
+import io
+import json
+import time
+import unittest
+import unittest.mock as mock
+import urllib.error
+import urllib.request
+
+from . import _bootstrap  # noqa: F401
+
+import rest_client  # type: ignore
+
+
+class RedirectHeaderStripTests(unittest.TestCase):
+    """Authorization must be dropped on cross-host redirect."""
+
+    def setUp(self) -> None:
+        self.handler = rest_client.StripAuthOnCrossHostRedirect()
+        # Minimal stand-in for the `fp` argument — the handler ignores it
+        # except when constructing HTTPError on unsupported-scheme paths.
+        self.fp = io.BytesIO(b"")
+        # Headers are a Message-like; handler reads nothing from it for
+        # the 302 path. An empty dict-like suffices.
+        self.msg = {}
+
+    def _make_request(self, url: str, auth: str = "Bearer tok123"):
+        req = urllib.request.Request(url)
+        if auth:
+            req.add_header("Authorization", auth)
+        return req
+
+    def _has_authorization(self, req) -> bool:
+        for k in list(req.headers.keys()) + list(req.unredirected_hdrs.keys()):
+            if k.lower() == "authorization":
+                return True
+        return False
+
+    def test_same_host_redirect_preserves_authorization(self):
+        req = self._make_request("https://na1.salesforce.com/services/data/v60.0/query")
+        new_req = self.handler.redirect_request(
+            req, self.fp, 302, "Found", self.msg,
+            "https://na1.salesforce.com/services/data/v60.0/query?page=2",
+        )
+        self.assertIsNotNone(new_req)
+        self.assertTrue(
+            self._has_authorization(new_req),
+            "same-host redirect must preserve Authorization",
+        )
+
+    def test_cross_host_redirect_strips_authorization(self):
+        req = self._make_request("https://na1.salesforce.com/services/data/v60.0/query")
+        new_req = self.handler.redirect_request(
+            req, self.fp, 302, "Found", self.msg,
+            "https://attacker.example.com/steal",
+        )
+        self.assertIsNotNone(new_req)
+        self.assertFalse(
+            self._has_authorization(new_req),
+            "cross-host redirect must strip Authorization ",
+        )
+
+    def test_downgrade_to_http_cross_host_strips(self):
+        """A redirect from HTTPS→HTTP on a different host is the classic
+        MITM bait. Authorization must not follow."""
+        req = self._make_request("https://na1.salesforce.com/services/data/v60.0/query")
+        new_req = self.handler.redirect_request(
+            req, self.fp, 302, "Found", self.msg,
+            "http://attacker.example.com/",
+        )
+        self.assertIsNotNone(new_req)
+        self.assertFalse(self._has_authorization(new_req))
+
+    def test_case_insensitive_host_match(self):
+        """DNS is case-insensitive — `Foo.com` and `foo.com` are same host."""
+        req = self._make_request("https://Foo.Salesforce.com/path")
+        new_req = self.handler.redirect_request(
+            req, self.fp, 302, "Found", self.msg,
+            "https://foo.salesforce.com/other",
+        )
+        self.assertIsNotNone(new_req)
+        self.assertTrue(self._has_authorization(new_req))
+
+    def test_build_opener_wires_the_handler(self):
+        opener = rest_client.build_opener()
+        self.assertIsInstance(opener, urllib.request.OpenerDirector)
+        installed = [
+            h for h in opener.handlers
+            if isinstance(h, rest_client.StripAuthOnCrossHostRedirect)
+        ]
+        self.assertEqual(
+            len(installed), 1,
+            "build_opener must install exactly one StripAuthOnCrossHostRedirect",
+        )
+
+
+class RedactErrorTests(unittest.TestCase):
+    """redact_error must scrub bearer tokens from exception strings."""
+
+    def test_bearer_token_redacted(self):
+        # Scanner-inert placeholder — redactor only cares about the
+        # `Authorization: Bearer ` prefix; the value is opaque `\S+`.
+        raw = "Authorization: Bearer TESTONLY_HEADER.TESTONLY_PAYLOAD.TESTONLY_SIG"
+        exc = RuntimeError(raw)
+        out = rest_client.redact_error(exc)
+        self.assertIn("<redacted>", out)
+        self.assertNotIn("TESTONLY_HEADER", out)
+        self.assertNotIn("TESTONLY_PAYLOAD", out)
+
+    def test_bearer_token_case_insensitive(self):
+        exc = RuntimeError("authorization: BEARER TESTONLY_BEARER_VALUE")
+        out = rest_client.redact_error(exc)
+        self.assertNotIn("TESTONLY_BEARER_VALUE", out)
+
+    def test_access_token_querystring_redacted(self):
+        exc = RuntimeError("POST /oauth/token accessToken=TESTONLY_TOKEN&foo=1")
+        out = rest_client.redact_error(exc)
+        self.assertNotIn("TESTONLY_TOKEN", out)
+        self.assertIn("<redacted>", out)
+        # The non-sensitive tail is preserved — handy for debugging.
+        self.assertIn("foo=1", out)
+
+    def test_access_token_snake_case_querystring_redacted(self):
+        exc = RuntimeError("access_token=TESTONLY_SNAKE_TOKEN&other=ok")
+        out = rest_client.redact_error(exc)
+        self.assertNotIn("TESTONLY_SNAKE_TOKEN", out)
+        self.assertIn("other=ok", out)
+
+    def test_access_token_json_redacted(self):
+        exc = RuntimeError('{"accessToken":"TESTONLY_JSON_TOKEN","status":0}')
+        out = rest_client.redact_error(exc)
+        self.assertNotIn("TESTONLY_JSON_TOKEN", out)
+        self.assertIn("<redacted>", out)
+        # Non-sensitive JSON preserved.
+        self.assertIn("status", out)
+
+    def test_access_token_json_snake_case_redacted(self):
+        exc = RuntimeError('{"access_token":"tok.ABC"}')
+        out = rest_client.redact_error(exc)
+        self.assertNotIn("tok.ABC", out)
+
+    def test_output_includes_exception_type(self):
+        exc = ValueError("boring message")
+        out = rest_client.redact_error(exc)
+        self.assertTrue(out.startswith("ValueError:"))
+
+    def test_empty_exception_safe(self):
+        exc = RuntimeError("")
+        out = rest_client.redact_error(exc)
+        self.assertTrue(out.startswith("RuntimeError:"))
+
+    def test_plain_message_unchanged(self):
+        exc = RuntimeError("connection refused")
+        out = rest_client.redact_error(exc)
+        self.assertIn("connection refused", out)
+
+
+class RedactTextPublicSymbolTests(unittest.TestCase):
+    """`redact_text` is the public symbol; `_redact_text` stays as
+    a deprecated alias for backwards compatibility.
+    """
+
+    def test_redact_text_importable_at_module_top(self):
+        """Public name must be reachable via a plain `from` import — this
+        is what sf_cli now relies on at module-top import time.
+        """
+        from rest_client import redact_text  # noqa: F401
+        self.assertTrue(callable(redact_text))
+
+    def test_redact_text_same_behavior_as_alias(self):
+        """The deprecated alias must be bound to the same function object
+        so behavior drift is impossible.
+        """
+        self.assertIs(rest_client._redact_text, rest_client.redact_text)
+
+    def test_underscore_alias_still_works(self):
+        """Backwards-compat: any lingering `from rest_client import
+        _redact_text` must keep functioning until the alias is removed
+        in a follow-up batch.
+        """
+        from rest_client import _redact_text  # noqa: F401
+        out = _redact_text("Authorization: Bearer tokXYZ")
+        self.assertIn("<redacted>", out)
+        self.assertNotIn("tokXYZ", out)
+
+    def test_public_redact_text_scrubs_bearer(self):
+        out = rest_client.redact_text("Authorization: Bearer secrettok")
+        self.assertNotIn("secrettok", out)
+        self.assertIn("<redacted>", out)
+
+
+def _make_http_error(code: int, body: bytes = b"") -> urllib.error.HTTPError:
+    """Build a minimal HTTPError carrying `code` + `body`.
+
+    We don't need a real socket — the decorator only reads `.code` and
+    (optionally) the stringified form. Body is passed for parity with
+    the wire.
+    """
+    return urllib.error.HTTPError(
+        url="https://example.salesforce.com/x",
+        code=code,
+        msg="error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+class RetryOn401Tests(unittest.TestCase):
+    """decorator refreshes the token on 401 and retries once."""
+
+    def test_401_then_success_calls_refresh_once(self):
+        """Wrapped fn raises 401 first, succeeds on retry.
+
+        refresh_fn MUST be called exactly once; wrapped fn returns normally.
+        """
+        call_count = {"n": 0}
+
+        def wrapped():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _make_http_error(401)
+            return {"ok": True}
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        result = decorated()
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(refresh_calls), 1, "refresh_fn must be called exactly once")
+        self.assertEqual(call_count["n"], 2)
+
+    def test_401_twice_reraises_with_original_context(self):
+        """Second 401 → original 401 context surfaces (wrapped as RestClientError).
+
+        refresh_fn still called only once (no infinite retry).
+        """
+
+        def wrapped():
+            raise _make_http_error(401, body=b"session bad")
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        with self.assertRaises(rest_client.RestClientError) as ctx:
+            decorated()
+
+        self.assertIn("auth error after refresh", str(ctx.exception))
+        self.assertEqual(len(refresh_calls), 1, "refresh_fn must be called only once")
+
+    def test_invalid_session_body_triggers_refresh(self):
+        """INVALID_SESSION_ID signalled via body (HTTP 200) → refresh + retry."""
+        call_count = {"n": 0}
+
+        def wrapped():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise rest_client._InvalidSessionSignal("body had INVALID_SESSION_ID")
+            return {"ok": True}
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        result = decorated()
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(refresh_calls), 1)
+
+    def test_non_auth_http_error_propagates_without_refresh(self):
+        """500 → NO refresh, error propagates as-is."""
+
+        def wrapped():
+            raise _make_http_error(500)
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            decorated()
+
+        self.assertEqual(ctx.exception.code, 500)
+        self.assertEqual(len(refresh_calls), 0, "500 must NOT trigger refresh")
+
+    def test_retry_error_messages_go_through_redact_error(self):
+        """A token baked into the original 401 body must not survive in the
+        RestClientError that gets re-raised on the second 401.
+        """
+
+        def wrapped():
+            # The HTTPError's str form echoes url + code. We bake a bearer
+            # token into the msg to exercise the redact path on the
+            # re-raise.
+            err = urllib.error.HTTPError(
+                url="https://example.salesforce.com",
+                code=401,
+                msg="Authorization: Bearer TESTONLY_HTTPERROR_TOKEN",
+                hdrs={},  # type: ignore[arg-type]
+                fp=io.BytesIO(b""),
+            )
+            raise err
+
+        def refresh():
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        with self.assertRaises(rest_client.RestClientError) as ctx:
+            decorated()
+        msg = str(ctx.exception)
+        self.assertNotIn("TESTONLY_HTTPERROR_TOKEN", msg)
+        # The redaction sentinel must appear somewhere — proof the
+        # substitution actually ran.
+        self.assertIn("<redacted>", msg)
+
+
+class QueryHelperTests(unittest.TestCase):
+    """tooling_query + data_query — happy paths with mocked opener."""
+
+    def _install_mock_opener(self, response_body: bytes):
+        """Monkeypatch build_opener to return an opener whose .open returns
+        a context manager yielding an object with .read() == response_body.
+        """
+        fake_resp = mock.MagicMock()
+        fake_resp.read.return_value = response_body
+        fake_resp.__enter__ = mock.MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = mock.MagicMock(return_value=False)
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = mock.MagicMock(return_value=fake_resp)
+        return mock.patch.object(
+            rest_client, "build_opener", return_value=fake_opener
+        )
+
+    def test_tooling_query_happy_path(self):
+        body = json.dumps({"records": [{"Id": "01p000000000001"}]}).encode("utf-8")
+        with self._install_mock_opener(body):
+            out = rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertEqual(out["records"][0]["Id"], "01p000000000001")
+
+    def test_data_query_happy_path(self):
+        body = json.dumps({"totalSize": 0, "records": []}).encode("utf-8")
+        with self._install_mock_opener(body):
+            out = rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM Account LIMIT 1",
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertEqual(out["totalSize"], 0)
+
+    def test_tooling_query_apex_body_with_marker_does_not_trigger_refresh(self):
+        """BUGFIX 2026-05-03: 200 OK Tooling response where ApexClass.Body
+        references `INVALID_SESSION_ID` in source must pass through
+        unchanged — no refresh, no retry, no error wrapping."""
+        good_body = json.dumps({
+            "size": 1,
+            "totalSize": 1,
+            "done": True,
+            "queryLocator": None,
+            "entityTypeName": "ApexClass",
+            "records": [
+                {
+                    "attributes": {"type": "ApexClass"},
+                    "Id": "01pUv000003a1YaIAI",
+                    "Name": "XCSF_FlowFaultMessage",
+                    "Body": "// if (code == 'INVALID_SESSION_ID') rethrow;",
+                }
+            ],
+        }).encode("utf-8")
+
+        open_count = {"n": 0}
+
+        def fake_open(req):
+            open_count["n"] += 1
+            resp = mock.MagicMock()
+            resp.read.return_value = good_body
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        with mock.patch.object(rest_client, "build_opener", return_value=fake_opener):
+            out = rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id, Name, Body FROM ApexClass WHERE Id IN (...)",
+                api_version="v66.0",
+                on_401_refresh=refresh,
+            )
+
+        self.assertEqual(out["totalSize"], 1)
+        self.assertEqual(out["records"][0]["Name"], "XCSF_FlowFaultMessage")
+        self.assertEqual(open_count["n"], 1,
+                         "exactly one HTTP call — no spurious retry")
+        self.assertEqual(refresh_calls, [],
+                         "refresh must not fire on a 200 OK success payload")
+
+    def test_tooling_query_invalid_session_in_body_triggers_refresh(self):
+        """HTTP 200 with INVALID_SESSION_ID body → refresh closure invoked."""
+        bad_body = json.dumps([
+            {"errorCode": "INVALID_SESSION_ID", "message": "Session expired"}
+        ]).encode("utf-8")
+        good_body = json.dumps({"records": []}).encode("utf-8")
+
+        # Two-shot opener: first call returns bad_body, second returns good.
+        responses = [bad_body, good_body]
+
+        def fake_open(req):
+            resp = mock.MagicMock()
+            resp.read.return_value = responses.pop(0)
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        with mock.patch.object(rest_client, "build_opener", return_value=fake_opener):
+            out = rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=refresh,
+            )
+
+        self.assertEqual(out, {"records": []})
+        self.assertEqual(len(refresh_calls), 1)
+
+
+class RetryOn401CredentialRefreshIntegrationTests(unittest.TestCase):
+    """Verify the retry carries the NEW token, not the stale one.
+
+    The previous design looked correct under unit tests (refresh_fn called
+    once, retry returns success) but was broken end-to-end: the closure
+    around `(instance_url, token)` was captured at decoration time, so
+    `refresh_fn`'s return value was thrown away and the retry saw the
+    SAME stale credentials. Any real 401 (bad token) would hit the retry
+    with the same bad token and 401 again.
+
+    This test exercises a full tooling_query through a mock opener that
+    401s for the stale token and succeeds for the refreshed token. A
+    fix that only changes decorator bookkeeping (without threading the
+    refresh into the retry's actual HTTP call) will fail this test.
+    """
+
+    def test_retry_on_401_uses_refreshed_credentials(self):
+        # creds cell — a single-slot list mutated by refresh_fn.
+        creds_cell: list = [("https://example.salesforce.com", "bad_token")]
+
+        def creds_provider():
+            return creds_cell[0]
+
+        def refresh_fn():
+            creds_cell[0] = ("https://example.salesforce.com", "good_token")
+            return creds_cell[0]
+
+        # Tracks the Authorization header seen on every request — this is
+        # what proves whether the retry carried the refreshed token or not.
+        auth_headers_seen: list[str] = []
+
+        def fake_open(req):
+            # urllib normalizes header names on add_header; read whichever
+            # case lands.
+            auth = None
+            for k, v in req.headers.items():
+                if k.lower() == "authorization":
+                    auth = v
+                    break
+            auth_headers_seen.append(auth or "")
+
+            if auth == "Bearer bad_token":
+                raise urllib.error.HTTPError(
+                    url=req.full_url,
+                    code=401,
+                    msg="Unauthorized",
+                    hdrs={},  # type: ignore[arg-type]
+                    fp=io.BytesIO(b""),
+                )
+            # Good token path — return a tiny success JSON.
+            resp = mock.MagicMock()
+            resp.read.return_value = json.dumps({"records": []}).encode("utf-8")
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+
+        with mock.patch.object(rest_client, "build_opener", return_value=fake_opener):
+            out = rest_client.tooling_query(
+                creds_provider,
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=refresh_fn,
+            )
+
+        self.assertEqual(out, {"records": []})
+        self.assertEqual(
+            len(auth_headers_seen), 2,
+            f"expected 2 attempts (401 + retry), got {len(auth_headers_seen)}",
+        )
+        self.assertEqual(
+            auth_headers_seen[0], "Bearer bad_token",
+            "first attempt should have used the stale token",
+        )
+        self.assertEqual(
+            auth_headers_seen[1], "Bearer good_token",
+            "retry MUST use the refreshed token — this is the bug",
+        )
+
+
+class TransientHttpWithRefreshIntegrationTests(unittest.TestCase):
+    """End-to-end stack test through `tooling_query`.
+
+    Drives the real decorator chain baked into `tooling_query`: first
+    response 429 (transient retry), second response 401 (refresh + retry),
+    third response 200. Proves that the stacking in the production
+    helper — NOT just the raw decorators — gives the intended behavior.
+    """
+
+    def test_tooling_query_429_then_401_then_success(self):
+        responses = [
+            ("429", None),
+            ("401", None),
+            ("ok", json.dumps({"records": [{"Id": "a"}]}).encode("utf-8")),
+        ]
+        creds_cell = [("https://example.salesforce.com", "bad_token")]
+        refresh_calls = []
+
+        def creds_provider():
+            return creds_cell[0]
+
+        def refresh():
+            refresh_calls.append(1)
+            creds_cell[0] = ("https://example.salesforce.com", "good_token")
+            return creds_cell[0]
+
+        def fake_open(req):
+            kind, body = responses.pop(0)
+            if kind == "429":
+                exc = urllib.error.HTTPError(
+                    url=req.full_url,
+                    code=429,
+                    msg="rate limited",
+                    hdrs=email.message.Message(),
+                    fp=io.BytesIO(b""),
+                )
+                exc.headers["Retry-After"] = "0"  # 0 → base_delay wins, but sleep is mocked
+                raise exc
+            if kind == "401":
+                raise urllib.error.HTTPError(
+                    url=req.full_url,
+                    code=401,
+                    msg="unauthorized",
+                    hdrs={},  # type: ignore[arg-type]
+                    fp=io.BytesIO(b""),
+                )
+            resp = mock.MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+
+        with mock.patch.object(rest_client, "build_opener", return_value=fake_opener), \
+             mock.patch.object(rest_client.time, "sleep"):
+            out = rest_client.tooling_query(
+                creds_provider,
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=refresh,
+            )
+
+        self.assertEqual(out["records"][0]["Id"], "a")
+        self.assertEqual(len(refresh_calls), 1,
+                         "exactly one refresh — 429 must NOT trigger the refresh")
+        self.assertEqual(responses, [], "all three canned responses consumed")
+
+
+class AcceptEncodingAndForbiddenInvalidSessionTests(unittest.TestCase):
+    """Accept-Encoding: identity + 403+INVALID_SESSION_ID handling."""
+
+    def test_query_sends_accept_encoding_identity(self):
+        """The outbound request carries `Accept-Encoding: identity` so no
+        gzip body ever lands on the body-inspection path."""
+        body = json.dumps({"records": []}).encode("utf-8")
+
+        captured: list = []
+
+        def fake_open(req):
+            captured.append(req)
+            resp = mock.MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+
+        with mock.patch.object(rest_client, "build_opener", return_value=fake_opener):
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+
+        self.assertEqual(len(captured), 1)
+        req = captured[0]
+        # urllib stores add_header'd names via .capitalize(); read any case.
+        accept_enc = None
+        for k, v in req.headers.items():
+            if k.lower() == "accept-encoding":
+                accept_enc = v
+                break
+        self.assertEqual(accept_enc, "identity",
+                         "Accept-Encoding must be 'identity'")
+
+    def test_403_invalid_session_triggers_refresh(self):
+        """HTTP 403 + INVALID_SESSION_ID body is treated as refreshable."""
+
+        call_count = {"n": 0}
+
+        def wrapped():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # 403 with INVALID_SESSION_ID body → should refresh.
+                raise urllib.error.HTTPError(
+                    url="https://example.salesforce.com/x",
+                    code=403,
+                    msg="Forbidden",
+                    hdrs={},  # type: ignore[arg-type]
+                    fp=io.BytesIO(
+                        b'[{"errorCode":"INVALID_SESSION_ID","message":"Session expired"}]'
+                    ),
+                )
+            return {"ok": True}
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        result = decorated()
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(refresh_calls), 1,
+                         "403+INVALID_SESSION_ID must trigger refresh")
+
+    def test_403_non_invalid_session_does_not_trigger_refresh(self):
+        """HTTP 403 with some OTHER errorCode propagates unchanged."""
+
+        def wrapped():
+            raise urllib.error.HTTPError(
+                url="https://example.salesforce.com/x",
+                code=403,
+                msg="Forbidden",
+                hdrs={},  # type: ignore[arg-type]
+                fp=io.BytesIO(
+                    b'[{"errorCode":"INSUFFICIENT_ACCESS","message":"Denied"}]'
+                ),
+            )
+
+        refresh_calls = []
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new_tok")
+
+        decorated = rest_client.retry_on_401(refresh)(wrapped)
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            decorated()
+
+        self.assertEqual(ctx.exception.code, 403)
+        self.assertEqual(len(refresh_calls), 0,
+                         "non-auth 403 must NOT burn a refresh")
+
+
+class RetryOnTransientHttpTests(unittest.TestCase):
+    """429/503 → exponential-backoff retry up to max_retries."""
+
+    def test_429_then_success_retries_once(self):
+        calls = {"n": 0}
+
+        def fn():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _make_http_error(429)
+            return {"ok": True}
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http()(fn)
+            out = decorated()
+
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(calls["n"], 2)
+        slept.assert_called_once()
+        # First retry: base_delay * 2**0 = 1.0
+        self.assertAlmostEqual(slept.call_args[0][0], 1.0)
+
+    def test_503_three_times_propagates_httperror(self):
+        """With max_retries=3, total attempts = 4. Four 503s must surface
+        the HTTPError after exactly 3 sleeps."""
+        def fn():
+            raise _make_http_error(503)
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http(max_retries=3)(fn)
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                decorated()
+
+        self.assertEqual(ctx.exception.code, 503)
+        self.assertEqual(slept.call_count, 3,
+                         "3 sleeps for 3 retries before the final failure")
+
+    def test_retry_after_header_honored_when_larger(self):
+        """Retry-After: 10 overrides the 1s exponential schedule."""
+        def fn():
+            exc = urllib.error.HTTPError(
+                url="https://example.salesforce.com/x",
+                code=429,
+                msg="rate limited",
+                hdrs=email.message.Message(),
+                fp=io.BytesIO(b""),
+            )
+            exc.headers["Retry-After"] = "10"
+            raise exc
+
+        # fn always raises → exhaust retries; we just need to observe the
+        # first sleep value.
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http(max_retries=1)(fn)
+            with self.assertRaises(urllib.error.HTTPError):
+                decorated()
+
+        self.assertEqual(slept.call_count, 1)
+        self.assertAlmostEqual(slept.call_args_list[0][0][0], 10.0,
+                               msg="Retry-After (10) must win over base_delay (1)")
+
+    def test_retry_after_smaller_than_base_loses(self):
+        """Retry-After: 0.5 with base_delay=1.0 → sleep 1.0 (base_delay wins)."""
+        def fn():
+            exc = urllib.error.HTTPError(
+                url="https://example.salesforce.com/x",
+                code=429,
+                msg="rate limited",
+                hdrs=email.message.Message(),
+                fp=io.BytesIO(b""),
+            )
+            exc.headers["Retry-After"] = "0.5"
+            raise exc
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http(max_retries=1)(fn)
+            with self.assertRaises(urllib.error.HTTPError):
+                decorated()
+
+        self.assertAlmostEqual(slept.call_args_list[0][0][0], 1.0)
+
+    def test_500_propagates_without_sleep(self):
+        """Non-429/503 HTTP errors are out of scope — no retry, no sleep."""
+        def fn():
+            raise _make_http_error(500)
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http()(fn)
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                decorated()
+
+        self.assertEqual(ctx.exception.code, 500)
+        slept.assert_not_called()
+
+    def test_401_propagates_without_sleep(self):
+        """401 is retry_on_401's job — this decorator must pass it through."""
+        def fn():
+            raise _make_http_error(401)
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http()(fn)
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                decorated()
+
+        self.assertEqual(ctx.exception.code, 401)
+        slept.assert_not_called()
+
+    def test_stacks_correctly_with_retry_on_401(self):
+        """Integration: 429 → transient retry → 401 → refresh retry → success.
+
+        This verifies the documented ordering in `tooling_query` /
+        `data_query`: transient-HTTP is inner, 401-refresh is outer. If
+        the layering were reversed, the refresh would fire on the 429.
+        """
+        sequence = ["429", "401", "ok"]
+        refresh_calls = []
+
+        def fn():
+            code = sequence.pop(0)
+            if code == "429":
+                raise _make_http_error(429)
+            if code == "401":
+                raise _make_http_error(401)
+            return {"ok": True}
+
+        def refresh():
+            refresh_calls.append(1)
+            return ("https://example.salesforce.com", "new")
+
+        with mock.patch.object(rest_client.time, "sleep"):
+            # Inner: transient retry. Outer: 401 refresh. Matches the
+            # stack in tooling_query / data_query.
+            decorated = rest_client.retry_on_401(refresh)(
+                rest_client.retry_on_transient_http()(fn)
+            )
+            out = decorated()
+
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(len(refresh_calls), 1,
+                         "exactly one refresh — 429 must not burn a refresh")
+        self.assertEqual(sequence, [], "all three responses consumed")
+
+    def test_retry_after_http_date_parses(self):
+        """HTTP-date form of Retry-After is accepted.
+
+        We pass an RFC 7231 date roughly 5 seconds in the future. The
+        parsed delta should be >= 0 and, since base_delay=1.0, the delta
+        wins whenever it exceeds 1s. We accept any value >= 1.0 to avoid
+        flakiness on slow test machines.
+        """
+        future_ts = time.time() + 30  # 30s out, plenty of slack
+        http_date = email.utils.formatdate(future_ts, usegmt=True)
+
+        def fn():
+            exc = urllib.error.HTTPError(
+                url="https://example.salesforce.com/x",
+                code=503,
+                msg="unavailable",
+                hdrs=email.message.Message(),
+                fp=io.BytesIO(b""),
+            )
+            exc.headers["Retry-After"] = http_date
+            raise exc
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http(max_retries=1)(fn)
+            with self.assertRaises(urllib.error.HTTPError):
+                decorated()
+
+        self.assertEqual(slept.call_count, 1)
+        delay = slept.call_args_list[0][0][0]
+        # Sanity: must be larger than base_delay (1.0) and no bigger than
+        # the original offset (30) plus generous test-timing slack.
+        self.assertGreaterEqual(delay, 1.0)
+        self.assertLessEqual(delay, 35.0)
+
+    def test_malformed_retry_after_falls_back_to_base(self):
+        """`Retry-After: not-a-date` → base_delay wins."""
+        def fn():
+            exc = urllib.error.HTTPError(
+                url="https://example.salesforce.com/x",
+                code=429,
+                msg="rate limited",
+                hdrs=email.message.Message(),
+                fp=io.BytesIO(b""),
+            )
+            exc.headers["Retry-After"] = "not-a-date"
+            raise exc
+
+        with mock.patch.object(rest_client.time, "sleep") as slept:
+            decorated = rest_client.retry_on_transient_http(max_retries=1, base_delay=2.0)(fn)
+            with self.assertRaises(urllib.error.HTTPError):
+                decorated()
+
+        self.assertAlmostEqual(slept.call_args_list[0][0][0], 2.0,
+                               msg="malformed Retry-After falls back to base_delay")
+
+
+class InvalidSessionDetectionTests(unittest.TestCase):
+    """Unit coverage for the body-inspection helper."""
+
+    def test_list_with_invalid_session_detected(self):
+        body = [{"errorCode": "INVALID_SESSION_ID", "message": "foo"}]
+        self.assertTrue(rest_client._body_indicates_invalid_session(body))
+
+    def test_dict_without_invalid_session_not_detected(self):
+        body = {"records": [{"Id": "a"}]}
+        self.assertFalse(rest_client._body_indicates_invalid_session(body))
+
+    def test_none_safe(self):
+        self.assertFalse(rest_client._body_indicates_invalid_session(None))
+
+    def test_string_with_marker(self):
+        self.assertTrue(rest_client._body_indicates_invalid_session(
+            "...INVALID_SESSION_ID..."
+        ))
+
+    # --- BUGFIX 2026-05-03: false positive on ApexClass.Body substring -----
+    # Regression: _body_indicates_invalid_session used to walk ALL dict
+    # values and substring-match. A 200 OK Tooling Query response whose
+    # records carried Apex source referencing the string INVALID_SESSION_ID
+    # (e.g. `XCSF_FlowFaultMessage`, `SkillRulesMatchAction`) was
+    # misclassified as a session error, triggering spurious Wave B retries
+    # and a bogus `INVALID_SESSION_ID after refresh` entry in `_unresolved`.
+
+    def test_success_body_with_apex_source_substring_not_detected(self):
+        """200 OK Tooling response whose ApexClass.Body mentions
+        INVALID_SESSION_ID in source code must NOT be flagged."""
+        apex_source = (
+            "public class XCSF_FlowFaultMessage {\n"
+            "    // Handles INVALID_SESSION_ID by rethrowing a typed error.\n"
+            "    public static void raise(String code) {\n"
+            "        if (code == 'INVALID_SESSION_ID') {\n"
+            "            throw new HandledException('session expired');\n"
+            "        }\n"
+            "    }\n"
+            "}"
+        )
+        body = {
+            "size": 2,
+            "totalSize": 2,
+            "done": True,
+            "queryLocator": None,
+            "entityTypeName": "ApexClass",
+            "records": [
+                {
+                    "attributes": {
+                        "type": "ApexClass",
+                        "url": "/services/data/v66.0/tooling/sobjects/ApexClass/01pUv0",
+                    },
+                    "Id": "01pUv000003a1YaIAI",
+                    "Name": "XCSF_FlowFaultMessage",
+                    "Body": apex_source,
+                },
+                {
+                    "attributes": {"type": "ApexClass"},
+                    "Id": "01pUv000003a1YbIAI",
+                    "Name": "SkillRulesMatchAction",
+                    "Body": "// references INVALID_SESSION_ID constant",
+                },
+            ],
+        }
+        self.assertFalse(
+            rest_client._body_indicates_invalid_session(body),
+            "success payload with INVALID_SESSION_ID inside ApexClass.Body "
+            "must not be misclassified as an auth failure",
+        )
+
+    def test_error_envelope_under_errors_key_still_detected(self):
+        """Dict-wrapped error envelope under a known key still flags."""
+        body = {
+            "errors": [
+                {"errorCode": "INVALID_SESSION_ID", "message": "Session expired"}
+            ]
+        }
+        self.assertTrue(rest_client._body_indicates_invalid_session(body))
+
+    def test_success_body_with_marker_in_data_field_not_detected(self):
+        """A top-level data field whose string value mentions the marker
+        must not trigger — only error-envelope keys are walked."""
+        body = {"records": [{"Id": "a", "Description": "handles INVALID_SESSION_ID"}]}
+        self.assertFalse(rest_client._body_indicates_invalid_session(body))
+
+
+class QueryWireShapeTests(unittest.TestCase):
+    """`_query_once` must send GET with a urlencoded `q=`
+    querystring. The prior POST-with-JSON-body shape returned HTTP 405
+    on every real-org run — three reference fixtures failed
+    end-to-end. These tests pin the wire shape so a regression back to
+    POST would break CI before landing.
+    """
+
+    def _install_capturing_opener(self, captured: list, response_body: bytes):
+        def fake_open(req):
+            captured.append(req)
+            resp = mock.MagicMock()
+            resp.read.return_value = response_body
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+        return mock.patch.object(
+            rest_client, "build_opener", return_value=fake_opener
+        )
+
+    def test_data_query_sends_get_with_urlencoded_querystring(self):
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        soql = "SELECT Id FROM BotDefinition WHERE DeveloperName = 'Foo'"
+
+        with self._install_capturing_opener(captured, body):
+            rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                soql,
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+
+        self.assertEqual(len(captured), 1)
+        req = captured[0]
+        # method must be GET. Previously POST.
+        self.assertEqual(req.get_method(), "GET",
+                         "REST Query endpoint is GET-only; POST returns 405")
+        # GET has no body.
+        self.assertIsNone(req.data,
+                          "GET requests must carry no body")
+        # URL must carry the urlencoded querystring.
+        self.assertIn("/services/data/v60.0/query/?q=", req.full_url)
+        # urllib.parse.urlencode produces `+` for spaces — decoding
+        # should round-trip the SOQL exactly.
+        import urllib.parse
+        parsed = urllib.parse.urlparse(req.full_url)
+        qs = urllib.parse.parse_qs(parsed.query)
+        self.assertEqual(qs.get("q"), [soql],
+                         "urlencoded `q` must round-trip the SOQL exactly")
+
+    def test_tooling_query_sends_get_to_tooling_path(self):
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        soql = "SELECT Id, DeveloperName FROM BotVersion"
+
+        with self._install_capturing_opener(captured, body):
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                soql,
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+
+        self.assertEqual(len(captured), 1)
+        req = captured[0]
+        self.assertEqual(req.get_method(), "GET")
+        self.assertIsNone(req.data)
+        # Tooling path is distinct from Data API path.
+        self.assertIn("/services/data/v60.0/tooling/query/?q=", req.full_url)
+
+    def test_query_does_not_send_content_type_header(self):
+        """GET has no body — Content-Type is inappropriate and was
+        removed alongside the method change. Some edge proxies complain
+        about Content-Type on a bodyless GET; we just drop it."""
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+
+        with self._install_capturing_opener(captured, body):
+            rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM Account LIMIT 1",
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+
+        req = captured[0]
+        content_type = None
+        for k, v in req.headers.items():
+            if k.lower() == "content-type":
+                content_type = v
+                break
+        self.assertIsNone(content_type,
+                          "GET requests must not carry Content-Type")
+
+    def test_soql_with_special_chars_is_urlencoded(self):
+        """SOQL string literals contain single quotes, commas, spaces,
+        parentheses. urlencode must escape them all; a naive concat
+        would break either the URL parse or the SOQL semantics."""
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        # Exercise the full SOQL character classes that routinely appear.
+        soql = (
+            "SELECT Id, Name FROM ApexClass "
+            "WHERE Name IN ('Foo', 'Bar Baz') "
+            "AND NamespacePrefix IS NULL LIMIT 200"
+        )
+
+        with self._install_capturing_opener(captured, body):
+            rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                soql,
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+
+        req = captured[0]
+        import urllib.parse
+        parsed = urllib.parse.urlparse(req.full_url)
+        qs = urllib.parse.parse_qs(parsed.query)
+        self.assertEqual(qs.get("q"), [soql])
+        # Spaces MUST be escaped — a raw space in a URL is malformed.
+        self.assertNotIn(" ", parsed.query,
+                         "querystring must contain no literal spaces")
+
+
+class ApiVersionRequiredKwargTests(unittest.TestCase):
+    """`api_version` is a REQUIRED keyword-only
+    argument on `tooling_query` + `data_query`.
+
+    The prior design hardcoded `v60.0`. Real orgs (my-org-alias,
+    my-perf-org-alias) run on v66 and expose fields v60 does not — confirmed
+    empirically: `BotDefinition.Description` resolves on v66, raises
+    `INVALID_FIELD` on v60 for the same org. Making `api_version`
+    required surfaces a missed call-site as a TypeError at call time,
+    not a silent regression back to a stale pinned version.
+    """
+
+    def test_tooling_query_requires_api_version(self):
+        with self.assertRaises(TypeError) as ctx:
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertIn("api_version", str(ctx.exception))
+
+    def test_data_query_requires_api_version(self):
+        with self.assertRaises(TypeError) as ctx:
+            rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM Account LIMIT 1",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertIn("api_version", str(ctx.exception))
+
+
+class ApiVersionUrlSubstitutionTests(unittest.TestCase):
+    """the `api_version` kwarg lands in the URL path
+    unchanged. A caller passing `v66.0` must produce
+    `/services/data/v66.0/...` in the outbound Request, NOT the old
+    hardcoded `v60.0`.
+
+    Regression shield: if a future refactor re-pins the version string,
+    these tests fail at the wire-shape assertion even when unit-level
+    behavior of `tooling_query` still looks correct.
+    """
+
+    def _install_capturing_opener(self, captured: list, response_body: bytes):
+        def fake_open(req):
+            captured.append(req)
+            resp = mock.MagicMock()
+            resp.read.return_value = response_body
+            resp.__enter__ = mock.MagicMock(return_value=resp)
+            resp.__exit__ = mock.MagicMock(return_value=False)
+            return resp
+
+        fake_opener = mock.MagicMock()
+        fake_opener.open = fake_open
+        return mock.patch.object(
+            rest_client, "build_opener", return_value=fake_opener
+        )
+
+    def test_tooling_query_v66_in_url(self):
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        with self._install_capturing_opener(captured, body):
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v66.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertEqual(len(captured), 1)
+        url = captured[0].full_url
+        self.assertIn("/services/data/v66.0/tooling/query/?q=", url)
+        # And the old hardcoded version must NOT appear — otherwise the
+        # substitution silently failed.
+        self.assertNotIn("v60.0", url)
+
+    def test_data_query_v66_in_url(self):
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        with self._install_capturing_opener(captured, body):
+            rest_client.data_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM BotDefinition LIMIT 1",
+                api_version="v66.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        url = captured[0].full_url
+        self.assertIn("/services/data/v66.0/query/?q=", url)
+        self.assertNotIn("v60.0", url)
+
+    def test_different_api_version_per_call(self):
+        """Two calls with different `api_version` land on distinct URLs —
+        proves the value is NOT cached in module-level state between
+        invocations."""
+        captured: list = []
+        body = json.dumps({"records": []}).encode("utf-8")
+        with self._install_capturing_opener(captured, body):
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v60.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+            rest_client.tooling_query(
+                rest_client.static_creds("https://example.salesforce.com", "tok"),
+                "SELECT Id FROM ApexClass",
+                api_version="v66.0",
+                on_401_refresh=lambda: ("https://example.salesforce.com", "new"),
+            )
+        self.assertEqual(len(captured), 2)
+        self.assertIn("/services/data/v60.0/tooling/query/", captured[0].full_url)
+        self.assertIn("/services/data/v66.0/tooling/query/", captured[1].full_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_sf_cli.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_sf_cli.py
@@ -1,0 +1,261 @@
+"""Tests for sf_cli loads YAML with safe_load only.
+
+Also covers redaction boundary for stderr content via the local
+_redact_subprocess_stderr helper.
+"""
+from __future__ import annotations
+
+import unittest
+
+import yaml
+
+from . import _bootstrap  # noqa: F401
+
+import sf_cli  # type: ignore
+
+
+class YamlSafeLoadTests(unittest.TestCase):
+    """the bound loader must be identity-equal to yaml.safe_load."""
+
+    def test_loader_is_yaml_safe_load(self):
+        self.assertIs(
+            sf_cli._SAFE_LOADER,
+            yaml.safe_load,
+            "sf_cli must use yaml.safe_load, not yaml.load ",
+        )
+
+    def test_module_docstring_mentions_safe_load(self):
+        """The security contract lives in the docstring; reviewers who
+        grep for `yaml.load` in this module should find only the banned
+        reference plus the explanation."""
+        self.assertIn("yaml.safe_load", sf_cli.__doc__ or "")
+        self.assertIn("yaml.load is banned", sf_cli.__doc__ or "")
+
+    def test_safe_load_rejects_python_object_construction(self):
+        """Sanity check that safe_load actually differs from load —
+        an attacker-controlled `!!python/object` tag must raise."""
+        malicious = "!!python/object/apply:os.system ['echo pwned']"
+        with self.assertRaises(yaml.YAMLError):
+            sf_cli._SAFE_LOADER(malicious)
+
+
+class StderrRedactionTests(unittest.TestCase):
+    """subprocess stderr is redacted before reaching log/exception text."""
+
+    def test_bearer_token_in_stderr_redacted(self):
+        stderr = "Error: API call failed\nAuthorization: Bearer TESTONLY_STDERR_TOKEN\n"
+        safe = sf_cli._redact_subprocess_stderr(stderr)
+        self.assertNotIn("TESTONLY_STDERR_TOKEN", safe)
+        self.assertIn("<redacted>", safe)
+
+    def test_empty_stderr_returns_empty(self):
+        self.assertEqual(sf_cli._redact_subprocess_stderr(""), "")
+        self.assertEqual(sf_cli._redact_subprocess_stderr(None), "")
+
+
+class ModuleTopImportTests(unittest.TestCase):
+    """`redact_text` is imported at sf_cli module top. If anyone
+    re-introduces a lazy `from rest_client import _redact_text` inside
+    `_redact_subprocess_stderr`, these tests fail.
+    """
+
+    def test_redact_text_bound_at_module_top(self):
+        self.assertTrue(hasattr(sf_cli, "redact_text"))
+        # And it's the actual public function, not a stub.
+        import rest_client as _rc
+        self.assertIs(sf_cli.redact_text, _rc.redact_text)
+
+    def test_subprocess_stderr_redaction_does_not_import_private(self):
+        """Behavioral proof: redaction works without any lazy import. If
+        rest_client.redact_text were renamed and nobody updated sf_cli's
+        module-top import, the module would fail to load — an obvious,
+        loud failure rather than a silent redaction skip at runtime.
+        """
+        stderr = "Authorization: Bearer TOKEN_MUST_NOT_SURVIVE"
+        out = sf_cli._redact_subprocess_stderr(stderr)
+        self.assertNotIn("TOKEN_MUST_NOT_SURVIVE", out)
+        self.assertIn("<redacted>", out)
+
+
+class StderrAuthLinePrefixTests(unittest.TestCase):
+    """auth patterns only match on lines starting with Error:/Warning:.
+
+    Tightens `_stderr_matches_auth` to line-anchored scanning so an
+    embedded substring in prose (or a stray Node ESM warning that
+    doesn't begin with Error:/Warning:) doesn't false-trigger
+    AuthRequired.
+    """
+
+    PATTERNS = ("NoOrgAuthenticationError", "NamedOrgNotFoundError")
+
+    def test_error_line_with_pattern_matches(self):
+        stderr = "Error: NoOrgAuthenticationError — no org logged in\n"
+        self.assertTrue(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+    def test_warning_line_with_pattern_matches(self):
+        """Warning-prefixed lines are ALSO in scope per the tightened rule.
+
+        Some sf CLI plugins emit auth issues as Warning-level diagnostics
+        before the hard Error; we don't want to miss those.
+        """
+        stderr = "Warning: NoOrgAuthenticationError — auth cache stale\n"
+        self.assertTrue(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+    def test_embedded_prose_does_not_match(self):
+        """Pattern embedded mid-line without Error:/Warning: prefix → NO match.
+
+        This is the behavior change: previous substring match would
+        have false-positived here.
+        """
+        stderr = "see docs for NoOrgAuthenticationError troubleshooting\n"
+        self.assertFalse(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+    def test_empty_stderr_no_match(self):
+        self.assertFalse(sf_cli._stderr_matches_auth("", self.PATTERNS))
+        self.assertFalse(sf_cli._stderr_matches_auth(None, self.PATTERNS))
+
+    def test_multiline_stderr_pattern_on_third_line_matches(self):
+        stderr = (
+            "Warning: @gthoppae/sf-cli-plugin-data360 is a linked ESM module\n"
+            "debug: config loaded\n"
+            "Error: NoOrgAuthenticationError — no default org\n"
+        )
+        self.assertTrue(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+    def test_esm_warning_without_auth_pattern_no_match(self):
+        """The exact warning shape we're trying NOT to false-positive on.
+
+        If a future sf CLI plugin name happened to contain an auth pattern
+        substring (unlikely but possible), the line-prefix rule alone
+        wouldn't save us. For now, this canonical ESM warning contains no
+        auth pattern, so it MUST NOT match.
+        """
+        stderr = (
+            "Warning: @gthoppae/sf-cli-plugin-data360 is a linked ESM module\n"
+            "and will not reload without CLI restart\n"
+        )
+        self.assertFalse(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+    def test_other_prefix_with_pattern_does_not_match(self):
+        """Lines that don't start with Error:/Warning: — even with a pattern
+        substring — are filtered out."""
+        stderr = "debug: NoOrgAuthenticationError transient\n"
+        self.assertFalse(sf_cli._stderr_matches_auth(stderr, self.PATTERNS))
+
+
+class RunSfTests(unittest.TestCase):
+    """Cover ``run_sf`` end-to-end with subprocess mocked.
+
+    Uses the real ``org_display`` recipe shipped under ``assets/cli/`` so
+    the recipe load + arg substitution + auth-pattern config exercise
+    real code paths.
+    """
+
+    from types import SimpleNamespace as _Namespace
+
+    def _patch_subprocess(self, *, returncode: int = 0,
+                          stdout: str = '{"status":0,"result":{}}',
+                          stderr: str = "",
+                          raise_exc: BaseException | None = None):
+        from unittest import mock
+        if raise_exc is not None:
+            return mock.patch.object(sf_cli.subprocess, "run", side_effect=raise_exc)
+        cp = self._Namespace(returncode=returncode, stdout=stdout, stderr=stderr)
+        return mock.patch.object(sf_cli.subprocess, "run", return_value=cp)
+
+    def test_returns_parsed_stdout_on_success(self):
+        with self._patch_subprocess():
+            data = sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+        self.assertEqual(data, {"status": 0, "result": {}})
+
+    def test_raises_when_required_param_missing(self):
+        with self.assertRaises(sf_cli.SfCliError) as ctx:
+            sf_cli.run_sf("org_display")  # missing ORG_ALIAS
+        self.assertIn("missing required params", str(ctx.exception))
+        self.assertIn("ORG_ALIAS", str(ctx.exception))
+
+    def test_classifies_auth_failure_via_stderr_pattern(self):
+        # org_display recipe has NoOrgAuthenticationError in its
+        # auth_required_stderr_patterns list.
+        with self._patch_subprocess(
+            returncode=1,
+            stdout='{"status":1}',
+            stderr="Error: NoOrgAuthenticationError — no org\n",
+        ):
+            with self.assertRaises(sf_cli.AuthRequired):
+                sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+
+    def test_raises_sfcli_error_on_nonauth_failure(self):
+        with self._patch_subprocess(
+            returncode=1,
+            stdout='{"status":1}',
+            stderr="Error: SomethingElseBlewUp\n",
+        ):
+            with self.assertRaises(sf_cli.SfCliError) as ctx:
+                sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+        self.assertIn("exit=1", str(ctx.exception))
+
+    def test_raises_sfcli_error_on_subprocess_timeout(self):
+        import subprocess as _subprocess
+        with self._patch_subprocess(
+            raise_exc=_subprocess.TimeoutExpired(cmd=["sf"], timeout=1),
+        ):
+            with self.assertRaises(sf_cli.SfCliError) as ctx:
+                sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+        self.assertIn("timed out", str(ctx.exception))
+
+    def test_raises_sfcli_error_when_binary_missing(self):
+        # FileNotFoundError = sf binary not on PATH.
+        with self._patch_subprocess(raise_exc=FileNotFoundError("sf not found")):
+            with self.assertRaises(sf_cli.SfCliError) as ctx:
+                sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+        self.assertIn("invocation failed", str(ctx.exception))
+
+    def test_passes_show_secrets_env_to_subprocess(self):
+        """Tripwire for the W-22582511 sf-CLI-redaction fix.
+
+        Without ``SF_TEMP_SHOW_SECRETS=true`` in the subprocess env, sf CLI
+        v2 returns the literal string ``"[REDACTED] Use 'sf org auth
+        show-access-token' to view"`` in place of the bearer token, and
+        every downstream Tooling/REST call returns INVALID_AUTH_HEADER 401.
+        """
+        from unittest import mock
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["env"] = kwargs.get("env")
+            captured["argv"] = argv
+            return self._Namespace(
+                returncode=0, stdout='{"status":0,"result":{}}', stderr="",
+            )
+
+        with mock.patch.object(sf_cli.subprocess, "run", side_effect=fake_run):
+            sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+
+        self.assertIsNotNone(captured["env"])
+        self.assertEqual(captured["env"].get("SF_TEMP_SHOW_SECRETS"), "true")
+
+    def test_org_display_recipe_includes_verbose_flag(self):
+        """Tripwire for the W-22582511 ``--verbose`` fix.
+
+        Without ``--verbose``, sf CLI v2 omits ``accessToken`` from the
+        ``--json`` output entirely (regardless of SF_TEMP_SHOW_SECRETS),
+        so the redaction-env workaround is necessary but not sufficient.
+        """
+        from unittest import mock
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return self._Namespace(
+                returncode=0, stdout='{"status":0,"result":{}}', stderr="",
+            )
+
+        with mock.patch.object(sf_cli.subprocess, "run", side_effect=fake_run):
+            sf_cli.run_sf("org_display", ORG_ALIAS="my-org")
+
+        self.assertIn("--verbose", captured["argv"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_signature_stamping.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_signature_stamping.py
@@ -1,0 +1,466 @@
+"""Tests for Section-7 signature stamping.
+
+Previously, every flow and every Apex class in the rendered architecture
+report's Section 7 showed `_Signature not captured._` because Wave B
+fetched `SymbolTable` + `Flow.Metadata` but we never projected that data
+onto the tree nodes the renderer reads. These tests pin the three
+helpers that close the gap:
+
+  * `_derive_apex_signature` — SymbolTable → one-line method signature
+  * `_derive_flow_signature` — Flow.Metadata → `in:/out:` param list
+  * `_stamp_signatures`     — walks the tree and writes `node["signature"]`
+
+The renderer at `render_architecture.py` reads `node.get("signature")`
+already; no renderer change was required.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+import main  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# _derive_apex_signature
+# ---------------------------------------------------------------------------
+
+
+class DeriveApexSignatureTests(unittest.TestCase):
+    def test_invocable_method_is_preferred(self):
+        """@InvocableMethod is what Flow / Agentforce actually call. If
+        present, it MUST be picked over any other method — otherwise the
+        rendered signature points at a private helper instead of the
+        public entry point."""
+        apex_row = {
+            "Name": "OrderLookup",
+            "SymbolTable": {
+                "methods": [
+                    {
+                        "name": "helper",
+                        "returnType": "void",
+                        "modifiers": ["private"],
+                        "parameters": [{"name": "x", "type": "String"}],
+                        "annotations": [],
+                    },
+                    {
+                        "name": "run",
+                        "returnType": "List<Result>",
+                        "modifiers": ["public", "static"],
+                        "parameters": [
+                            {"name": "input", "type": "List<Request>"},
+                        ],
+                        "annotations": [{"name": "InvocableMethod"}],
+                    },
+                ],
+            },
+        }
+        sig = main._derive_apex_signature(apex_row)
+        self.assertEqual(sig, "public static List<Result> run(List<Request> input)")
+
+    def test_no_invocable_falls_back_to_global(self):
+        """Without `@InvocableMethod`, a `global` method wins over a
+        `private` helper."""
+        apex_row = {
+            "Name": "Utility",
+            "SymbolTable": {
+                "methods": [
+                    {
+                        "name": "privateHelper",
+                        "returnType": "void",
+                        "modifiers": ["private"],
+                        "parameters": [],
+                        "annotations": [],
+                    },
+                    {
+                        "name": "publicEntry",
+                        "returnType": "String",
+                        "modifiers": ["global"],
+                        "parameters": [{"name": "id", "type": "Id"}],
+                        "annotations": [],
+                    },
+                ],
+            },
+        }
+        sig = main._derive_apex_signature(apex_row)
+        self.assertEqual(sig, "global String publicEntry(Id id)")
+
+    def test_empty_symbol_table_returns_none(self):
+        """`SymbolTable = null` is the common case for classes the org
+        couldn't compile a symbol table for. Must not raise, must return
+        None so the renderer falls back to the `_Signature not captured._`
+        placeholder."""
+        self.assertIsNone(
+            main._derive_apex_signature({"Name": "X", "SymbolTable": None})
+        )
+        self.assertIsNone(
+            main._derive_apex_signature({"Name": "X", "SymbolTable": {}})
+        )
+        self.assertIsNone(
+            main._derive_apex_signature(
+                {"Name": "X", "SymbolTable": {"methods": []}}
+            )
+        )
+
+    def test_no_candidate_methods_returns_none(self):
+        """A class whose only method is private AND not invocable has no
+        sensible public signature to surface; return None rather than
+        expose internal detail."""
+        apex_row = {
+            "Name": "PrivateOnly",
+            "SymbolTable": {
+                "methods": [
+                    {
+                        "name": "hidden",
+                        "returnType": "void",
+                        "modifiers": ["private"],
+                        "parameters": [],
+                        "annotations": [],
+                    },
+                ],
+            },
+        }
+        self.assertIsNone(main._derive_apex_signature(apex_row))
+
+
+# ---------------------------------------------------------------------------
+# _derive_flow_signature
+# ---------------------------------------------------------------------------
+
+
+class DeriveFlowSignatureTests(unittest.TestCase):
+    def test_input_and_output_both_present(self):
+        """Both sides rendered with ` | ` separator.
+
+        Flow.Metadata exposes a flat `variables[]` list; each item carries
+        boolean `isInput` / `isOutput` flags. We partition the list by
+        those flags rather than reading the non-existent
+        `inputParameters` / `outputParameters` fields.
+        """
+        record = {
+            "Metadata": {
+                "variables": [
+                    {"name": "caseId", "dataType": "String",
+                     "isInput": True, "isOutput": False},
+                    {"name": "priority", "dataType": "String",
+                     "isInput": True, "isOutput": False},
+                    {"name": "result", "dataType": "String",
+                     "isInput": False, "isOutput": True},
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(
+            sig,
+            "in: caseId: String, priority: String | out: result: String",
+        )
+
+    def test_only_input_side(self):
+        """outputs empty → only `in:` side rendered, no trailing ` | `."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {"name": "caseId", "dataType": "String",
+                     "isInput": True, "isOutput": False},
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(sig, "in: caseId: String")
+
+    def test_no_parameters_returns_none(self):
+        """No variables at all → None (render falls back to placeholder)."""
+        record = {"Metadata": {"variables": []}}
+        self.assertIsNone(main._derive_flow_signature(record))
+        self.assertIsNone(main._derive_flow_signature({"Metadata": {}}))
+        self.assertIsNone(main._derive_flow_signature({}))
+
+    def test_collection_type_rendered_as_list(self):
+        """`isCollection: True` on a variable → `List<DataType>` (and for
+        sObject variables, the `objectType` feeds the inner type rather
+        than the literal `SObject`; case-insensitive match on
+        `dataType`)."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {
+                        "name": "ids",
+                        "dataType": "String",
+                        "isCollection": True,
+                        "isInput": True,
+                        "isOutput": False,
+                    },
+                    {
+                        "name": "cases",
+                        "dataType": "sObject",
+                        "objectType": "Case",
+                        "isCollection": True,
+                        "isInput": True,
+                        "isOutput": False,
+                    },
+                    {
+                        "name": "result",
+                        "dataType": "SObject",   # upper-case variant
+                        "objectType": "Account",
+                        "isInput": False,
+                        "isOutput": True,
+                    },
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(
+            sig,
+            "in: ids: List<String>, cases: List<Case> | out: result: Account",
+        )
+
+    def test_round_trip_variable_appears_on_both_sides(self):
+        """A variable with `isInput: True` AND `isOutput: True` is a
+        round-trip — flows use this for parameters the caller passes in
+        and the flow mutates back out. It must appear on BOTH sides of
+        the rendered signature."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {"name": "payload", "dataType": "String",
+                     "isInput": True, "isOutput": True},
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(
+            sig,
+            "in: payload: String | out: payload: String",
+        )
+
+    def test_derive_flow_signature_local_variables_ignored(self):
+        """A variable with `isInput: False` AND `isOutput: False` is a
+        flow-local — it exists only inside the flow's execution and is
+        not part of its public surface. It must not appear in either
+        side of the signature."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {"name": "scratch", "dataType": "String",
+                     "isInput": False, "isOutput": False},
+                    {"name": "caseId", "dataType": "String",
+                     "isInput": True, "isOutput": False},
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(sig, "in: caseId: String")
+
+    def test_derive_flow_signature_handlefaultfault_shape(self):
+        """Real-org fixture modeled on `handleFlowFault` from the
+        my-org-alias org: 8 variables → 5 inputs, 3 outputs. Pins the
+        exact expected signature string end-to-end so that any future
+        regression in partitioning, rendering, or ordering surfaces
+        immediately."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {"name": "alwaysLogError", "dataType": "Boolean",
+                     "isCollection": False, "isInput": True,
+                     "isOutput": False, "objectType": None},
+                    {"name": "errorCode", "dataType": "String",
+                     "isCollection": False, "isInput": False,
+                     "isOutput": True, "objectType": None},
+                    {"name": "errorMessage", "dataType": "String",
+                     "isCollection": False, "isInput": False,
+                     "isOutput": True, "objectType": None},
+                    {"name": "flowFaultMessage", "dataType": "String",
+                     "isCollection": False, "isInput": True,
+                     "isOutput": False, "objectType": None},
+                    {"name": "flowName", "dataType": "String",
+                     "isCollection": False, "isInput": True,
+                     "isOutput": False, "objectType": None},
+                    {"name": "flowObject", "dataType": "String",
+                     "isCollection": False, "isInput": True,
+                     "isOutput": False, "objectType": None},
+                    {"name": "flowSection", "dataType": "String",
+                     "isCollection": False, "isInput": True,
+                     "isOutput": False, "objectType": None},
+                    {"name": "isFatal", "dataType": "Boolean",
+                     "isCollection": False, "isInput": False,
+                     "isOutput": True, "objectType": None},
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(
+            sig,
+            "in: alwaysLogError: Boolean, flowFaultMessage: String, "
+            "flowName: String, flowObject: String, flowSection: String | "
+            "out: errorCode: String, errorMessage: String, isFatal: Boolean",
+        )
+
+    def test_derive_flow_signature_apex_type_uses_apexclass(self):
+        """Apex-typed variables (e.g. Flow invocable action return rows)
+        carry the concrete class name in `apexClass`, not `dataType`
+        (which is the generic literal `Apex`). The signature MUST render
+        the concrete class so authors can trace the type back to real
+        code — `List<Apex>` is useless."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {
+                        "name": "OrgList",
+                        "dataType": "Apex",
+                        "apexClass": "CX_OrgSelector.Org",
+                        "isCollection": True,
+                        "isInput": False,
+                        "isOutput": True,
+                    },
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(sig, "out: OrgList: List<CX_OrgSelector.Org>")
+
+    def test_derive_flow_signature_apex_type_without_apexclass_falls_through(self):
+        """Defensive fallback: if `apexClass` is missing/blank on an
+        Apex-typed variable we render the literal `Apex` so the surface
+        still reports *something* — losing the signature entirely would
+        regress today's behavior."""
+        record = {
+            "Metadata": {
+                "variables": [
+                    {
+                        "name": "rows",
+                        "dataType": "Apex",
+                        "apexClass": None,
+                        "isCollection": True,
+                        "isInput": False,
+                        "isOutput": True,
+                    },
+                ],
+            },
+        }
+        sig = main._derive_flow_signature(record)
+        self.assertEqual(sig, "out: rows: List<Apex>")
+
+    def test_bare_metadata_dict_accepted(self):
+        """Test convenience: callers can pass the `Metadata` dict
+        directly (what they'd get from `record["Metadata"]`) without
+        wrapping it in the outer Tooling row. Exercised by several
+        sibling tests; pin the contract explicitly."""
+        bare = {
+            "variables": [
+                {"name": "caseId", "dataType": "String",
+                 "isInput": True, "isOutput": False},
+            ],
+        }
+        sig = main._derive_flow_signature(bare)
+        self.assertEqual(sig, "in: caseId: String")
+
+
+# ---------------------------------------------------------------------------
+# _stamp_signatures — walks tree, writes node["signature"]
+# ---------------------------------------------------------------------------
+
+
+class StampSignaturesTests(unittest.TestCase):
+    def test_stamp_applies_to_tree(self):
+        """APEX + FLOW nodes whose api_name matches the sigs dicts get
+        `node["signature"]` populated; unmatched nodes are left alone."""
+        tree_root = {
+            "kind": "AGENT",
+            "api_name": "MyAgent",
+            "children": [
+                {
+                    "kind": "APEX",
+                    "api_name": "OrderLookup",
+                    "children": [],
+                },
+                {
+                    "kind": "APEX",
+                    "api_name": "UnmatchedApex",
+                    "children": [],
+                },
+                {
+                    "kind": "FLOW",
+                    "api_name": "LookupOrder",
+                    "children": [
+                        {
+                            "kind": "APEX",
+                            "api_name": "OrderLookup",
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+        }
+        apex_sigs = {
+            "OrderLookup": "public static List<Result> run(List<Request> input)",
+        }
+        flow_sigs = {
+            "LookupOrder": "in: caseId: String | out: result: String",
+        }
+
+        main._stamp_signatures(tree_root, apex_sigs, flow_sigs)
+
+        self.assertEqual(
+            tree_root["children"][0]["signature"],
+            "public static List<Result> run(List<Request> input)",
+        )
+        # Unmatched Apex stays bare.
+        self.assertNotIn("signature", tree_root["children"][1])
+        # Flow node gets its signature.
+        self.assertEqual(
+            tree_root["children"][2]["signature"],
+            "in: caseId: String | out: result: String",
+        )
+        # Apex nested under the flow also stamped.
+        self.assertEqual(
+            tree_root["children"][2]["children"][0]["signature"],
+            "public static List<Result> run(List<Request> input)",
+        )
+        # Root itself (neither APEX nor FLOW) is untouched.
+        self.assertNotIn("signature", tree_root)
+
+    def test_stamp_preserves_shared_utility_across_branches(self):
+        """Shared utility flows (e.g. handleFlowFault referenced from N
+        places) must get the SAME signature stamped on every occurrence —
+        they reference the same FlowDefinition / ApexClass by name."""
+        tree_root = {
+            "kind": "AGENT",
+            "api_name": "Agent",
+            "children": [
+                {
+                    "kind": "FLOW",
+                    "api_name": "BranchA",
+                    "children": [
+                        {
+                            "kind": "FLOW",
+                            "api_name": "handleFlowFault",
+                            "children": [],
+                        },
+                    ],
+                },
+                {
+                    "kind": "FLOW",
+                    "api_name": "BranchB",
+                    "children": [
+                        {
+                            "kind": "FLOW",
+                            "api_name": "handleFlowFault",
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+        }
+        flow_sigs = {"handleFlowFault": "in: fault: String"}
+        main._stamp_signatures(tree_root, {}, flow_sigs)
+
+        stamp_a = tree_root["children"][0]["children"][0]["signature"]
+        stamp_b = tree_root["children"][1]["children"][0]["signature"]
+        self.assertEqual(stamp_a, "in: fault: String")
+        self.assertEqual(stamp_b, "in: fault: String")
+        self.assertEqual(stamp_a, stamp_b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_soql_loader.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_soql_loader.py
@@ -1,0 +1,501 @@
+"""Tests for load_soql revalidates every substituted string."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401 — sys.path setup
+
+
+class LoadSoqlValidationTests(unittest.TestCase):
+    """every param must be revalidated at the substitution boundary."""
+
+    def setUp(self) -> None:
+        # Use a throwaway SOQL_DIR populated per test so we don't depend on
+        # the shipped assets having a specific template name.
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.soql_dir = Path(self._tmpdir.name)
+        # Patch config.SOQL_DIR BEFORE importing soql_loader so the module
+        # constant reflects the tmpdir. Because soql_loader binds SOQL_DIR
+        # at import, we re-import it fresh under the patch.
+        self._patch = mock.patch("config.SOQL_DIR", self.soql_dir)
+        self._patch.start()
+        # Force a fresh import so load_soql reads the patched SOQL_DIR.
+        import importlib
+        import soql_loader  # type: ignore
+        importlib.reload(soql_loader)
+        self.soql_loader = soql_loader
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+        self._tmpdir.cleanup()
+
+    def _write_template(self, name: str, body: str) -> None:
+        (self.soql_dir / f"{name}.soql").write_text(body)
+
+    # ---- happy path -------------------------------------------------------
+
+    def test_valid_param_substitutes(self):
+        self._write_template(
+            "bot_lookup",
+            "SELECT Id FROM BotDefinition WHERE DeveloperName = '{{NAME}}'",
+        )
+        out = self.soql_loader.load_soql("bot_lookup", NAME="MyAgent")
+        self.assertEqual(
+            out,
+            "SELECT Id FROM BotDefinition WHERE DeveloperName = 'MyAgent'",
+        )
+
+    def test_multiple_valid_params(self):
+        self._write_template(
+            "lookup",
+            "SELECT Id FROM Obj WHERE A='{{A}}' AND B='{{B}}'",
+        )
+        out = self.soql_loader.load_soql("lookup", A="Foo", B="Bar_v2")
+        self.assertIn("A='Foo'", out)
+        self.assertIn("B='Bar_v2'", out)
+
+    # ---- injection attempts must raise ------------------------------------
+
+    def test_injection_quote_or_clause_raises(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Name='{{NAME}}'")
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql("q", NAME="x' OR Id!=null--")
+        self.assertEqual(ctx.exception.key, "NAME")
+
+    def test_injection_drop_table_raises(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Name='{{NAME}}'")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", NAME="'; DROP TABLE x;--")
+
+    def test_injection_or_1eq1_raises(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Name='{{NAME}}'")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", NAME="x OR 1=1")
+
+    def test_whitespace_rejected(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Name='{{NAME}}'")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", NAME="x OR y")  # space
+
+    def test_dash_rejected(self):
+        # Common SOQL-injection payload prefix.
+        self._write_template("q", "SELECT Id FROM X WHERE Name='{{NAME}}'")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", NAME="x-y")
+
+    # ---- type errors ------------------------------------------------------
+
+    def test_non_string_value_raises(self):
+        self._write_template("q", "SELECT {{N}}")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", N=42)
+
+    def test_none_value_raises(self):
+        self._write_template("q", "SELECT {{N}}")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", N=None)
+
+    def test_empty_string_raises(self):
+        self._write_template("q", "SELECT {{N}}")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", N="")
+
+    # ---- single-pass substitution guarantee -------------------------------
+
+    def test_value_containing_other_placeholder_does_not_retrigger(self):
+        """A valid value that contains `{{OTHER}}` must NOT trigger a
+        second substitution pass on OTHER. str.replace is single-pass
+        by contract; we assert that the validator's regex prevents any
+        value from containing `{`, `}`, or whitespace in the first place
+        — so the injection path is closed at validation, not at
+        substitution.
+        """
+        self._write_template("q", "SELECT {{A}} AND {{B}}")
+        # Reject values that carry placeholder syntax — the regex forbids
+        # `{` and `}` (they're not in [A-Za-z0-9_]).
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("q", A="{{B}}", B="safe")
+
+    def test_raw_replace_is_single_pass(self):
+        """Belt-and-braces: even if a value slipped through (it cannot,
+        per the regex), Python's str.replace does not recursively scan
+        the output. Simulate by bypassing the validator and confirming
+        str.replace behavior directly.
+        """
+        template = "SELECT {{A}} AND {{B}}"
+        # Substitute A first with a value that "looks like" the B
+        # placeholder. str.replace for B should then replace the
+        # template's own `{{B}}` — but A's embedded `{{B}}` should stay
+        # (Python replaces left-to-right in a single pass; the output
+        # of the A replacement is the NEW string and B's pass runs on
+        # that new string). The assertion below therefore confirms
+        # that B's replacement hits BOTH occurrences (the original and
+        # the one inside A's substituted value) — demonstrating that
+        # str.replace is NOT recursive on the ORIGINAL template alone,
+        # but IS a single linear scan of the full post-A string.
+        step1 = template.replace("{{A}}", "{{B}}")
+        step2 = step1.replace("{{B}}", "replaced")
+        # Both occurrences of `{{B}}` in step1 are replaced in a single
+        # left-to-right pass. This is the property tested for.
+        self.assertEqual(step2, "SELECT replaced AND replaced")
+        # The safety net: if a caller EVER skipped revalidation and
+        # allowed a `{{X}}` to reach substitution, the above behavior
+        # could matter — which is PRECISELY why revalidates at
+        # the boundary. The regex denies `{`, `}`, whitespace, making
+        # this scenario unreachable in production.
+
+
+class LoadSoqlNameValidationTests(unittest.TestCase):
+    """the `name` argument is validated before any filesystem access.
+
+    Without this, a caller that sources `name` from data (config file, user
+    argument, discovered string) could read arbitrary files via traversal
+    (`../../../etc/passwd`). The regex gate closes that before `read_text()`.
+    """
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.soql_dir = Path(self._tmpdir.name)
+        self._patch = mock.patch("config.SOQL_DIR", self.soql_dir)
+        self._patch.start()
+        import importlib
+        import soql_loader  # type: ignore
+        importlib.reload(soql_loader)
+        self.soql_loader = soql_loader
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+        self._tmpdir.cleanup()
+
+    # ---- traversal attempts must raise before any file read ---------------
+
+    def test_parent_traversal_raises(self):
+        """`../../../etc/passwd` must be caught by validation, not by the
+        filesystem. The error must be SoqlParamError (clearly labeled) —
+        NOT a bare FileNotFoundError or a ValidationError with raw path.
+        """
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql("../../../etc/passwd")
+        self.assertEqual(ctx.exception.key, "soql_template_name")
+        # The absolute SOQL_DIR must NOT appear in the surfaced message.
+        self.assertNotIn(str(self.soql_dir), str(ctx.exception))
+
+    def test_dotdot_alone_raises(self):
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("..")
+
+    def test_slash_in_name_raises(self):
+        """`/` is not in [A-Za-z0-9_], so `plugins/by_planner` must be
+        caught at validation — never reach the filesystem."""
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("plugins/by_planner")
+
+    def test_backslash_in_name_raises(self):
+        """Windows-style separators — belt and braces."""
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("plugins\\by_planner")
+
+    def test_absolute_path_raises(self):
+        """A caller passing an absolute path (a different traversal variant)
+        must still hit validation, not a false-negative file read."""
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("/etc/passwd")
+
+    def test_empty_name_raises(self):
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("")
+
+    def test_none_name_raises(self):
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql(None)  # type: ignore[arg-type]
+
+    def test_whitespace_in_name_raises(self):
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql("bot lookup")
+
+    def test_traversal_never_reads_filesystem(self):
+        """Validation runs before any I/O — verify read_text is never
+        called when the name is invalid. If the order ever flips, a bad
+        name could still leak a FileNotFoundError with raw path info.
+        """
+        with mock.patch.object(Path, "read_text") as mock_read:
+            with self.assertRaises(self.soql_loader.SoqlParamError):
+                self.soql_loader.load_soql("../../../evil")
+            mock_read.assert_not_called()
+
+
+class LoadSoqlTemplateNotFoundTests(unittest.TestCase):
+    """FileNotFoundError is translated into SoqlTemplateNotFound
+    whose message is free of filesystem-path leakage.
+    """
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.soql_dir = Path(self._tmpdir.name)
+        self._patch = mock.patch("config.SOQL_DIR", self.soql_dir)
+        self._patch.start()
+        import importlib
+        import soql_loader  # type: ignore
+        importlib.reload(soql_loader)
+        self.soql_loader = soql_loader
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+        self._tmpdir.cleanup()
+
+    def test_missing_template_raises_custom_exception(self):
+        with self.assertRaises(self.soql_loader.SoqlTemplateNotFound) as ctx:
+            self.soql_loader.load_soql("nonexistent_template")
+        self.assertEqual(ctx.exception.name, "nonexistent_template")
+
+    def test_missing_template_message_excludes_soql_dir(self):
+        """The SOQL_DIR absolute path must NOT appear in the surfaced error
+        string — information-disclosure hygiene. Attackers don't need to know
+        where the skill install lives on disk.
+        """
+        with self.assertRaises(self.soql_loader.SoqlTemplateNotFound) as ctx:
+            self.soql_loader.load_soql("nonexistent_template")
+        msg = str(ctx.exception)
+        self.assertNotIn(str(self.soql_dir), msg)
+        self.assertNotIn(".soql", msg)
+        # Template name IS allowed in the message — that's the triage signal.
+        self.assertIn("nonexistent_template", msg)
+
+    def test_missing_template_does_not_leak_via_cause_chain(self):
+        """`raise ... from None` is load-bearing: without it, the
+        FileNotFoundError (with its raw `filename` attribute) would be
+        reachable via `exception.__cause__`. Verify the chain is severed.
+        """
+        try:
+            self.soql_loader.load_soql("nonexistent_template")
+        except self.soql_loader.SoqlTemplateNotFound as e:
+            # `from None` sets __cause__ = None AND __suppress_context__ = True.
+            # Either alone suppresses traceback rendering of the underlying
+            # FileNotFoundError.
+            self.assertIsNone(e.__cause__)
+            self.assertTrue(e.__suppress_context__)
+        else:
+            self.fail("expected SoqlTemplateNotFound")
+
+    def test_not_found_exception_is_distinct_from_file_not_found(self):
+        """Callers should be able to tell 'template missing' apart from
+        'permission denied / I/O error' at the except-clause layer.
+        """
+        self.assertFalse(
+            issubclass(
+                self.soql_loader.SoqlTemplateNotFound,
+                FileNotFoundError,
+            ),
+            "SoqlTemplateNotFound must not subclass FileNotFoundError",
+        )
+
+    def test_valid_name_with_params_unchanged(self):
+        """Regression: must not break the happy path."""
+        (self.soql_dir / "lookup.soql").write_text(
+            "SELECT Id FROM X WHERE Name = '{{NAME}}'"
+        )
+        out = self.soql_loader.load_soql("lookup", NAME="MyAgent")
+        self.assertEqual(
+            out,
+            "SELECT Id FROM X WHERE Name = 'MyAgent'",
+        )
+
+
+class LoadSoqlInListParamTests(unittest.TestCase):
+    """`load_soql_in` renders `WHERE X IN (...)` list placeholders.
+
+    Same validation surface as `load_soql` — every list element passes
+    through `fs_guard.validate_api_name`. Empty lists fail fast (SOQL
+    `WHERE X IN ()` is invalid). Dedup + sort are load-bearing for
+    stable cache keys.
+    """
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.soql_dir = Path(self._tmpdir.name)
+        self._patch = mock.patch("config.SOQL_DIR", self.soql_dir)
+        self._patch.start()
+        import importlib
+        import soql_loader  # type: ignore
+        importlib.reload(soql_loader)
+        self.soql_loader = soql_loader
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+        self._tmpdir.cleanup()
+
+    def _write_template(self, name: str, body: str) -> None:
+        (self.soql_dir / f"{name}.soql").write_text(body)
+
+    # ---- happy path ------------------------------------------------------
+
+    def test_list_params_render_single_quoted_comma_joined(self):
+        self._write_template(
+            "apex_by_names",
+            "SELECT Id FROM ApexClass WHERE Name IN ({{NAMES_LIST}})",
+        )
+        out = self.soql_loader.load_soql_in(
+            "apex_by_names",
+            list_params={"NAMES_LIST": ["ClassA", "ClassB"]},
+        )
+        self.assertIn("WHERE Name IN ('ClassA','ClassB')", out)
+
+    def test_mixed_string_and_list_params(self):
+        self._write_template(
+            "functions_q",
+            "SELECT Id FROM GenAiFunctionDefinition "
+            "WHERE PlannerId = '{{PLANNER_ID}}' OR PluginId IN ({{PLUGIN_IDS}})",
+        )
+        out = self.soql_loader.load_soql_in(
+            "functions_q",
+            string_params={"PLANNER_ID": "X"},
+            list_params={"PLUGIN_IDS": ["P1", "P2"]},
+        )
+        self.assertIn("PlannerId = 'X'", out)
+        self.assertIn("PluginId IN ('P1','P2')", out)
+
+    def test_string_params_optional(self):
+        """string_params defaults to None — list_params alone should work."""
+        self._write_template(
+            "flow_by_names",
+            "SELECT Id FROM FlowDefinition WHERE DeveloperName IN ({{NAMES_LIST}})",
+        )
+        out = self.soql_loader.load_soql_in(
+            "flow_by_names",
+            list_params={"NAMES_LIST": ["Flow_A"]},
+        )
+        self.assertIn("IN ('Flow_A')", out)
+
+    # ---- validation: list elements must match api_name regex ---------------
+
+    def test_injection_in_list_element_raises_with_list_key(self):
+        """A SOQL injection attempt inside a list element must raise
+        SoqlParamError whose `key` is the LIST key (not the element
+        index or a synthetic name) — so the caller can log / mark
+        `_unresolved[NAMES_LIST]` at the upstream boundary.
+        """
+        self._write_template(
+            "q", "SELECT Id FROM ApexClass WHERE Name IN ({{NAMES_LIST}})",
+        )
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql_in(
+                "q",
+                list_params={"NAMES_LIST": ["ClassA", "ClassB'; DROP TABLE x;--"]},
+            )
+        self.assertEqual(ctx.exception.key, "NAMES_LIST")
+
+    def test_non_string_element_raises(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Id IN ({{IDS}})")
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql_in(
+                "q", list_params={"IDS": ["ClassA", 42]},
+            )
+        self.assertEqual(ctx.exception.key, "IDS")
+
+    def test_whitespace_in_list_element_raises(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Id IN ({{IDS}})")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            self.soql_loader.load_soql_in(
+                "q", list_params={"IDS": ["ClassA", "x OR 1=1"]},
+            )
+
+    # ---- empty list fails fast --------------------------------------------
+
+    def test_empty_list_raises(self):
+        """SOQL `WHERE X IN ()` is a syntax error; fail at the loader,
+        not at the CLI. The reason string must mention empty so the
+        `_unresolved` bucket can be tagged distinctly from injection.
+        """
+        self._write_template("q", "SELECT Id FROM X WHERE Id IN ({{IDS}})")
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql_in("q", list_params={"IDS": []})
+        self.assertEqual(ctx.exception.key, "IDS")
+        self.assertIn("empty", ctx.exception.reason.lower())
+
+    def test_list_params_not_a_list_raises(self):
+        """Defensive: a dict or string passed in `list_params[KEY]`
+        must be rejected — silently iterating a string would produce
+        one-char-per-element SOQL, which is worse than an explicit error.
+        """
+        self._write_template("q", "SELECT Id FROM X WHERE Id IN ({{IDS}})")
+        with self.assertRaises(self.soql_loader.SoqlParamError):
+            # type: ignore[arg-type]
+            self.soql_loader.load_soql_in("q", list_params={"IDS": "notalist"})
+
+    # ---- dedupe + deterministic order -------------------------------------
+
+    def test_dedupe_eliminates_duplicates(self):
+        self._write_template("q", "SELECT Id FROM X WHERE Name IN ({{NS}})")
+        out = self.soql_loader.load_soql_in(
+            "q", list_params={"NS": ["ClassA", "ClassA", "ClassB"]},
+        )
+        self.assertEqual(out.count("'ClassA'"), 1)
+        self.assertEqual(out.count("'ClassB'"), 1)
+
+    def test_output_is_sorted_for_deterministic_order(self):
+        """Stable cache-key requirement: input order MUST NOT affect
+        output. `sorted(set(...))` lands ClassA before ClassB regardless
+        of input order.
+        """
+        self._write_template("q", "SELECT Id FROM X WHERE Name IN ({{NS}})")
+        out1 = self.soql_loader.load_soql_in(
+            "q", list_params={"NS": ["ClassB", "ClassA"]},
+        )
+        out2 = self.soql_loader.load_soql_in(
+            "q", list_params={"NS": ["ClassA", "ClassB"]},
+        )
+        self.assertEqual(out1, out2)
+        # And the order is alphabetical, not input-dependent.
+        self.assertLess(out1.index("'ClassA'"), out1.index("'ClassB'"))
+
+    # ---- scalar validation path shared with load_soql ---------------------
+
+    def test_scalar_injection_still_raises(self):
+        """string_params go through the same validator as `load_soql` —
+        no shortcut. A SOQL-injection attempt in a scalar must still
+        surface SoqlParamError.
+        """
+        self._write_template(
+            "q",
+            "SELECT Id FROM X WHERE P = '{{PID}}' OR Q IN ({{LIST}})",
+        )
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql_in(
+                "q",
+                string_params={"PID": "x' OR Id!=null--"},
+                list_params={"LIST": ["A"]},
+            )
+        self.assertEqual(ctx.exception.key, "PID")
+
+    # ---- template-name validation reused ----------------------------------
+
+    def test_template_traversal_raises(self):
+        with self.assertRaises(self.soql_loader.SoqlParamError) as ctx:
+            self.soql_loader.load_soql_in(
+                "../../../evil", list_params={"IDS": ["A"]},
+            )
+        self.assertEqual(ctx.exception.key, "soql_template_name")
+
+    def test_missing_template_raises_template_not_found(self):
+        with self.assertRaises(self.soql_loader.SoqlTemplateNotFound):
+            self.soql_loader.load_soql_in(
+                "nonexistent_for_in", list_params={"IDS": ["A"]},
+            )
+
+    # ---- existing load_soql unchanged -------------------------------------
+
+    def test_load_soql_signature_untouched(self):
+        """contract: `load_soql(name, **params)` keeps its original
+        signature — no kwargs-only, no extra params. A caller that still
+        uses the old form must keep working.
+        """
+        self._write_template("q", "SELECT Id FROM X WHERE Name = '{{NAME}}'")
+        out = self.soql_loader.load_soql("q", NAME="Foo")
+        self.assertIn("'Foo'", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_summarize_tree.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_summarize_tree.py
@@ -1,0 +1,241 @@
+"""Tests for ``summarize_tree`` — declared-action-tree → markdown summary.
+
+Covers:
+- ``render_tree``  recursive box-drawing renderer
+- ``main``         CLI orchestration via argv (tree_json + out_md + built_at)
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import summarize_tree  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# render_tree — pure dict → list[str]
+# -----------------------------------------------------------------------------
+
+
+class RenderTreeTests(unittest.TestCase):
+
+    def test_single_leaf_uses_last_connector(self):
+        # is_last=True (default) → "└── "; no children → no recursion.
+        out = summarize_tree.render_tree({"kind": "TOPIC", "api_name": "T1"})
+        self.assertEqual(out, ["└── [TOPIC] T1"])
+
+    def test_first_of_two_siblings_uses_branch_connector(self):
+        # render at top-level isn't the natural use, but the function
+        # accepts is_last=False → "├── ".
+        out = summarize_tree.render_tree(
+            {"kind": "TOPIC", "api_name": "T1"}, is_last=False
+        )
+        self.assertEqual(out, ["├── [TOPIC] T1"])
+
+    def test_bot_definition_with_version_includes_version_in_label(self):
+        agent = {"version": "v3"}
+        out = summarize_tree.render_tree(
+            {"kind": "BOT_DEFINITION", "api_name": "MyAgent"},
+            agent_=agent,
+        )
+        self.assertEqual(out, ["└── [BOT_DEFINITION] MyAgent (v3)"])
+
+    def test_bot_definition_without_version_omits_version_suffix(self):
+        out = summarize_tree.render_tree(
+            {"kind": "BOT_DEFINITION", "api_name": "MyAgent"},
+            agent_={},
+        )
+        self.assertEqual(out, ["└── [BOT_DEFINITION] MyAgent"])
+
+    def test_gen_ai_function_includes_unwraps_arrow(self):
+        out = summarize_tree.render_tree({
+            "kind": "GEN_AI_FUNCTION",
+            "api_name": "GAF1",
+            "unwraps_to": {"kind": "FLOW", "api_name": "FlowA"},
+        })
+        self.assertEqual(out, ["└── [GEN_AI_FUNCTION] GAF1 → FLOW:FlowA"])
+
+    def test_gen_ai_function_without_unwraps_omits_arrow(self):
+        out = summarize_tree.render_tree({
+            "kind": "GEN_AI_FUNCTION",
+            "api_name": "GAF1",
+        })
+        self.assertEqual(out, ["└── [GEN_AI_FUNCTION] GAF1"])
+
+    def test_standard_action_uses_invocation_type_when_present(self):
+        out = summarize_tree.render_tree({
+            "kind": "STANDARD_ACTION",
+            "api_name": "SA1",
+            "invocation_type": "standardinvocableaction",
+        })
+        self.assertEqual(
+            out, ["└── [STANDARD_ACTION] SA1 (standardinvocableaction)"]
+        )
+
+    def test_standard_action_falls_back_to_legacy_invocation_keys(self):
+        # raw_invocation_type wins when invocation_type missing.
+        with self.subTest("raw_invocation_type"):
+            out = summarize_tree.render_tree({
+                "kind": "STANDARD_ACTION",
+                "api_name": "SA1",
+                "raw_invocation_type": "legacyA",
+            })
+            self.assertIn("legacyA", out[0])
+        with self.subTest("raw_action_type"):
+            out = summarize_tree.render_tree({
+                "kind": "UNKNOWN",
+                "api_name": "U1",
+                "raw_action_type": "legacyB",
+            })
+            self.assertIn("legacyB", out[0])
+
+    def test_element_name_appended_for_non_bot_kinds(self):
+        out = summarize_tree.render_tree({
+            "kind": "FLOW",
+            "api_name": "FlowA",
+            "element_name": "callX",
+        })
+        self.assertEqual(out, ["└── [FLOW] FlowA  — element:callX"])
+
+    def test_element_name_skipped_on_bot_definition(self):
+        out = summarize_tree.render_tree({
+            "kind": "BOT_DEFINITION",
+            "api_name": "MyAgent",
+            "element_name": "should-not-appear",
+        }, agent_={"version": "v1"})
+        self.assertNotIn("should-not-appear", out[0])
+
+    def test_nested_children_recurse_with_correct_prefix(self):
+        out = summarize_tree.render_tree({
+            "kind": "TOPIC",
+            "api_name": "T1",
+            "children": [
+                {"kind": "STANDARD_ACTION", "api_name": "A1"},
+                {"kind": "STANDARD_ACTION", "api_name": "A2"},
+            ],
+        })
+        # Top-level (is_last=True) gets " " continuation prefix.
+        self.assertEqual(out, [
+            "└── [TOPIC] T1",
+            "    ├── [STANDARD_ACTION] A1",
+            "    └── [STANDARD_ACTION] A2",
+        ])
+
+    def test_branch_node_uses_pipe_continuation_for_children(self):
+        # is_last=False at parent → "│ " continuation prefix.
+        out = summarize_tree.render_tree({
+            "kind": "TOPIC",
+            "api_name": "T1",
+            "children": [{"kind": "APEX", "api_name": "A1"}],
+        }, is_last=False)
+        self.assertEqual(out, [
+            "├── [TOPIC] T1",
+            "│   └── [APEX] A1",
+        ])
+
+
+# -----------------------------------------------------------------------------
+# main — argv-based CLI
+# -----------------------------------------------------------------------------
+
+
+def _minimal_tree() -> dict:
+    return {
+        "agent": {
+            "api_name": "MyAgent", "version": "v1", "bot_id": "0Xx000000000",
+            "master_label": "My Agent", "generation": "nga",
+            "planner_name": "MyPlanner", "planner_type": "Atlas__Reasoning",
+            "_version_auto_picked": False,
+        },
+        "node_count": 2,
+        "depth": 1,
+        "_kind_counts": {"TOPIC": 1, "STANDARD_ACTION": 1},
+        "_partial": False,
+        "root": {
+            "kind": "BOT_DEFINITION", "api_name": "MyAgent",
+            "children": [{"kind": "TOPIC", "api_name": "Greetings"}],
+        },
+    }
+
+
+class MainTests(unittest.TestCase):
+
+    def test_main_returns_one_when_argv_count_wrong(self):
+        with mock.patch.object(summarize_tree, "sys") as fake_sys:
+            fake_sys.argv = ["summarize_tree.py"]  # missing args
+            fake_sys.stderr.write = lambda *_a, **_kw: None
+            rc = summarize_tree.main()
+        self.assertEqual(rc, 1)
+
+    def test_main_returns_one_when_tree_json_unreadable(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            with mock.patch.object(summarize_tree, "sys") as fake_sys:
+                fake_sys.argv = [
+                    "summarize_tree.py",
+                    str(tmp / "missing.json"),
+                    str(tmp / "out.md"),
+                    "2026-05-09T00:00:00Z",
+                ]
+                fake_sys.stderr.write = lambda *_a, **_kw: None
+                rc = summarize_tree.main()
+            self.assertEqual(rc, 1)
+
+    def test_main_writes_summary_md_with_expected_sections(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            tree_path = tmp / "tree.json"
+            tree_path.write_text(json.dumps(_minimal_tree()))
+            out_path = tmp / "out.summary.md"
+
+            with mock.patch.object(summarize_tree, "sys") as fake_sys:
+                fake_sys.argv = [
+                    "summarize_tree.py",
+                    str(tree_path), str(out_path),
+                    "2026-05-09T00:00:00Z",
+                ]
+                fake_sys.stderr.write = lambda *_a, **_kw: None
+                rc = summarize_tree.main()
+
+            self.assertEqual(rc, 0)
+            content = out_path.read_text()
+            self.assertIn("# MyAgent v1 — declared action tree", content)
+            self.assertIn("## Kind counts", content)
+            self.assertIn("## Declared action tree", content)
+            # tree section is wrapped in ``` fence
+            self.assertIn("```\n└── [BOT_DEFINITION] MyAgent (v1)", content)
+            # 2026-05-09 timestamp surfaced
+            self.assertIn("2026-05-09T00:00:00Z", content)
+
+    def test_main_appends_unresolved_section_when_present(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            tree = _minimal_tree()
+            tree["_unresolved"] = [
+                {"kind": "FLOW", "api_name": "Missing", "reason": "404"},
+            ]
+            tree_path = tmp / "tree.json"
+            tree_path.write_text(json.dumps(tree))
+            out_path = tmp / "out.summary.md"
+
+            with mock.patch.object(summarize_tree, "sys") as fake_sys:
+                fake_sys.argv = [
+                    "summarize_tree.py",
+                    str(tree_path), str(out_path),
+                    "2026-05-09T00:00:00Z",
+                ]
+                fake_sys.stderr.write = lambda *_a, **_kw: None
+                summarize_tree.main()
+
+            content = out_path.read_text()
+            self.assertIn("## Unresolved", content)
+            self.assertIn("`FLOW`/`Missing` — 404", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/scripts/tests/test_write_emit_ctx.py
+++ b/skills/investigating-agentforce-architecture/scripts/tests/test_write_emit_ctx.py
@@ -1,0 +1,480 @@
+"""Integration tests for  (REMEDIATE): tree → write_emit_ctx → emit_result.
+
+The defect: parse_wave.py writes `_partial_reason` and `_pending_fetches`
+into the tree on disk. emit_result.py reads `ctx["partial_reason"]` and
+`ctx["pending_fetches_count"]` from the emit ctx. But write_emit_ctx.py
+NEVER populated those ctx keys from the tree — they silently defaulted to
+empty / 0 on every run. Depth-cap truncation was invisible downstream.
+
+These tests exercise both halves of the wiring:
+
+    test_write_emit_ctx_reads_tree_partial_signals
+        fake tree JSON → write_emit_ctx → assert ctx keys populated.
+
+    test_end_to_end_tree_surfaces_partial_reason_in_result_block
+        tree → write_emit_ctx → emit_result → assert RESULT block carries
+        PARTIAL_REASON + PENDING_FETCHES_COUNT. End-to-end — this is the
+        test both reviewers called for.
+
+Missing-tree behavior is also covered so early-abort paths still work.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from . import _bootstrap  # noqa: F401
+
+
+def _tools_dir() -> pathlib.Path:
+    """Absolute path to the skill's tools/ dir — where the scripts live."""
+    here = pathlib.Path(__file__).resolve()
+    return here.parent.parent.parent / "tools"
+
+
+def _run_script(script_name: str, env: dict) -> subprocess.CompletedProcess:
+    """Invoke `python3 <tools>/<script>.py` with the given env.
+
+    We deliberately run the scripts as subprocesses rather than importing
+    them: they're shipped as stand-alone CLIs (the agent bash invokes them
+    via `python3 write_emit_ctx.py`) and `main()` reads env at call time +
+    returns an exit code. Subprocess gives us the exact production call
+    path without having to monkey-patch os.environ.
+    """
+    script_path = _tools_dir() / script_name
+    return subprocess.run(
+        [sys.executable, str(script_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class WriteEmitCtxTreeSignalsTests(unittest.TestCase):
+    """write_emit_ctx must plumb `_partial_reason` + rollup from tree."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.work_dir = pathlib.Path(self._tmp.name) / "work"
+        self.data_dir = pathlib.Path(self._tmp.name) / "data"
+        self.work_dir.mkdir()
+        self.data_dir.mkdir()
+
+    def _base_env(self, status: str = "OK") -> dict:
+        return {
+            **os.environ,
+            "WORK_DIR": str(self.work_dir),
+            "DATA_DIR": str(self.data_dir),
+            "STATUS": status,
+            "AGENT_API_NAME": "MyBot",
+            "AGENT_VERSION": "v1",
+            "ORG_ID_15": "00D000000000ABC",
+            "BOT_ID": "0XxFAKEBOTID",
+            "NODE_COUNT": "42",
+            "DEPTH": "3",
+            "PARTIAL": "true",
+            "START_EPOCH": "0",
+        }
+
+    def _write_tree(self, payload: dict) -> None:
+        (self.work_dir / "declared_action_tree.json").write_text(
+            json.dumps(payload)
+        )
+
+    def _read_ctx(self) -> dict:
+        return json.loads((self.work_dir / ".emit_ctx.json").read_text())
+
+    def test_write_emit_ctx_reads_tree_partial_signals(self):
+        """Fake tree → ctx carries partial_reason + pending_fetches_count."""
+        self._write_tree({
+            "_partial": True,
+            "_partial_reason": "max-depth-cap",
+            "_pending_fetches": {
+                "FLOW": ["F6"],
+                "APEX": [],
+                "PROMPT_TEMPLATE": [],
+                "STANDARD_ACTION": [],
+            },
+        })
+
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        ctx = self._read_ctx()
+        self.assertEqual(ctx["partial_reason"], "max-depth-cap")
+        self.assertEqual(ctx["pending_fetches_count"], 1)
+
+    def test_write_emit_ctx_rollup_sums_across_kinds(self):
+        self._write_tree({
+            "_partial": True,
+            "_partial_reason": "pending-refs",
+            "_pending_fetches": {
+                "FLOW": ["F1", "F2"],
+                "APEX": ["A1"],
+                "PROMPT_TEMPLATE": [],
+                "STANDARD_ACTION": ["S1", "S2", "S3"],
+            },
+        })
+
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        ctx = self._read_ctx()
+        self.assertEqual(ctx["partial_reason"], "pending-refs")
+        self.assertEqual(ctx["pending_fetches_count"], 6)
+
+    def test_write_emit_ctx_missing_tree_defaults_safely(self):
+        """Early-abort paths never write a tree — ctx must default cleanly."""
+        # No tree file written.
+        result = _run_script(
+            "write_emit_ctx.py",
+            self._base_env(status="AGENT_NOT_FOUND"),
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertEqual(ctx["partial_reason"], "")
+        self.assertEqual(ctx["pending_fetches_count"], 0)
+
+    def test_write_emit_ctx_malformed_tree_defaults_safely(self):
+        (self.work_dir / "declared_action_tree.json").write_text("{ not json")
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertEqual(ctx["partial_reason"], "")
+        self.assertEqual(ctx["pending_fetches_count"], 0)
+
+
+class TreeToResultBlockEndToEndTests(unittest.TestCase):
+    """end-to-end: tree → write_emit_ctx → emit_result → RESULT block.
+
+    This is the test both reviewers called for — it would have caught the
+    original defect. A fix that only makes write_emit_ctx plumb the
+    fields but doesn't verify they land in the RESULT block is not a fix.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.work_dir = pathlib.Path(self._tmp.name) / "work"
+        self.data_dir = pathlib.Path(self._tmp.name) / "data"
+        self.work_dir.mkdir()
+        self.data_dir.mkdir()
+
+    def test_end_to_end_tree_surfaces_partial_reason_in_result_block(self):
+        # 1. Tree on disk — depth-cap tripped, one pending flow.
+        (self.work_dir / "declared_action_tree.json").write_text(json.dumps({
+            "_partial": True,
+            "_partial_reason": "max-depth-cap",
+            "_pending_fetches": {
+                "FLOW": ["F6"],
+                "APEX": [],
+                "PROMPT_TEMPLATE": [],
+                "STANDARD_ACTION": [],
+            },
+        }))
+
+        # 2. write_emit_ctx — populates .emit_ctx.json from env + tree.
+        env = {
+            **os.environ,
+            "WORK_DIR": str(self.work_dir),
+            "DATA_DIR": str(self.data_dir),
+            "STATUS": "OK",
+            "AGENT_API_NAME": "MyBot",
+            "AGENT_VERSION": "v1",
+            "ORG_ID_15": "00D000000000ABC",
+            "BOT_ID": "0XxFAKEBOTID",
+            "NODE_COUNT": "5",
+            "DEPTH": "5",
+            "PARTIAL": "true",
+            "START_EPOCH": "0",
+        }
+        r1 = _run_script("write_emit_ctx.py", env)
+        self.assertEqual(r1.returncode, 0, msg=r1.stderr)
+
+        # 3. emit_result — reads .emit_ctx.json, prints RESULT block.
+        r2 = _run_script("emit_result.py", env)
+        self.assertEqual(r2.returncode, 0, msg=r2.stderr)
+
+        # 4. Assert the RESULT block carries the plumbed fields.
+        block = r2.stdout
+        self.assertIn("PARTIAL_REASON=max-depth-cap", block)
+        self.assertIn("PENDING_FETCHES_COUNT=1", block)
+        # Auto-promote: partial=True + status=OK → PARTIAL_OK.
+        self.assertIn("STATUS=PARTIAL_OK", block)
+        self.assertNotIn("STATUS=OK\n", block)  # not the base OK status
+
+    def test_end_to_end_no_tree_produces_empty_partial_fields(self):
+        """Early-abort path (no tree) → RESULT block carries empties, not crashes."""
+        env = {
+            **os.environ,
+            "WORK_DIR": str(self.work_dir),
+            "DATA_DIR": str(self.data_dir),
+            "STATUS": "AGENT_NOT_FOUND",
+            "AGENT_API_NAME": "Missing",
+            "AGENT_VERSION": "",
+            "ORG_ID_15": "00D000000000ABC",
+            "BOT_ID": "",
+            "START_EPOCH": "0",
+        }
+        r1 = _run_script("write_emit_ctx.py", env)
+        self.assertEqual(r1.returncode, 0, msg=r1.stderr)
+        r2 = _run_script("emit_result.py", env)
+        self.assertEqual(r2.returncode, 0, msg=r2.stderr)
+
+        block = r2.stdout
+        self.assertIn("STATUS=AGENT_NOT_FOUND", block)
+        self.assertIn("PARTIAL_REASON=", block)
+        self.assertIn("PENDING_FETCHES_COUNT=0", block)
+
+
+class WriteEmitCtxArchitectureSignalsTests(unittest.TestCase):
+    """write_emit_ctx must plumb architecture-render signals.
+
+    Cases:
+      * Render succeeded → architecture.md present, no sidecar →
+        ctx.architecture_path set, render_failed=False, detail="".
+      * Render failed → sidecar present → render_failed=True,
+        detail populated (truncated + redacted).
+      * Render not attempted → no file, no sidecar → empties,
+        render_failed=False. This is the early-abort / cache-hit path.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.work_dir = pathlib.Path(self._tmp.name) / "work"
+        self.data_dir = pathlib.Path(self._tmp.name) / "data"
+        self.work_dir.mkdir()
+        self.data_dir.mkdir()
+
+    def _base_env(self, status: str = "OK") -> dict:
+        return {
+            **os.environ,
+            "WORK_DIR": str(self.work_dir),
+            "DATA_DIR": str(self.data_dir),
+            "STATUS": status,
+            "AGENT_API_NAME": "MyBot",
+            "AGENT_VERSION": "v1",
+            "ORG_ID_15": "00D000000000ABC",
+            "BOT_ID": "0XxFAKEBOTID",
+            "START_EPOCH": "0",
+        }
+
+    def _read_ctx(self) -> dict:
+        return json.loads((self.work_dir / ".emit_ctx.json").read_text())
+
+    def test_render_success_surfaces_architecture_path(self):
+        # filename is {agent}_{ver}_architecture.md.
+        (self.data_dir / "MyBot_v1_architecture.md").write_text("# Architecture\n")
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertEqual(
+            ctx["architecture_path"],
+            str(self.data_dir / "MyBot_v1_architecture.md"),
+        )
+        self.assertFalse(ctx["render_failed"])
+        self.assertEqual(ctx["render_error_detail"], "")
+
+    def test_render_failure_surfaces_sidecar_detail(self):
+        (self.data_dir / "MyBot_v1_architecture.md.error").write_text(
+            "render_architecture failed: KeyError: 'agent'\n"
+        )
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertTrue(ctx["render_failed"])
+        self.assertIn("KeyError", ctx["render_error_detail"])
+        # Sidecar's truncation + redaction happened — detail shouldn't
+        # exceed 200 chars even for a pathological sidecar.
+        self.assertLessEqual(len(ctx["render_error_detail"]), 200)
+        # No architecture.md present → architecture_path stays empty.
+        self.assertEqual(ctx["architecture_path"], "")
+
+    def test_render_failure_detail_is_redacted(self):
+        # Sidecar content mimics an exception that echoed back an
+        # Authorization header — the redactor must scrub it.
+        (self.data_dir / "MyBot_v1_architecture.md.error").write_text(
+            "render_architecture failed: RequestError: Authorization: Bearer TESTONLY_RENDER_TOKEN xyz\n"
+        )
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertTrue(ctx["render_failed"])
+        self.assertNotIn("TESTONLY_RENDER_TOKEN", ctx["render_error_detail"])
+        self.assertIn("<redacted>", ctx["render_error_detail"])
+
+    def test_render_not_attempted_keeps_fields_empty(self):
+        # No architecture.md, no sidecar — e.g. early-abort paths.
+        result = _run_script(
+            "write_emit_ctx.py",
+            self._base_env(status="AGENT_NOT_FOUND"),
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertEqual(ctx["architecture_path"], "")
+        self.assertFalse(ctx["render_failed"])
+        self.assertEqual(ctx["render_error_detail"], "")
+
+    def test_render_success_and_failure_concurrent_surfaces_both(self):
+        # Edge case: architecture.md present + sidecar present. This
+        # shouldn't happen in practice (finalize writes one or the
+        # other), but the reader shouldn't mutate behaviour based on
+        # cross-key state — path present + render_failed=True.
+        (self.data_dir / "MyBot_v1_architecture.md").write_text("# Architecture\n")
+        (self.data_dir / "MyBot_v1_architecture.md.error").write_text(
+            "render_architecture failed: RuntimeError: partial output\n"
+        )
+        result = _run_script("write_emit_ctx.py", self._base_env())
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        ctx = self._read_ctx()
+        self.assertTrue(ctx["render_failed"])
+        self.assertEqual(
+            ctx["architecture_path"],
+            str(self.data_dir / "MyBot_v1_architecture.md"),
+        )
+
+
+class EmitResultArchitectureSignalsTests(unittest.TestCase):
+    """emit_result surfaces architecture + render-failure fields.
+
+    The integration tests in TreeToResultBlockEndToEndTests cover the
+    write_emit_ctx -> emit_result handoff; these tests exercise
+    emit_result's block-shaping logic in isolation via `build_block`.
+    """
+
+    def _import_mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "emit_result_mod", _tools_dir() / "emit_result.py",
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_render_ok_emits_architecture_path_and_render_failed_false(self):
+        mod = self._import_mod()
+        ctx = {
+            "status": "OK",
+            "architecture_path": "/tmp/data/architecture.md",
+            "render_failed": False,
+        }
+        block = mod.build_block(ctx, wall_time_seconds=0.5)
+        self.assertIn("OUTPUT_ARCHITECTURE_PATH=/tmp/data/architecture.md", block)
+        self.assertIn("RENDER_FAILED=false", block)
+        # Detail key is ONLY emitted on failure — must NOT appear here.
+        self.assertNotIn("RENDER_ERROR_DETAIL=", block)
+        # Status stays OK.
+        self.assertIn("STATUS=OK", block)
+        self.assertNotIn("STATUS=PARTIAL_OK", block)
+
+    def test_render_failed_auto_promotes_to_partial_ok(self):
+        mod = self._import_mod()
+        ctx = {
+            "status": "OK",
+            "architecture_path": "",  # render failed, no file produced
+            "render_failed": True,
+            "render_error_detail": "KeyError: 'agent'",
+        }
+        block = mod.build_block(ctx, wall_time_seconds=0.5)
+        self.assertIn("STATUS=PARTIAL_OK", block)
+        self.assertIn("RENDER_FAILED=true", block)
+        self.assertIn("RENDER_ERROR_DETAIL=KeyError: 'agent'", block)
+        # PARTIAL_REASON pinned to render-failed when the tree didn't
+        # already claim a reason.
+        self.assertIn("PARTIAL_REASON=render-failed", block)
+        # OUTPUT_ARCHITECTURE_PATH always emitted, empty on failure.
+        self.assertIn("OUTPUT_ARCHITECTURE_PATH=", block)
+
+    def test_render_failed_preserves_tree_partial_reason(self):
+        # When the tree is ALREADY partial with a reason, render_failed
+        # must NOT clobber the tree's reason — the tree's signal is more
+        # informative for triage.
+        mod = self._import_mod()
+        ctx = {
+            "status": "OK",
+            "partial": True,
+            "partial_reason": "max-depth-cap",
+            "render_failed": True,
+            "render_error_detail": "RuntimeError: ...",
+        }
+        block = mod.build_block(ctx, wall_time_seconds=0.5)
+        self.assertIn("PARTIAL_REASON=max-depth-cap", block)
+        self.assertNotIn("PARTIAL_REASON=render-failed", block)
+        # Still surfaces as PARTIAL_OK (either the tree or the render
+        # flag is sufficient to trip the auto-promote).
+        self.assertIn("STATUS=PARTIAL_OK", block)
+        self.assertIn("RENDER_FAILED=true", block)
+
+    def test_render_failed_does_not_clobber_error_status(self):
+        mod = self._import_mod()
+        ctx = {
+            "status": "AUTH_REQUIRED",
+            "render_failed": True,
+            "render_error_detail": "ignored under error status",
+        }
+        block = mod.build_block(ctx, wall_time_seconds=0.1)
+        self.assertIn("STATUS=AUTH_REQUIRED", block)
+        self.assertNotIn("STATUS=PARTIAL_OK", block)
+        # The render fields still surface for diagnostics.
+        self.assertIn("RENDER_FAILED=true", block)
+
+
+class EmitResultPositionalSafetyTests(unittest.TestCase):
+    """emit_result must assert lines[1] starts with 'STATUS=' before rewrite.
+
+    The auto-promote branch (PARTIAL → PARTIAL_OK) rewrites `lines[1]`
+    in place. If a future refactor reorders the header, the rewrite
+    would clobber the wrong line. The assertion catches that at test
+    time instead of silently producing a malformed RESULT block in prod.
+    """
+
+    def test_build_block_happy_path_auto_promotes_without_asserting(self):
+        """Sanity: the assertion does NOT fire under normal operation."""
+        # Force import of emit_result from the tools/ dir.
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "emit_result_mod", _tools_dir() / "emit_result.py",
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        ctx = {
+            "status": "OK",
+            "partial": True,
+            "partial_reason": "max-depth-cap",
+            "pending_fetches_count": 3,
+            "node_count": 10,
+            "depth": 5,
+        }
+        block = mod.build_block(ctx, wall_time_seconds=1.23)
+        self.assertIn("STATUS=PARTIAL_OK", block)
+        self.assertIn("PARTIAL_REASON=max-depth-cap", block)
+        self.assertIn("PENDING_FETCHES_COUNT=3", block)
+
+    def test_positional_assertion_fires_when_header_reordered(self):
+        """Simulate a refactor that puts something other than STATUS at lines[1].
+
+        We construct a fake `lines` list directly and run the same
+        assertion the production code runs. This is the exact guarantee
+        adds — the production assert catches the drift.
+        """
+        # This mirrors the production code's assertion verbatim.
+        lines = ["=== RESULT ===", "WAS_MOVED=true", "STATUS=OK"]
+        with self.assertRaises(AssertionError):
+            assert lines[1].startswith("STATUS="), (
+                f"emit block reordered — lines[1]={lines[1]!r}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-architecture/tools/emit_env.py
+++ b/skills/investigating-agentforce-architecture/tools/emit_env.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Generic JSON-in → shell-export-out extractor.
+
+Reads a JSON document (from stdin or a file), traverses it by dot-path specs,
+and emits `export KEY=shlex.quote(VALUE)` lines on stdout. Callers consume via
+`eval "$(python3 emit_env.py ...)"`.
+
+Replaces four single-purpose parsers that previously existed as inline Python
+heredocs in the agent:
+  * sf org display result parser
+  * Q1 row-count + SESSION_ACTIVE derivation
+  * _cache_meta.json reader (CACHED_AT_UTC, SESSION_ACTIVE_AT_CACHE)
+  * individual field extractors
+
+Field-spec DSL:
+    EXPORT_KEY:path           — plain dot-path traversal
+    EXPORT_KEY:path[:N]       — string slice after traversal (first N chars)
+    EXPORT_KEY:path.length    — length of array / string at path
+    EXPORT_KEY:path.empty     — "true" if missing or empty string, else "false"
+
+The DSL is deliberately small: three operators, no dot-inside-key escaping.
+Any path component is a dictionary key OR an integer array index
+(`data[0].ssot__Foo` works). If the path doesn't resolve, the emitted value
+is the empty string — caller decides whether that's OK.
+
+Usage:
+    # Parse `sf org display --json` output via stdin
+    eval "$(printf '%s' "$_SF_JSON" | python3 emit_env.py stdin \\
+            'ACCESS_TOKEN:result.accessToken' \\
+            'INSTANCE_URL:result.instanceUrl' \\
+            'ORG_ID_18:result.id' \\
+            'ORG_ID_15:result.id[:15]')"
+
+    # Q1 post-wave: derive SESSION_ACTIVE from row 0's end timestamp
+    eval "$(python3 emit_env.py "$WORK_DIR/_q1_body.json" \\
+            'SESSION_ACTIVE:data[0].ssot__EndTimestamp__c.empty')"
+
+    # Cache-hit meta read
+    eval "$(python3 emit_env.py "$WORK_DIR/$SID.dc.json" \\
+            'CACHED_AT_UTC:_cache_meta.cached_at_utc' \\
+            'SESSION_ACTIVE:_cache_meta.session_active_at_cache')"
+
+Inputs:
+    argv[1]     'stdin' or an absolute file path
+    argv[2+]    field specs (at least one)
+
+Outputs:
+    stdout      zero or more `export K=V` lines
+    exit 0      always (missing keys just produce empty values)
+    exit 1      bad argv, unparseable JSON, or I/O error
+"""
+import json
+import pathlib
+import re
+import shlex
+import sys
+
+SLICE_RE = re.compile(r"^(.*?)\[:(\d+)\]$")
+
+
+def traverse(data, path: str):
+    # Path components are dot-separated. Numeric components index into arrays;
+    # everything else is a dict key. Missing/invalid → None (emitted as empty).
+    node = data
+    for part in path.split("."):
+        if node is None:
+            return None
+        if part.isdigit():
+            try:
+                node = node[int(part)]
+            except (IndexError, KeyError, TypeError):
+                return None
+        elif isinstance(node, dict):
+            node = node.get(part)
+        else:
+            return None
+    return node
+
+
+def apply_spec(data, spec: str) -> tuple[str, str]:
+    # spec: "EXPORT_KEY:path<operator>"
+    if ":" not in spec:
+        raise ValueError(f"spec missing colon: {spec}")
+    key, rhs = spec.split(":", 1)
+    if not key:
+        raise ValueError(f"spec has empty key: {spec}")
+
+    # Resolve the operator suffix on rhs. Check slice LAST because it's the
+    # only one that doesn't alter the traversed value's type.
+    if rhs.endswith(".length"):
+        value = traverse(data, rhs[:-7])
+        if value is None:
+            return key, "0"
+        if isinstance(value, (list, str)):
+            return key, str(len(value))
+        return key, "0"
+
+    if rhs.endswith(".empty"):
+        value = traverse(data, rhs[:-6])
+        is_empty = value is None or value == ""
+        return key, "true" if is_empty else "false"
+
+    m = SLICE_RE.match(rhs)
+    if m:
+        path, n = m.group(1), int(m.group(2))
+        value = traverse(data, path)
+        if value is None:
+            return key, ""
+        return key, str(value)[:n]
+
+    # Plain traversal.
+    value = traverse(data, rhs)
+    if value is None:
+        return key, ""
+    if isinstance(value, bool):
+        # Python `True` / `False` → `true` / `false` so bash string compares
+        # work without an extra lowercase step.
+        return key, "true" if value else "false"
+    return key, str(value)
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        sys.stderr.write("emit_env.py: need source ('stdin' or path) and at least one field spec\n")
+        return 1
+
+    source = sys.argv[1]
+    specs = sys.argv[2:]
+
+    try:
+        if source == "stdin":
+            raw = sys.stdin.read()
+        else:
+            raw = pathlib.Path(source).read_text()
+    except OSError as e:
+        sys.stderr.write(f"emit_env.py: cannot read {source}: {e}\n")
+        return 1
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"emit_env.py: JSON parse error: {e}\n")
+        return 1
+
+    for spec in specs:
+        try:
+            key, value = apply_spec(data, spec)
+        except ValueError as e:
+            sys.stderr.write(f"emit_env.py: {e}\n")
+            return 1
+        sys.stdout.write(f"export {key}={shlex.quote(value)}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/tools/emit_result.py
+++ b/skills/investigating-agentforce-architecture/tools/emit_result.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Final-phase RESULT emitter for investigating-agentforce-architecture.
+
+Reads `$WORK_DIR/.emit_ctx.json` (populated by write_emit_ctx.py) and prints
+the final output:
+
+    1. One-line prose status (for humans; first signal in the log).
+    2. A blank line.
+    3. The `=== RESULT ===` KV block.
+
+BEFORE writing to stdout, the complete RESULT block is teed to
+`$DATA_DIR/last_result_block.txt`. Writing the tee first means a consumer
+reading the file can never see a truncated block — disk write is atomic
+(`tmp + os.replace`), and the stdout print is a best-effort afterthought.
+
+The callers that abort early (AGENT_NOT_FOUND, AGENT_VERSION_NOT_FOUND,
+INVALID_INPUT) emit their own RESULT blocks directly — resolve_bot.py and
+fs_guard.py have the same disk-tee discipline. All other terminal paths
+(OK, PARTIAL_OK, AUTH_REQUIRED, RETRIEVE_FAILED, WRITE_FAILED) flow through
+this script.
+
+Usage:
+    python3 emit_result.py
+
+Inputs:
+    env $WORK_DIR     reads $WORK_DIR/.emit_ctx.json
+
+Outputs:
+    $DATA_DIR/last_result_block.txt    full RESULT block (atomic write)
+    stdout                             prose line + RESULT block
+    exit 0                             always (this script emits; the bash
+                                       harness decides the agent's exit code)
+    exit 1                             missing env, missing ctx file, bad JSON
+"""
+import json
+import os
+import pathlib
+import sys
+import time
+
+STATUS_ENUM = {
+    "OK",
+    "PARTIAL_OK",
+    "INVALID_INPUT",
+    "AUTH_REQUIRED",
+    "AGENT_NOT_FOUND",
+    "AGENT_VERSION_NOT_FOUND",
+    "RETRIEVE_FAILED",
+    "WRITE_FAILED",
+}
+
+PROSE = {
+    "OK": "Declared action tree discovered and cached.",
+    "PARTIAL_OK": "Declared action tree partially discovered — see UNRESOLVED_COUNT.",
+    "INVALID_INPUT": "Input validation failed.",
+    "AUTH_REQUIRED": "sf CLI not authenticated for this org.",
+    "AGENT_NOT_FOUND": "BotDefinition.DeveloperName not found in the org.",
+    "AGENT_VERSION_NOT_FOUND": "No matching BotVersion under the bot.",
+    "RETRIEVE_FAILED": "Metadata API retrieve failed (auth/network/permissions).",
+    "WRITE_FAILED": "A filesystem write failed during finalize.",
+}
+
+
+def scrub(s) -> str:
+    if not isinstance(s, str):
+        s = "" if s is None else str(s)
+    bad = set("`$\"\\\r\t\0\n")
+    return "".join(c for c in s if c not in bad)
+
+
+def bool_str(v) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    s = str(v).lower()
+    return "true" if s in ("true", "1", "yes", "on") else "false"
+
+
+def build_block(ctx: dict, wall_time_seconds: float) -> str:
+    status = (ctx.get("status") or "").strip().upper()
+    if status not in STATUS_ENUM:
+        status = "WRITE_FAILED"
+
+    lines = ["=== RESULT ===", f"STATUS={status}"]
+
+    error_detail = scrub(ctx.get("error_detail", ""))
+    if error_detail:
+        lines.append(f"ERROR_DETAIL={error_detail}")
+
+    # Always-emitted identity fields (may be empty on early-abort paths)
+    lines.extend([
+        f"AGENT_API_NAME={scrub(ctx.get('agent_api_name', ''))}",
+        f"AGENT_VERSION={scrub(ctx.get('agent_version', ''))}",
+        f"VERSION_AUTO_PICKED={bool_str(ctx.get('version_auto_picked', False))}",
+        f"AGENT_GENERATION={scrub(ctx.get('agent_generation', '') or 'unknown')}",
+        f"BOT_ID={scrub(ctx.get('bot_id', ''))}",
+        f"ORG_ID_15={scrub(ctx.get('org_id_15', ''))}",
+        f"ORG_ID_18={scrub(ctx.get('org_id_18', ''))}",
+    ])
+
+    # Output + cache paths (populated on success; may be empty on fail paths)
+    # OUTPUT_ARCHITECTURE_PATH is always emitted — empty
+    # string on fail paths, cache-hit paths where the renderer wasn't
+    # invoked, or when render failed. Downstream consumers can distinguish
+    # "no architecture produced" from "architecture produced but stale"
+    # by cross-referencing RENDER_FAILED + CACHE_HIT.
+    lines.extend([
+        f"OUTPUT_JSON_PATH={scrub(ctx.get('output_json_path', ''))}",
+        f"OUTPUT_SUMMARY_PATH={scrub(ctx.get('output_summary_path', ''))}",
+        f"OUTPUT_ARCHITECTURE_PATH={scrub(ctx.get('architecture_path', '') or '')}",
+        f"CACHE_PATH={scrub(ctx.get('cache_path', ''))}",
+        f"CACHE_HIT={bool_str(ctx.get('cache_hit', False))}",
+        f"CACHED_AT_UTC={scrub(ctx.get('cached_at_utc', ''))}",
+    ])
+
+    # Tree stats
+    # emit `_partial_reason` + a rollup of `_pending_fetches` counts
+    # alongside the existing PARTIAL / UNRESOLVED_COUNT fields. The write
+    # path populates ctx["partial"], ctx["partial_reason"], and
+    # ctx["pending_fetches_count"] from the finalized tree JSON —
+    # emit_result is intentionally presentation-only and does not re-read
+    # the tree itself (ctx is the single source of truth per the emit
+    # contract).
+    partial_flag = bool(ctx.get("partial", False))
+    partial_reason = scrub(ctx.get("partial_reason", "") or "")
+    pending_fetches_count = int(ctx.get("pending_fetches_count", 0) or 0)
+
+    # If the upstream pipeline forgot to populate partial_reason but
+    # flagged partial=True, emit an empty value rather than nothing —
+    # downstream consumers can distinguish "no reason supplied" from
+    # "key missing" this way.
+    lines.extend([
+        f"NODE_COUNT={int(ctx.get('node_count', 0) or 0)}",
+        f"DEPTH={int(ctx.get('depth', 0) or 0)}",
+        f"PARTIAL={bool_str(partial_flag)}",
+        f"PARTIAL_REASON={partial_reason}",
+        f"PENDING_FETCHES_COUNT={pending_fetches_count}",
+        f"UNRESOLVED_COUNT={int(ctx.get('unresolved_count', 0) or 0)}",
+    ])
+
+    # when the tree is partial but status was left blank / "OK",
+    # auto-promote the status to PARTIAL_OK so the RESULT block reflects
+    # the tree's actual state. ERROR paths (AUTH_REQUIRED etc.) keep
+    # their original status — never clobber a failure status.
+    if partial_flag and status == "OK":
+        # positional safety — `lines[1]` is by construction
+        # "STATUS=...". If a future refactor reorders the header we want
+        # a loud failure here rather than silently rewriting the wrong
+        # line. Assertion cost is negligible; the payoff is catching a
+        # whole class of refactor bugs at test time.
+        assert lines[1].startswith("STATUS="), (
+            f"emit block reordered — lines[1]={lines[1]!r}"
+        )
+        lines[1] = "STATUS=PARTIAL_OK"
+        status = "PARTIAL_OK"
+
+    # emit RENDER_FAILED unconditionally, and auto-promote to
+    # PARTIAL_OK when the tree succeeded but the architecture.md render
+    # raised. The signal surface is:
+    # * RENDER_FAILED=true|false — always emitted.
+    # * RENDER_ERROR_DETAIL=<...> — emitted ONLY on true, redacted
+    # at write_emit_ctx-time.
+    # * STATUS auto-promoted OK -> PARTIAL_OK; _partial_reason pinned
+    # to "render-failed" when the tree wasn't already partial.
+    # ERROR paths (AUTH_REQUIRED etc.) retain their original status:
+    # render never runs in those cases, and render_failed defaults to
+    # False so the auto-promote below is a no-op.
+    render_failed = bool(ctx.get("render_failed", False))
+    lines.append(f"RENDER_FAILED={bool_str(render_failed)}")
+    if render_failed:
+        detail = scrub(ctx.get("render_error_detail", "") or "")
+        lines.append(f"RENDER_ERROR_DETAIL={detail}")
+        if status == "OK":
+            # Same positional-safety discipline as the partial auto-promote.
+            assert lines[1].startswith("STATUS="), (
+                f"emit block reordered — lines[1]={lines[1]!r}"
+            )
+            lines[1] = "STATUS=PARTIAL_OK"
+            status = "PARTIAL_OK"
+            # Pin a partial_reason so triagers can tell this apart from a
+            # tree-level partial. We walk backwards to find the existing
+            # PARTIAL_REASON line (always present — emitted above) and
+            # rewrite in place. A fresh line would create two competing
+            # reason values in the block.
+            for idx in range(len(lines) - 1, -1, -1):
+                if lines[idx].startswith("PARTIAL_REASON="):
+                    # Only overwrite when the tree didn't already claim
+                    # a reason — the tree's reason is more informative.
+                    if lines[idx] == "PARTIAL_REASON=":
+                        lines[idx] = "PARTIAL_REASON=render-failed"
+                    break
+
+    # Error-path-specific optional keys
+    if status == "AGENT_NOT_FOUND":
+        bots = scrub(ctx.get("available_bots", ""))
+        if bots:
+            lines.append(f"AVAILABLE_BOTS={bots}")
+    if status == "AGENT_VERSION_NOT_FOUND":
+        vers = scrub(ctx.get("available_versions", ""))
+        if vers:
+            lines.append(f"AVAILABLE_VERSIONS={vers}")
+
+    lines.append(f"WALL_TIME_SECONDS={wall_time_seconds:.2f}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    work_dir_s = os.environ.get("WORK_DIR", "")
+    if not work_dir_s:
+        sys.stderr.write("emit_result.py: $WORK_DIR not set\n")
+        return 1
+
+    ctx_path = pathlib.Path(work_dir_s) / ".emit_ctx.json"
+    try:
+        ctx = json.loads(ctx_path.read_text())
+    except FileNotFoundError:
+        sys.stderr.write(f"emit_result.py: missing {ctx_path}\n")
+        return 1
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"emit_result.py: cannot read {ctx_path}: {e}\n")
+        return 1
+
+    start_epoch = float(ctx.get("start_epoch") or time.time())
+    wall = max(0.0, time.time() - start_epoch)
+
+    data_dir_s = scrub(ctx.get("data_dir", ""))
+    if not data_dir_s:
+        data_dir_s = str(pathlib.Path.home() / ".claude" / "data" / "investigating-agentforce-architecture" / "_agents")
+    data_dir = pathlib.Path(data_dir_s)
+    tee_path = data_dir / "last_result_block.txt"
+
+    body = build_block(ctx, wall)
+    body += f"RESULT_BLOCK_PATH={tee_path}\n"
+
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        tmp = tee_path.with_suffix(tee_path.suffix + ".tmp")
+        tmp.write_text(body)
+        os.replace(tmp, tee_path)
+    except OSError as e:
+        sys.stderr.write(f"emit_result.py: tee failed ({e}); continuing with stdout\n")
+
+    status = (ctx.get("status") or "").strip().upper()
+    prose = PROSE.get(status, f"Unknown status {status}.")
+    sys.stdout.write(prose + "\n\n")
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/tools/grant_allowlist.py
+++ b/skills/investigating-agentforce-architecture/tools/grant_allowlist.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""First-run setup: grant allowlist rules + seed gitignore files.
+
+Idempotent. Called by the agent's Phase 3 on first run (sentinel absent). On
+every subsequent run the agent skips calling this script entirely.
+
+Three actions:
+ 1. Merge ~30 canonical rules into ~/.claude/settings.json permissions.allow
+    (only adds missing entries; preserves any rules already present). Atomic
+    write: staged tmp file in the same directory + os.replace(). On corrupt
+    JSON, the original is copied aside to .corrupt.backup and the script
+    exits 2 without modifying anything — Claude Code refusing to start on a
+    blanked permission list is worse than refusing to grant.
+ 2. mkdir -p ~/.claude/data/investigating-agentforce-architecture/ + write
+    .gitignore (`*`) iff the current content is not already exactly `*`.
+    Metadata trees can carry customer-specific labels, descriptions, and
+    flow names; preventing accidental git commits is load-bearing.
+ 3. mkdir -p ~/.claude/cache/investigating-agentforce-architecture/ + same
+    .gitignore seeding.
+
+Usage:
+    python3 grant_allowlist.py
+
+Inputs:
+    none (all paths hardcoded under $HOME/.claude/)
+
+Outputs:
+    side effects: settings.json rewritten, two .gitignore files seeded
+    stdout: one progress line per action
+    exit 0: full success
+    exit 1: write failure (disk full, permission denied)
+    exit 2: settings.json unparseable (refuses to wipe)
+"""
+import json
+import pathlib
+import shutil
+import sys
+
+HOME = pathlib.Path.home()
+SETTINGS = HOME / ".claude" / "settings.json"
+DATA = HOME / ".claude" / "data" / "investigating-agentforce-architecture"
+CACHE = HOME / ".claude" / "cache" / "investigating-agentforce-architecture"
+SKILL = HOME / ".claude" / "skills" / "investigating-agentforce-architecture"
+
+# Canonical allowlist rules. Every script gets its own scoped entry — no
+# python3:* blanket, no python3 -c:* (agent forbids inline -c).
+NEEDED = [
+    # /tmp work dir — ephemeral per-invocation scratch (see SKILL.md
+    # WORK_DIR construction). Matches the runtime path-prefix in SKILL.md.
+    "Bash(mkdir -p /tmp/investigating-agentforce-architecture-*:*)",
+    "Bash(rm -rf /tmp/investigating-agentforce-architecture-*:*)",
+    "Bash(unzip:*)",
+    # Salesforce CLI commands
+    "Bash(sf project retrieve start:*)",
+    "Bash(sf data query:*)",
+    "Bash(sf org display:*)",
+    # Read/write: /tmp
+    "Read(/tmp/investigating-agentforce-architecture-**)",
+    "Write(/tmp/investigating-agentforce-architecture-**)",
+    # Skill + agent dirs (read-only)
+    f"Read({HOME}/.claude/agents/**)",
+    f"Read({HOME}/.claude/skills/**)",
+    # Standalone data root
+    f"Read({DATA}/**)",
+    f"Write({DATA}/**)",
+    f"Bash(mkdir -p {DATA}/**)",
+    # Standalone cache root
+    f"Read({CACHE}/**)",
+    f"Write({CACHE}/**)",
+    f"Bash(mkdir -p {CACHE}/**)",
+    f"Bash(rm -rf {CACHE}/**)",
+    f"Bash(mv {CACHE}/**:*)",
+    # Sentinel (unversioned)
+    f"Bash(touch {HOME}/.claude/.investigating-agentforce-architecture.allowlist-done.v2:*)",
+    f"Bash(rm -f {HOME}/.claude/.investigating-agentforce-architecture.allowlist-done.v2:*)",
+    # Tools scripts (per-file scoped — no glob). Tools live under tools/;
+    # pipeline scripts under scripts/.
+    # fix: the rename batch left these pointing at
+    # tools/<name>.py for files that actually live in scripts/. Pre-
+    # existing port artifact, now made user-visible by install.sh
+    # (every internal invocation prompted). Realigned.
+    f"Bash(python3 {SKILL}/tools/sanitize.py:*)",
+    f"Bash(python3 {SKILL}/tools/grant_allowlist.py:*)",
+    # fs_guard moved to plugin _shared/ in v1.5.0 (mirrored into every
+    # sibling skill's scripts/_shared/ at install/build time so all 4
+    # skills can import it standalone). SKILL.md phase-1 invokes it
+    # from this new path; the allowlist mirrors that.
+    f"Bash(python3 {SKILL}/scripts/_shared/fs_guard.py:*)",
+    f"Bash(python3 {SKILL}/tools/emit_env.py:*)",
+    f"Bash(python3 {SKILL}/tools/write_emit_ctx.py:*)",
+    f"Bash(python3 {SKILL}/tools/emit_result.py:*)",
+    # Pipeline scripts (scripts/, not tools/).
+    f"Bash(python3 {SKILL}/scripts/main.py:*)",
+    f"Bash(python3 {SKILL}/scripts/resolve_bot.py:*)",
+    f"Bash(python3 {SKILL}/scripts/cache_check.py:*)",
+    f"Bash(python3 {SKILL}/scripts/parse_bundle.py:*)",
+    f"Bash(python3 {SKILL}/scripts/parse_wave.py:*)",
+    f"Bash(python3 {SKILL}/scripts/finalize.py:*)",
+    f"Bash(python3 {SKILL}/scripts/summarize_tree.py:*)",
+    f"Bash(python3 {SKILL}/scripts/render_architecture.py:*)",
+    f"Bash(python3 {SKILL}/scripts/probe_channels.py:*)",
+    f"Bash(python3 {SKILL}/scripts/fetch_soql.py:*)",
+    f"Bash(python3 {SKILL}/scripts/rest_client.py:*)",
+    f"Bash(python3 {SKILL}/scripts/sf_cli.py:*)",
+    f"Bash(python3 {SKILL}/scripts/soql_loader.py:*)",
+    f"Bash(python3 {SKILL}/scripts/parallel_retrieve.py:*)",
+    f"Bash(python3 {SKILL}/scripts/resolve_invocation_target.py:*)",
+    f"Bash(python3 {SKILL}/scripts/retrieve_planner.py:*)",
+    f"Bash(python3 {SKILL}/scripts/config.py:*)",
+]
+
+
+def grant_allowlist() -> None:
+    if SETTINGS.exists():
+        try:
+            data = json.loads(SETTINGS.read_text())
+        except json.JSONDecodeError as e:
+            backup = SETTINGS.with_suffix(".corrupt.backup")
+            shutil.copy(SETTINGS, backup)
+            print(f"[allowlist] settings.json unparseable ({e}); backed up to {backup}")
+            print("[allowlist] fix settings.json and retry; not modifying")
+            sys.exit(2)
+    else:
+        data = {}
+
+    data.setdefault("permissions", {}).setdefault("allow", [])
+    allow = data["permissions"]["allow"]
+    before = set(allow)
+    added = 0
+    for rule in NEEDED:
+        if rule not in before:
+            allow.append(rule)
+            added += 1
+
+    tmp = SETTINGS.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(SETTINGS)
+    print(f"[allowlist] added {added} rules ({len(NEEDED)} canonical, {len(allow) - added} pre-existing)")
+
+
+def seed_gitignore(root: pathlib.Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    gitignore = root / ".gitignore"
+    current = gitignore.read_text() if gitignore.exists() else ""
+    if current.strip() != "*":
+        gitignore.write_text("*\n")
+        print(f"[allowlist] seeded {gitignore}")
+
+
+def main() -> int:
+    try:
+        grant_allowlist()
+        seed_gitignore(DATA)
+        seed_gitignore(CACHE)
+        print("[allowlist] done")
+        return 0
+    except (OSError, IOError) as e:
+        print(f"[allowlist] write failure: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-architecture/tools/sanitize.py
+++ b/skills/investigating-agentforce-architecture/tools/sanitize.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Scrub dangerous characters from a string before splicing into the RESULT block.
+
+Strips characters that would corrupt the `KEY=VALUE` line format parsers use to read
+the RESULT block: backtick, dollar, double-quote, backslash, CR, tab, NUL, newline.
+
+Used when interpolating user-controlled values (session_id, org_alias, sf CLI stderr
+excerpts) into ERROR_DETAIL and other RESULT fields. Without scrubbing, a malicious
+or malformed input could inject fake KEY=VALUE pairs that downstream consumers
+would treat as authoritative.
+
+Usage:
+    _safe=$(python3 "$SKILL/tools/sanitize.py" "$raw_value")
+
+Arguments:
+    argv[1]  raw string (may be empty)
+
+Output:
+    stdout   scrubbed string (no trailing newline)
+    exit 0   always (even on empty input)
+"""
+import sys
+
+BAD = set("`$\"\\\r\t\0\n")
+
+
+def scrub(s: str) -> str:
+    return "".join(c for c in s if c not in BAD)
+
+
+if __name__ == "__main__":
+    raw = sys.argv[1] if len(sys.argv) > 1 else ""
+    sys.stdout.write(scrub(raw))

--- a/skills/investigating-agentforce-architecture/tools/write_emit_ctx.py
+++ b/skills/investigating-agentforce-architecture/tools/write_emit_ctx.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Write the `$WORK_DIR/.emit_ctx.json` context file for `emit_result.py`.
+
+The agent's bash pipeline has ~10 places where it needs to populate this
+context file (one OK path + 6 error paths + cache-hit path). Previously this
+was done with inline `python3 - <<PYCTX` heredocs; extracting it into one
+script gives a stable allowlist footprint and a single source of truth for
+the ctx-file shape.
+
+This script reads every field from env vars the agent has already exported
+and writes the JSON atomically. Status-specific error messages come in via
+`STATUS` + `ERROR_DETAIL`; the rest of the fields are derived from the run's
+already-exported state.
+
+Usage:
+    STATUS=OK ERROR_DETAIL='' CACHE_HIT=false \\
+      python3 write_emit_ctx.py
+
+Inputs (env):
+    WORK_DIR             required — target dir for .emit_ctx.json
+    AGENT_API_NAME       required
+    AGENT_VERSION        required on success paths, may be empty on early fails
+    VERSION_AUTO_PICKED  'true'/'false'; defaults to false
+    AGENT_GENERATION     'classic'|'nga'|'unknown'; defaults to 'unknown'
+    BOT_ID               required on success paths, may be empty on early fails
+    ORG_ID_15            required on success paths, may be empty on early fails
+    ORG_ID_18            required on success paths, may be empty on early fails
+    CACHE_HIT            'true'/'false'; defaults to false
+    CACHED_AT_UTC        ISO-8601 or empty
+    NODE_COUNT           integer as string; defaults to 0
+    DEPTH                integer as string; defaults to 0
+    PARTIAL              'true'/'false'; defaults to false
+    UNRESOLVED_COUNT     integer as string; defaults to 0
+    START_EPOCH          float seconds since epoch
+    DATA_DIR             required — absolute path (may be org-less sentinel dir on early fail)
+    CACHE_PATH           optional — absolute path to cache dir (ends with /)
+    OUTPUT_JSON_PATH     optional — computed if empty on OK path
+    OUTPUT_SUMMARY_PATH  optional — computed if empty on OK path
+    AVAILABLE_BOTS       optional — csv, for AGENT_NOT_FOUND
+    AVAILABLE_VERSIONS   optional — csv, for AGENT_VERSION_NOT_FOUND
+    STATUS               required — one of the 7 enum values
+    ERROR_DETAIL         optional — human-readable error message
+
+ (REMEDIATE) derived keys (read from tree JSON, not env):
+    ctx["partial_reason"]         from tree["_partial_reason"] (default "")
+    ctx["pending_fetches_count"]  sum(len(v) for v in tree["_pending_fetches"].values())
+                                  (default 0)
+
+The tree is read from `$WORK_DIR/declared_action_tree.json` — this is
+where parse_wave.py writes. If the file is missing / unreadable / malformed,
+both keys default to empty / 0 (pre-remediation behavior). This keeps
+early-abort paths (AGENT_NOT_FOUND / AUTH_REQUIRED / etc.) working —
+they never produce a tree and rightly surface `partial_reason=""` +
+`pending_fetches_count=0`.
+
+derived keys (read from data_dir, not env):
+    ctx["architecture_path"]       absolute path to `architecture.md` when
+                                   the renderer produced one, else "".
+    ctx["render_failed"]           True iff a `architecture.md.error`
+                                   sidecar exists (written by
+                                   main._run_finalize on renderer exception).
+    ctx["render_error_detail"]     first 200 chars of sidecar, scrubbed via
+                                   rest_client.redact_text. Empty when
+                                   render_failed is False. The redact pass
+                                   is defensive — the sidecar shouldn't
+                                   carry tokens, but exception messages
+                                   can carry arbitrary org content.
+
+The sidecar convention pairs with `architecture.md`: finalize writes the
+`.error` only on exception; emit_result's RESULT-block auto-promote to
+PARTIAL_OK relies on this boolean to flag "tree OK, diagram skipped".
+
+Output:
+    $WORK_DIR/.emit_ctx.json
+    exit 0 on success, 1 on missing env / write failure
+"""
+import json
+import os
+import pathlib
+import re
+import sys
+
+
+# local, dependency-free token scrub mirroring the patterns in
+# `scripts/rest_client.redact_text`. Keeping the redactor inline preserves
+# the tools/ <-> scripts/ decoupling (tools/ is stdlib-only by policy) and
+# avoids adding a sys.path hop on every write_emit_ctx invocation. The two
+# implementations must stay in sync; the shared regex shapes are:
+# * Authorization: Bearer <token>
+# * access(_)?Token=<value> in query strings
+# * "access(_)?Token":"<value>" in JSON payloads
+# If a new redaction pattern is added to rest_client.redact_text it MUST be
+# mirrored here — the sidecar surface is narrow (render_architecture
+# exception messages) so the risk of drift is low, but the dual-impl is a
+# known trade-off for decoupling.
+_TOOLS_AUTH_HEADER_RE = re.compile(
+    r"(Authorization:\s*Bearer\s+)[^\s\"'<>]+",
+    flags=re.IGNORECASE,
+)
+_TOOLS_ACCESS_TOKEN_QS_RE = re.compile(
+    r"(access[_]?token=)[^&\s\"'<>]+",
+    flags=re.IGNORECASE,
+)
+_TOOLS_ACCESS_TOKEN_JSON_RE = re.compile(
+    r"(\"access[_]?token\"\s*:\s*\")[^\"]*",
+    flags=re.IGNORECASE,
+)
+
+
+def _redact(text: str) -> str:
+    if not text:
+        return text
+    text = _TOOLS_AUTH_HEADER_RE.sub(r"\1<redacted>", text)
+    text = _TOOLS_ACCESS_TOKEN_QS_RE.sub(r"\1<redacted>", text)
+    text = _TOOLS_ACCESS_TOKEN_JSON_RE.sub(r'\1<redacted>', text)
+    return text
+
+
+def _bool(v: str) -> bool:
+    return (v or "").strip().lower() == "true"
+
+
+def _int(v: str, default: int = 0) -> int:
+    try:
+        return int((v or "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _read_architecture_signals(
+    data_dir: str,
+    agent_api_name: str = "",
+    agent_version: str = "",
+) -> tuple[str, bool, str]:
+    """surface architecture.md presence + render-failure sidecar.
+
+    filename is now self-identifying —
+    `{agent_api_name}_{agent_version}_architecture.md` (plus `.error`
+    sidecar). Callers pass both identifiers through; when either is
+    missing we fall back to the legacy bare `architecture.md` / `.error`
+    names so early-abort paths that haven't resolved an agent yet still
+    surface any stray files they produced.
+
+    Returns `(architecture_path, render_failed, render_error_detail)`:
+
+      * `architecture_path` — absolute str to the rendered architecture.md
+        when present; `""` otherwise. Empty also covers cache-hit paths
+        where a *past* run's file may exist — see the inline note.
+      * `render_failed` — True iff the `.error` sidecar exists (written by
+        main._run_finalize on renderer exception).
+      * `render_error_detail` — first 200 chars of the sidecar, stripped +
+        scrubbed via `_redact`. Empty when `render_failed` is False.
+
+    Tolerant of: missing dir, unreadable sidecar, binary content. A failure
+    to read the sidecar degrades to an empty detail string rather than
+    suppressing the render_failed flag — consumers still see the outage
+    signal, just without the triage text.
+
+    Cache-hit caveat: on a cache replay, the prior run's architecture.md
+    may still be present. We intentionally surface its path anyway (the
+    file *is* a product of this run's data_dir). Sidecar semantics are
+    different — the sidecar only lands via finalize, so a cache replay
+    cannot plant a stale `.error`.
+    """
+    if not data_dir:
+        return ("", False, "")
+    dd = pathlib.Path(data_dir)
+    if agent_api_name and agent_version:
+        arch = dd / f"{agent_api_name}_{agent_version}_architecture.md"
+        sidecar = dd / f"{agent_api_name}_{agent_version}_architecture.md.error"
+    else:
+        # Early-abort paths (no agent resolved) fall back to the legacy
+        # bare name so any stray file still surfaces.
+        arch = dd / "architecture.md"
+        sidecar = dd / "architecture.md.error"
+
+    arch_path = str(arch) if arch.is_file() else ""
+
+    if not sidecar.is_file():
+        return (arch_path, False, "")
+
+    try:
+        # read_text()'s default is utf-8 with strict errors; a sidecar
+        # written by finalize is always ascii prose, but be defensive in
+        # case future code changes widen the content set.
+        raw = sidecar.read_text(errors="replace")
+    except OSError:
+        return (arch_path, True, "")
+
+    # Truncate to a single-line-ish detail string. The sidecar format is
+    # `"render_architecture failed: <ExcType>: <msg>\n"`; we strip + cap
+    # at 200 chars to keep the RESULT block readable, then scrub.
+    detail = raw.strip().splitlines()[0] if raw.strip() else ""
+    detail = _redact(detail)[:200]
+    return (arch_path, True, detail)
+
+
+def _read_tree_partial_signals(work_dir: str) -> tuple[str, int]:
+    """extract `_partial_reason` + pending-fetches rollup from the tree.
+
+    Reads `$WORK_DIR/declared_action_tree.json` (parse_wave's output) and
+    returns `(partial_reason, pending_fetches_count)`.
+
+    Tolerant of: missing file, unreadable file, malformed JSON, missing
+    keys, wrong-typed keys. All of those degrade to `("", 0)` — the
+    pre-remediation defaults — so early-abort code paths (which never
+    produce a tree) behave unchanged.
+
+    This is intentionally defensive: write_emit_ctx runs on every exit
+    path, including ones where the tree was never created. A raise here
+    would turn a clean error status into a write failure.
+    """
+    try:
+        tree_path = pathlib.Path(work_dir) / "declared_action_tree.json"
+        if not tree_path.is_file():
+            return ("", 0)
+        tree = json.loads(tree_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return ("", 0)
+
+    if not isinstance(tree, dict):
+        return ("", 0)
+
+    reason_raw = tree.get("_partial_reason")
+    reason = reason_raw if isinstance(reason_raw, str) else ""
+
+    pending = tree.get("_pending_fetches")
+    count = 0
+    if isinstance(pending, dict):
+        for v in pending.values():
+            if isinstance(v, list):
+                count += len(v)
+
+    return (reason, count)
+
+
+def main() -> int:
+    try:
+        work_dir = os.environ["WORK_DIR"]
+        data_dir = os.environ["DATA_DIR"]
+        status = os.environ["STATUS"]
+    except KeyError as e:
+        sys.stderr.write(f"write_emit_ctx.py: missing env {e}\n")
+        return 1
+
+    agent_api_name = os.environ.get("AGENT_API_NAME", "")
+    agent_version = os.environ.get("AGENT_VERSION", "")
+    org_id_15 = os.environ.get("ORG_ID_15", "")
+
+    # Default OUTPUT_*_PATH paths follow the agent-scoped naming convention.
+    # Caller can override by exporting directly. If DATA_DIR already ends with
+    # the per-agent suffix (because the agent bash composed it), don't re-append.
+    #
+    # summary.md dropped from the output contract — OUTPUT_SUMMARY_PATH
+    # is kept in the RESULT block (empty string) for shape stability.
+    default_json = ""
+    if status in ("OK", "PARTIAL_OK") and org_id_15 and agent_api_name and agent_version:
+        per_agent_suffix = f"{org_id_15}/{agent_api_name}__{agent_version}"
+        dd = data_dir.rstrip("/")
+        base = dd if dd.endswith(per_agent_suffix) else f"{dd}/{per_agent_suffix}"
+        default_json = f"{base}/{agent_api_name}_{agent_version}_metadata_tree.json"
+
+    output_json = os.environ.get("OUTPUT_JSON_PATH") or default_json
+    output_summary = os.environ.get("OUTPUT_SUMMARY_PATH") or ""
+
+    try:
+        start_epoch = float(os.environ.get("START_EPOCH", "0") or "0")
+    except ValueError:
+        start_epoch = 0.0
+
+    # derive partial_reason + pending_fetches_count from the tree
+    # on disk rather than relying on the agent bash to export them. The
+    # tree is the single source of truth — parse_wave wrote these fields;
+    # having the bash re-export them would be a narrow, drift-prone
+    # integration layer. Absent tree → default ("", 0).
+    partial_reason, pending_fetches_count = _read_tree_partial_signals(work_dir)
+
+    # derive architecture-output signals from the data_dir.
+    # Parallel to the partial-signals plumbing above: data_dir is the
+    # single source of truth for what finalize produced. A missing dir
+    # (early-abort paths) degrades to empty fields and render_failed=False.
+    architecture_path, render_failed, render_error_detail = (
+        _read_architecture_signals(data_dir, agent_api_name, agent_version)
+    )
+
+    ctx = {
+        "status": status,
+        "error_detail": os.environ.get("ERROR_DETAIL", ""),
+        "agent_api_name": agent_api_name,
+        "agent_version": agent_version,
+        "version_auto_picked": _bool(os.environ.get("VERSION_AUTO_PICKED", "")),
+        "agent_generation": os.environ.get("AGENT_GENERATION", "") or "unknown",
+        "bot_id": os.environ.get("BOT_ID", ""),
+        "org_id_15": org_id_15,
+        "org_id_18": os.environ.get("ORG_ID_18", ""),
+        "cache_hit": _bool(os.environ.get("CACHE_HIT", "")),
+        "cached_at_utc": os.environ.get("CACHED_AT_UTC", ""),
+        "cache_path": os.environ.get("CACHE_PATH", ""),
+        "output_json_path": output_json,
+        "output_summary_path": output_summary,
+        "node_count": _int(os.environ.get("NODE_COUNT", "0")),
+        "depth": _int(os.environ.get("DEPTH", "0")),
+        "partial": _bool(os.environ.get("PARTIAL", "")),
+        # plumbed from the tree, not env.
+        "partial_reason": partial_reason,
+        "pending_fetches_count": pending_fetches_count,
+        "unresolved_count": _int(os.environ.get("UNRESOLVED_COUNT", "0")),
+        "available_bots": os.environ.get("AVAILABLE_BOTS", ""),
+        "available_versions": os.environ.get("AVAILABLE_VERSIONS", ""),
+        "start_epoch": start_epoch,
+        "data_dir": data_dir,
+        "work_dir": work_dir,
+        # architecture-render outcome signals.
+        "architecture_path": architecture_path,
+        "render_failed": render_failed,
+        "render_error_detail": render_error_detail,
+    }
+
+    out = pathlib.Path(work_dir) / ".emit_ctx.json"
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        tmp = out.with_suffix(out.suffix + ".tmp")
+        tmp.write_text(json.dumps(ctx, indent=2))
+        os.replace(tmp, out)
+    except OSError as e:
+        sys.stderr.write(f"write_emit_ctx.py: write failed: {e}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new skill, `investigating-agentforce-architecture`, that produces a declared architecture snapshot for one Agentforce agent — planner + topics + actions + flows + Apex + prompts + NGA plugins.

The skill reads design-time metadata only (`BotDefinition` + `GenAi*` Tooling objects + Metadata API retrieve), normalizes classic ReAct and NGA planner shapes into a single tree, and renders a human-readable architecture document plus a Mermaid invocation graph.

GUS work item: [W-22704206](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002b1lNUYAY/view)

## What it does

- **7 parallel Tooling SOQL channels** for the planner → plugins → functions fan-out. Targeted Metadata retrieve only for `GenAiPromptTemplate` and NGA external plugins.
- **30–45s typical wall-clock** on reference fixtures, ≤60s hard cap. A naive sequential implementation would take 90–220s — parallel fan-out delivers 3–5×.
- **Asset-hash-keyed tree cache** + 7-day TTL channel-describe probe.
- **Path-traversal-safe**: every path component is regex-validated before `Path` composition.
- **Auth hardening**: Authorization-stripping HTTP redirect handler, 401 token refresh with serialized + deduped refresh, transient-HTTP backoff for 429 / 503.

## Outputs

Two files under `~/.claude/data/investigating-agentforce-architecture/<org_id15>/<agent>__<version>/`:

- `<agent>_<ver>_metadata_tree.json` — canonical normalized tree (primary artifact)
- `<agent>_<ver>_architecture.md` — human-readable section-by-section rendering (8 sections + Mermaid invocation graph + flow / Apex / prompt catalog)

## Validation

- `python3 -m pytest scripts/tests/`: **570 passed, 44 subtests passed**
- `npm run validate:skills`: **61 of 61 skills checked, no errors**
- End-to-end smoke test against a live NGA agent (`Atlas__ConcurrentMultiAgentOrchestration`) in a real org: 58 nodes / depth 6, zero unresolved references, `STATUS=OK`, 18.95s wall.

## Test plan

- [ ] Reviewer runs `npm run validate:skills` locally — passes.
- [ ] Reviewer skims `SKILL.md` (`description` field has both TRIGGER and DO NOT TRIGGER prose, per the developing-agentforce convention).
- [ ] Reviewer skims `README.md` — directory layout, prerequisites, troubleshooting table.
- [ ] If the reviewer has an authenticated `sf` org with an Agentforce agent: install via `mkdir -p ~/.claude/skills/investigating-agentforce-architecture && cp -R skills/investigating-agentforce-architecture/. ~/.claude/skills/investigating-agentforce-architecture/`, then in Claude Code: `/investigating-agentforce-architecture --org <alias> --agent <api_name>`.

## Author

Raghul Jayagopal (RJ), Salesforce ANZ FDE.