### PR TITLE
@W-22707610 feat: add investigating-agentforce-d360 skill

### DIFF
--- a/skills/investigating-agentforce-d360/README.md
+++ b/skills/investigating-agentforce-d360/README.md
@@ -1,0 +1,128 @@
+# investigating-agentforce-d360
+
+Data Cloud 360° view of a single Agentforce session. Pulls 24 STDM + GenAI DMOs from Salesforce Data Cloud, assembles a hierarchical session tree (Interaction → Step → Generation → GatewayRequest), and renders a human-readable markdown summary.
+
+This skill is **DC-only** — it reads runtime audit data that Salesforce Data Cloud has materialized for a session. It does not call into runtime telemetry, performance services, or any Splunk / observability surface.
+
+Input: an Agent Session UUID (`019d…`) **or** a MessagingSession id (`0Mw…`, 15/18 chars), and an `sf` CLI org alias.
+
+Output: per-DMO JSON artifacts plus three derived files under `~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<version>/<session_id>/`:
+
+- `dc.<name>.json` — 24 raw DMO results (one per query in the waterfall)
+- `dc._session_manifest.json` — per-DMO row counts, classified `session_shape`, and empty-by-design reasons
+- `dc._session_tree.json` — hierarchical join (the primary artifact; the summary is rendered from this)
+- `dc._session_summary.md` — human-readable summary, up to 11 sections
+
+---
+
+## Runtime budget
+
+**~10–30s typical** on a 15-turn session. The 5-wave fetch waterfall fans out 24 queries; later waves depend on ids harvested from earlier waves, so wave-to-wave is sequential, but each wave's queries run concurrently within the wave.
+
+---
+
+## Prerequisites
+
+| Tool | Why |
+|---|---|
+| `sf` CLI (authenticated against the target org) | Shells `sf org display --target-org <alias> --json` for the Data Cloud Query REST API access token |
+| Data Cloud enabled on the target org | Required — the STDM + GenAI DMOs must have materialized for the session |
+| Python 3.10+ | `pathlib`, dataclasses, `\|` union types |
+
+---
+
+## First invocation — auto-grants permissions
+
+On first use, `tools/grant_allowlist.py` merges scoped permission rules into `~/.claude/settings.json`'s `permissions.allow` array (append-only, idempotent) and seeds `~/.claude/data/investigating-agentforce-d360/.gitignore`. Each rule is per-script scoped — no `python3:*` blanket. Re-running the script is safe; the sentinel file at `~/.claude/.investigating-agentforce-d360.allowlist-done.v1` short-circuits subsequent runs.
+
+The script reads/writes only `~/.claude/`; it touches no org data.
+
+---
+
+## Usage
+
+Invoked conversationally via Claude Code. Example prompts:
+
+| User says | Skill does |
+|---|---|
+| `trace session 019dface-... in my-org` | Run the 3-stage pipeline: fetch → assemble → render |
+| `summarize what happened in 0MwTESTMSG12345AAA` | Resolve the messaging id → UUID, then run the pipeline |
+| `find escalated sessions today on Messaging in my-org` | Run `discover_sessions.py`, print a numbered picker, user picks one, then run the pipeline |
+| `walk me through this session` | Same as trace — the rendered summary reads top-to-bottom |
+
+See `SKILL.md` for the full TRIGGER conditions, flag table, and the "DC-only blind spot" guidance.
+
+---
+
+## Pipeline
+
+Three stages, each independently runnable:
+
+```
+fetch_dc.py     →  24 dc.<name>.json + dc._session_manifest.json   (DC Query REST waterfall)
+assemble_dc.py  →  dc._session_tree.json                           (in-memory hierarchical join)
+render_dc.py    →  dc._session_summary.md                          (markdown rendering)
+```
+
+`fetch_dc.py --session <sid> --org <alias>` chains all three by default. Pass `--no-assemble` / `--no-render` to stop early.
+
+---
+
+## Artifacts read order
+
+1. **`dc._session_summary.md`** — human-readable, top-to-bottom answers "what happened in this session?"
+2. **`dc._session_tree.json`** — single source of truth, the hierarchical join the summary was rendered from
+3. **`dc._session_manifest.json`** — open this when something looks missing in the tree (per-DMO row counts, empty-by-design reasons)
+4. **`dc.<name>.json`** — raw per-DMO rows, only when the manifest reports an unexpected count
+
+See `references/artifacts.md` for the full inventory.
+
+---
+
+## What this skill does NOT answer
+
+DC alone tells you **what happened** — every step, every LLM call, every gateway request, in order, with timestamps. It does **not** tell you **what could have happened but didn't**:
+
+- Which **topics were eligible** for the classifier on a given turn
+- Which **actions survived rule expressions** and were actually offered to the LLM
+- Why the LLM picked one topic/action over another
+
+If the user's question is about *why a particular topic or action was or wasn't used*, DC-only is almost never sufficient. See "DC-only blind spot" in `SKILL.md`.
+
+For design-time architecture questions (topic/action tree, flow inventory, Apex classes, prompt templates), use the sibling skill `investigating-agentforce-architecture` instead.
+
+---
+
+## Layout
+
+```
+investigating-agentforce-d360/
+├── SKILL.md                               ← Claude-parsed entry point (TRIGGER / DO NOT TRIGGER, flags, prompts)
+├── README.md                              ← this file
+├── scripts/
+│   ├── fetch_dc.py                        ← 5-wave DC fetch + chained pipeline driver
+│   ├── assemble_dc.py                     ← in-memory hierarchical join → dc._session_tree.json
+│   ├── render_dc.py                       ← markdown rendering → dc._session_summary.md
+│   ├── discover_sessions.py               ← session picker by time / agent / channel / outcome / grep
+│   ├── resolve_session.py                 ← `0Mw…` MessagingSession id → Agent Session UUID
+│   ├── dc.py                              ← DC Query REST API client (load_sql, post)
+│   ├── storage.py                         ← per-session JSON writer (path-validated)
+│   ├── config.py                          ← shared constants + DATA_ROOT re-export
+│   ├── _shared/                           ← path / SQL helpers (paths, fs_guard, sql)
+│   └── tests/                             ← pytest suite (367 tests + 18 subtests)
+├── tools/
+│   ├── grant_allowlist.py                 ← first-run permission grant
+│   └── archive_data_dir.sh                ← opt-in stop-hook tarballer
+├── references/
+│   ├── artifacts.md                       ← the full per-session artifact inventory
+│   ├── dc_dmo_fields.md                   ← per-DMO field reference + cross-DMO join map
+│   └── dc_pipeline_contract.md            ← pipeline contract: tree shape + render-stage section list
+└── assets/
+    └── dc/                                ← 26 .sql templates loaded by dc.load_sql
+```
+
+---
+
+## License
+
+Apache-2.0. See repository root `LICENSE`.

--- a/skills/investigating-agentforce-d360/README.md
+++ b/skills/investigating-agentforce-d360/README.md
@@ -123,6 +123,12 @@ investigating-agentforce-d360/
 
 ---
 
+## Authored by
+
+Raghul Jayagopal (RJ), Salesforce ANZ FDE.
+
+---
+
 ## License
 
 Apache-2.0. See repository root `LICENSE`.

--- a/skills/investigating-agentforce-d360/SKILL.md
+++ b/skills/investigating-agentforce-d360/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: investigating-agentforce-d360
+description: "Data Cloud 360° view of a single Agentforce session. Pulls 24 STDM + GenAI DMO rows via the DC Query REST API, assembles a hierarchical session tree (Interaction → Step → Generation → GatewayRequest), renders a human-readable summary with transcript + per-turn topic/action invocations + LLM generations + tool calls + audit chain. TRIGGER when user asks to trace, inspect, summarize, or describe a specific Agentforce session by session id (Agent Session UUID `019d…` or MessagingSession id `0Mw…`). Also triggers on session discovery — find/list/search sessions by time, agent, channel, outcome, or conversation text — when the user has no session id yet. DO NOT TRIGGER for design-time architecture questions (use investigating-agentforce-architecture instead) or for runtime perf/latency/SLO questions that require platform telemetry beyond Data Cloud."
+license: Apache-2.0
+compatibility: "Requires Agentforce license, Data Cloud enabled on the target org, sf CLI authenticated to target org, Python 3.10+"
+metadata:
+  version: "1.0"
+  last_updated: "2026-05-28"
+  author: "Raghul Jayagopal (RJ), Salesforce ANZ FDE"
+---
+
+# investigating-agentforce-d360 — Data Cloud 360° session view
+
+Hierarchical session reconstruction from Data Cloud STDM + GenAI DMOs for one Agentforce session. Three stages — fetch → assemble → render. Typical wall-clock: ~10–30s for a ~15-turn session.
+
+The pipeline is **DC-only**: it reads runtime audit rows that Data Cloud has materialized. It is **not** a runtime-availability tool — see "DC-only blind spot" below for what this skill cannot answer.
+
+## When to use
+
+Trigger this skill when the user:
+- Asks to **trace / inspect / describe / summarize** a specific Agentforce session by id.
+- **Doesn't have a session id?** Asks to **find / list / search / discover** sessions by time / agent / channel / outcome / conversation text. The skill runs a Data Cloud discovery query, prints a numbered picker, and the user picks one UUID to trace.
+- Says things like: "trace session `<uuid>`", "summarize what happened in `0Mw…`", "find escalated sessions today on Messaging in `<org>`", "Data Cloud snapshot for session `<uuid>`".
+
+**DO NOT trigger** when the question is about:
+- The agent's **declared architecture** — topic/action tree, flow inventory, Apex classes, prompt templates. Use `investigating-agentforce-architecture` instead.
+- Runtime **availability** questions — *which* topic/action was *eligible* for the planner on a given turn, or *why* the LLM picked one over another. DC alone can't answer these (see "DC-only blind spot").
+
+## If the user hasn't given enough to proceed
+
+When invoked with no session id AND no discovery criteria, print this block **verbatim** — do not paraphrase, do not pre-run any script. Trigger condition: the input is empty OR contains no session-id shape (neither a UUID nor a `0Mw…` messaging id) AND no discovery expression (no time phrase / `--agent` / `--channel` / `--outcome` / `--grep` / verbs like "find" / "list").
+
+> Which session should I pull from Data Cloud, and in which org?
+>
+> I need:
+> - **Session id** — either an Agent Session UUID (`019db7f6-…`) or a MessagingSession id (`0Mw…`, 15/18 chars).
+>   - **No session id?** — Tell me what you remember and I'll find it: how recent (e.g. "last 2 hours", "today", a date), which agent, which channel (Messaging / Builder / Voice), how it ended (escalated, user ended, transferred, timed out), or a phrase from the conversation. I'll show matching sessions as a numbered list — you pick one, I pull it.
+> - **Org alias** — for `sf` CLI auth (the alias you configured with `sf org login`).
+>
+> Artifacts land in `~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<ver>/<session_id>/`.
+
+## Session id forms — UUID or MessagingSession id
+
+Both forms are accepted on `--session`:
+
+| Form | Example | Resolution |
+|---|---|---|
+| Agent Session UUID | `019dface-0000-7000-8000-000000000002` | Pass-through |
+| MessagingSession id (`0Mw` prefix) | `0MwTESTMSG12345AAA` | Resolved via `resolve_session.py` — live DC lookup on first fetch, disk-first thereafter |
+
+**Multi-match is real.** One MessagingSession id can map to multiple Agent Session UUIDs. On multi-match the resolver prints every candidate and exits non-zero; the user re-invokes with a specific UUID.
+
+Artifacts always land under `~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<ver>/<session_id>/` — the messaging id is a lookup key only, never a directory name. The dominant agent (first in `sorted(agents_observed)`) names the `<agent>__<ver>/` segment.
+
+## Resolving the script prefix
+
+The default install puts the skill under `~/.claude/skills/`. If the skill
+was cloned somewhere else (e.g. directly from the `forcedotcom/sf-skills`
+repo into a custom path), set `SKILL_ROOT` to point at the skill directory.
+
+```bash
+prefix="${SKILL_ROOT:-$HOME/.claude/skills/investigating-agentforce-d360}/scripts"
+```
+
+Every subsequent invocation in this doc uses `"$prefix/..."`.
+
+## First-run permissions
+
+On first invocation only, run the allowlist grant. This registers the skill's
+`python3 scripts/*.py` and `sf org display ...` invocation patterns into
+Claude Code's `permissions.allow` list in `~/.claude/settings.json`, so the
+subsequent fetch / assemble / render stages don't prompt for permission on
+every shell call. The script is idempotent — subsequent runs see the
+sentinel file (`~/.claude/.investigating-agentforce-d360.allowlist-done.v1`)
+and exit immediately. Reads/writes only `~/.claude/`; touches no org data.
+
+```bash
+python3 "${SKILL_ROOT:-$HOME/.claude/skills/investigating-agentforce-d360}/tools/grant_allowlist.py"
+```
+
+## Session discovery (no id yet)
+
+When the user doesn't have a session id, run `discover_sessions.py` against the STDM session DMO. Prints a numbered picker; user picks one; proceed with the chosen UUID.
+
+```bash
+python3 "$prefix/discover_sessions.py" --org <alias> [filters...]
+```
+
+**Filters** (all optional except `--org`): `--since <expr>` (default last 24h; accepts "last 2 hours", "today", ISO dates), `--agent <api-name>`, `--channel <Messaging|Builder|Voice>`, `--outcome <USER_ENDED|ESCALATED|TRANSFERRED|TIMEOUT|NOT_SET>`, `--grep <substring>` (conversation text), `--tz <IANA>`, `--limit <N>` (default 20).
+
+**Output**: markdown table with `#`, `UUID`, `Start (UTC)`, `Agent`, `Channel`, `Duration`, `Outcome`. User replies with a number; proceed with that UUID.
+
+## Pipeline — three stages
+
+```
+fetch_dc.py     →  24 dc.<name>.json + dc._session_manifest.json     (DC Query REST waterfall, 5 waves)
+assemble_dc.py  →  dc._session_tree.json                             (pure in-memory hierarchical join)
+render_dc.py    →  dc._session_summary.md                            (human summary, multi-section)
+```
+
+Each stage is independently runnable. `fetch_dc.py --session <sid> --org <alias>` chains all three by default.
+
+### Invocation
+
+```bash
+python3 "$prefix/fetch_dc.py" --session <session-id-or-messaging-id> --org <alias>
+```
+
+Flags: `--verbose` for per-DMO row counts; `--no-assemble` / `--no-render` to stop early.
+
+### Output artifacts
+
+Everything lands under `~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<ver>/<session_id>/`:
+
+```
+dc.sessions.json              dc.steps.json                dc.gateway_requests.json
+dc.interactions.json          dc.messages.json             dc.gateway_responses.json
+dc.participants.json          dc.generations.json          dc.gateway_request_llm.json
+dc.content_quality.json       dc.content_category.json     dc.gateway_request_metadata.json
+dc.tags.json                  dc.tag_definitions.json      dc.gateway_request_tags.json
+dc.tag_associations.json      dc.tag_definition_associations.json
+dc.feedback.json              dc.feedback_details.json     dc.gateway_records.json
+dc.moments.json               dc.moment_interactions.json
+dc.telemetry_spans.json       dc.app_generation.json
+
+dc._session_manifest.json     (per-DMO row counts + empties)
+dc._session_tree.json         (hierarchical join — session → interactions → steps → messages → generations → gateway)
+dc._session_summary.md        (rendered human summary)
+```
+
+Zero-row queries are recorded in the manifest with `status: empty`; no file is written. `assemble_dc` tolerates missing files. See `references/artifacts.md` for the full read order.
+
+## The DC-only blind spot — read before committing to a root cause
+
+DC alone answers **what happened** — steps that ran, generations that fired, gateway requests that were logged. It does NOT answer **what could have happened but didn't**:
+
+- Which **topics were eligible** for the classifier on a given turn (this lives in runtime planner telemetry, not DC).
+- Which **actions were declared** on a topic vs. which **survived rule expressions** and were actually offered to the LLM.
+- Why the LLM picked one topic/action over another (the full prompt + response text only lives in the planner runtime telemetry).
+
+If the user's question is about *why a particular topic or action was or wasn't used*, DC-only is almost never sufficient. **Tell the user**: "Availability questions need the runtime planner trace for that turn — which is outside this skill's Data Cloud surface. Check the platform telemetry that mirrors the planner's logged decisions." Don't fabricate a root cause from runtime-only evidence.
+
+### What DC IS good at
+
+- **What ran** — every step, every LLM call, every gateway request + response, in order, with timestamps and durations. Good for "walk me through the session".
+- **What the user saw** — full message transcript (user + agent), ordered.
+- **What the LLM produced** — generations, token counts, trust scores (toxicity, instruction adherence, content-category breakdown from `content_quality` + `content_category`).
+- **Tool invocations** — action calls, inputs, outputs, errors (from `gateway_request_metadata` + `gateway_records`).
+- **Feedback + flags** — user feedback, escalation markers, session-end type.
+- **Audit integrity** — the 1:1 invariant between GatewayRequest and GatewayResponse is checked; drift is flagged in `counts.audit_chain_1to1_ok`.
+
+## Prerequisites
+
+| Tool | Required |
+|---|---|
+| `sf` CLI (authenticated against the target org) | yes — `sf org login web --alias <alias>` |
+| Data Cloud enabled on the target org | yes — the STDM + GenAI DMOs must have materialized for the session |
+| Python 3.10+ | yes — pipeline scripts |
+
+## Typical prompts — what they map to
+
+| User says | Skill does |
+|---|---|
+| *"Trace session `<uuid>` in my-org"* | `fetch_dc.py --session <uuid> --org my-org` → assemble → render |
+| *"Summarize what happened in `0Mw…`"* | Resolve `0Mw…` → UUID, then full DC pipeline |
+| *"Find escalated sessions today in my-org on Messaging"* | Run `discover_sessions.py --since today --outcome ESCALATED --channel Messaging`, print picker, user picks, then DC pipeline |
+| *"Walk me through this session"* | Same as trace — read the rendered summary top to bottom |
+
+## What comes back to the user
+
+After the pipeline completes, the rendered `dc._session_summary.md` carries these top-level sections:
+
+1. **Session identity** — UUID, start/end, duration, agent, channel, end type, participant counts
+2. **Session bootstrap** — channel mode + bootstrap variables (`identity.mode`, `identity.bootstrap_variables`)
+3. **ID reference** — full UUIDs for everything truncated in the hierarchical trace
+4. **Transcript** — USER ↔ AGENT narrative per TURN interaction
+5. **Complete hierarchical trace** — Interaction → Step → Generation → GatewayRequest, with `+start + duration = +end` math
+6. **Per-turn summary** — one row per interaction
+7. **Planner LLM calls (full prompts + responses)** — opt-in via `--show-prompts`; suppressed by default
+8. **Visual analysis** — gantt + LLM-call overlay
+9. **Session counts** — engineer-facing table of manifest counts
+10. **Empties diagnostics** — one row per DMO with `rows == 0` and a populated `_unavailable_reason`
+11. **Catalog (session-filtered)** — TagDefinitions / TagDefinitionAssociations / Tags filtered to agents observed in the session
+
+For deep-dive, open `dc._session_tree.json` — the single source of truth the summary was rendered from. See `references/dc_pipeline_contract.md` for the full pipeline contract and `references/dc_dmo_fields.md` for per-DMO field reference.
+
+## Caveats
+
+- **`gateway_requests_dropped_by_stdm`** — when DC reports zero `gateway_requests` rows but runtime telemetry would show LLM calls did fire, this skill cannot definitively distinguish "STDM exporter dropped writes" from "logging genuinely disabled at the source". The session is reported as `planner_ran_no_gateway_logs`; the operator can check platform telemetry to disambiguate. See `references/dc_pipeline_contract.md` §2.8.
+- **Latency** — Generation and GatewayRequest carry single-write timestamps, not start/end pairs. The renderer does not compute "latencies" between them — that delta reflects DC's serialization order, not how long the LLM call took.
+- **Data Cloud materialization lag** — fresh sessions may show `interactions_not_materialized_yet` if STDM hasn't caught up. Re-run after a minute or two.

--- a/skills/investigating-agentforce-d360/assets/dc/app_generation.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/app_generation.sql
@@ -1,0 +1,51 @@
+-- App-layer generation records — reusable for any WHERE filter.
+-- DMO: GenAIAppGeneration__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Sibling of GenAIGeneration__dlm: where GenAIGeneration is the raw
+-- gateway response, GenAIAppGeneration appears to be the app/feature-
+-- layer view of the same generation (separate `id__c` from `generationId__c`).
+--
+-- No `ssot__` prefix — fields end in `__c` directly.
+--
+-- Join to a session: the same Step → Generation bridge used for
+-- GenAIGeneration also works here. Pull session steps, collect
+-- non-empty `ssot__GenerationId__c` values, then query here with
+-- `generationId__c IN (...)`. The App-Generation row points at the
+-- same underlying gateway generation.
+--
+-- The DMO is provisioned by default on orgs with generative AI audit
+-- enabled, but row population depends on whether the org uses app-layer
+-- regeneration / update flows. Verify presence with `sf ssot/metadata`
+-- before relying on it.
+
+SELECT
+    id__c,
+    generationId__c,
+    generationUpdate__c,
+    generationUpdateId__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIAppGeneration__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- App-generations for a set of step generation ids
+-- WHERE    → generationId__c IN ('<gen_id1>','<gen_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- App-generations in a time window for one org
+-- WHERE    → orgId__c = '<org_id_18>'
+--            AND timestamp__c >= '<iso_window_start>'
+--            AND timestamp__c <  '<iso_window_end>'
+-- ORDER BY → ORDER BY timestamp__c

--- a/skills/investigating-agentforce-d360/assets/dc/content_category.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/content_category.sql
@@ -1,0 +1,44 @@
+-- GenAI content category (per-detector rows) — reusable WHERE.
+-- DMO: GenAIContentCategory__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Two shapes of parent FK:
+--   - Direct on a generation: non-TOXICITY detectors (InstructionAdherence,
+--     TaskResolution, PII, PROMPT_DEFENSE) — parent__c = generationId__c
+--   - Via a quality row: TOXICITY sub-categories —
+--     parent__c = GenAIContentQuality.id__c
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    id__c,
+    parent__c,
+    detectorType__c,
+    category__c,
+    value__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIContentCategory__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Non-TOXICITY detectors for a set of generations (direct join)
+-- WHERE    → parent__c IN ('<gen_id1>','<gen_id2>')
+--            AND detectorType__c != 'TOXICITY'
+
+-- TOXICITY sub-categories for a set of quality rows
+-- WHERE    → parent__c IN ('<quality_id1>','<quality_id2>')
+--            AND detectorType__c = 'TOXICITY'
+
+-- InstructionAdherence scores only
+-- WHERE    → parent__c IN ('<gen_id1>','<gen_id2>')
+--            AND detectorType__c = 'InstructionAdherence'

--- a/skills/investigating-agentforce-d360/assets/dc/content_quality.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/content_quality.sql
@@ -1,0 +1,41 @@
+-- GenAI content quality (per-generation quality rows) — reusable WHERE.
+-- DMO: GenAIContentQuality__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Joined to a generation via `parent__c = generationId__c`. One row per
+-- INPUT/OUTPUT side. `isToxicityDetected__c` is populated only on OUTPUT rows.
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    id__c,
+    parent__c,
+    isToxicityDetected__c,
+    contentType__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIContentQuality__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Quality rows for a set of generations
+-- WHERE    → parent__c IN ('<gen_id1>','<gen_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Only rows where toxicity was detected (OUTPUT rows)
+-- WHERE    → parent__c IN ('<gen_id1>','<gen_id2>')
+--            AND isToxicityDetected__c = 'true'
+
+-- Only OUTPUT-side rows
+-- WHERE    → parent__c IN ('<gen_id1>','<gen_id2>')
+--            AND contentType__c = 'OUTPUT'

--- a/skills/investigating-agentforce-d360/assets/dc/discover_sessions.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/discover_sessions.sql
@@ -1,0 +1,36 @@
+-- Session discovery — find candidate sessions by time/agent/channel/outcome/grep.
+-- Produces a short row-per-session shape for the picker rendered by
+-- scripts/discover_sessions.py. NOT used by the trace pipeline — once the user
+-- picks a UUID, the full pipeline runs fetch_dc.py against the 24-DMO waterfall.
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   SELECT_LIST  — either `s.ssot__Id__c, s.ssot__StartTimestamp__c, s.ssot__EndTimestamp__c,
+--                          s.ssot__AiAgentChannelType__c, s.ssot__AiAgentSessionEndType__c`
+--                 OR `DISTINCT <same columns>` when JOINs are present (DC SQL requires
+--                 ORDER BY columns to appear in a DISTINCT projection).
+--   JOINS        — zero or more JOIN clauses, newline-separated, or empty string:
+--                   * `JOIN ssot__AiAgentSessionParticipant__dlm p ON s.ssot__Id__c = p.ssot__AiAgentSessionId__c`
+--                     (required when filtering by --agent)
+--                   * `JOIN ssot__AiAgentInteraction__dlm i ON s.ssot__Id__c = i.ssot__AiAgentSessionId__c
+--                      JOIN ssot__AiAgentInteractionMessage__dlm m ON i.ssot__Id__c = m.ssot__AiAgentInteractionId__c`
+--                     (required when filtering by --grep)
+--   WHERE_CLAUSE — composed by the caller. No "WHERE" keyword. Always non-empty
+--                 (at minimum the time-range predicate). All user-supplied string
+--                 literals are single-quote-escaped by doubling quotes (O'Brien → O''Brien).
+--   LIMIT        — integer, 1..N. Default in caller is 20.
+--
+-- Field reference:
+--   time range → s.ssot__StartTimestamp__c >= '<startISO>' AND s.ssot__StartTimestamp__c < '<endISO>'
+--   outcome    → s.ssot__AiAgentSessionEndType__c = '<USER_ENDED|ESCALATED|TRANSFERRED|TIMEOUT|NOT_SET>'
+--   channel    → s.ssot__AiAgentChannelType__c = '<Builder|SCRT2 - EmbeddedMessaging|Voice|...>'
+--   agent      → p.ssot__AiAgentApiName__c = '<AgentApiName>'  (requires participant JOIN)
+--   grep       → m.ssot__ContentText__c LIKE '%<escaped-pattern>%'  (requires interaction+message JOIN)
+--
+-- All STDM timestamps are UTC.
+
+SELECT {{SELECT_LIST}}
+FROM ssot__AIAgentSession__dlm s
+{{JOINS}}
+WHERE {{WHERE_CLAUSE}}
+ORDER BY s.ssot__StartTimestamp__c DESC
+LIMIT {{LIMIT}};

--- a/skills/investigating-agentforce-d360/assets/dc/feedback.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/feedback.sql
@@ -1,0 +1,47 @@
+-- User feedback on generations — one row per feedback event.
+-- DMO: GenAIFeedback__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Captures thumbs-up/thumbs-down (and richer `action__c`) that a user gave
+-- a specific generation. Joined via `generationId__c = Generation.generationId__c`.
+-- `feedbackId__c` is the PK that GenAIFeedbackDetail rows point at.
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    feedbackId__c,
+    generationId__c,
+    generationUpdateId__c,
+    generationGroupId__c,
+    userId__c,
+    feedback__c,
+    action__c,
+    source__c,
+    feature__c,
+    appType__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIFeedback__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Feedback for a set of generations (typical session trace path)
+-- WHERE    → generationId__c IN ('<gen_id1>','<gen_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Feedback by a specific user in a time window
+-- WHERE    → userId__c = '<user_id>'
+--            AND timestamp__c >= '<iso_cutoff>'
+
+-- Only thumbs-down
+-- WHERE    → generationId__c IN ('<gen_id1>','<gen_id2>')
+--            AND feedback__c = 'DOWN'

--- a/skills/investigating-agentforce-d360/assets/dc/feedback_details.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/feedback_details.sql
@@ -1,0 +1,38 @@
+-- Free-text / structured detail attached to a feedback event.
+-- DMO: GenAIFeedbackDetail__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Zero or more rows per feedback. `feedbackText__c` is what the user typed;
+-- `appFeedback__c` is an app-layer tag (e.g. the reason bucket).
+-- Joined via `parent__c = GenAIFeedback.feedbackId__c`.
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    feedbackDetailId__c,
+    parent__c,
+    feedbackText__c,
+    appFeedback__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIFeedbackDetail__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Details for a set of feedback rows
+-- WHERE    → parent__c IN ('<feedback_id1>','<feedback_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Free-text feedback only (DC Query returns "" for unset text, not NULL)
+-- WHERE    → parent__c IN ('<feedback_id1>','<feedback_id2>')
+--            AND feedbackText__c IS NOT NULL AND feedbackText__c != ''

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_records.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_records.sql
@@ -1,0 +1,45 @@
+-- Gateway object records — structured attachments on requests/feedback.
+-- DMO: GenAIGtwyObjRecord__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Polymorphic attachment table. `parent__c` points at different parents
+-- depending on `type__c`:
+--   - `parent__c = GenAIGatewayRequest.gatewayRequestId__c` (grounded-record
+--     attachments) — the forward-only path used by this skill's waterfall.
+--   - `parent__c = GenAIFeedback.feedbackId__c` (feedback attachments) —
+--     present only when the session has feedback rows.
+-- The waterfall queries the gateway-request case (wave 3); feedback attachments
+-- appear through the session only when feedback is present.
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    id__c,
+    parent__c,
+    recordId__c,
+    type__c,
+    name__c,
+    value__c,
+    metadata__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGtwyObjRecord__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Records attached to a set of feedback rows
+-- WHERE    → parent__c IN ('<feedback_id1>','<feedback_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Records attached to a set of gateway request ids
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>')

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_request_llm.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_request_llm.sql
@@ -1,0 +1,50 @@
+-- Per-request LLM call diagnostics — reusable for any WHERE filter.
+-- DMO: GenAIGtwyRequestLLM__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Child of GenAIGatewayRequest__dlm. Captures LLM invocation
+-- diagnostics (latency, status, endpoint, region, model). Populated
+-- only when Trust Layer gateway LLM telemetry is on.
+--
+-- The DMO is provisioned by default but rows only appear when the
+-- gateway LLM telemetry is emitted. Join column pattern mirrors
+-- GenAIGtwyRequestMetadata__dlm (same parent__c shape).
+--
+-- No `ssot__` prefix — fields end in `__c` directly. Note that org id
+-- is `salesforceOrgId__c` on this DMO, not the usual `orgId__c`.
+--
+-- Joined via `parent__c = GatewayRequest.gatewayRequestId__c`.
+
+SELECT
+    id__c,
+    parent__c,
+    endpoint__c,
+    region__c,
+    genAILLM__c,
+    llmCallStatus__c,
+    llmCallLatency__c,
+    llmErrorTrace__c,
+    metadata__c,
+    feature__c,
+    salesforceOrgId__c,
+    timestamp__c,
+    cloud__c
+FROM GenAIGtwyRequestLLM__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All LLM diagnostic rows for a set of gateway request ids
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Only failed LLM calls
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>')
+--            AND llmCallStatus__c != 'success'

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_request_metadata.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_request_metadata.sql
@@ -1,0 +1,44 @@
+-- Additional per-request metadata — reusable for any WHERE filter.
+-- DMO: GenAIGtwyRequestMetadata__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Child of GenAIGatewayRequest__dlm. Holds typed metadata rows for a
+-- request — observed values include `metadataType__c = 'ToolCall'` and
+-- `feature__c = 'plannerservice'`, so this is where planner/tool-call
+-- metadata on a gateway request lives.
+--
+-- No `ssot__` prefix — fields end in `__c` directly.
+--
+-- Joined via `parent__c = GatewayRequest.gatewayRequestId__c`.
+-- Join direction verified live: sampled row's parent__c matched exactly
+-- one row in GenAIGatewayRequest__dlm. The table is usually heavily
+-- populated on orgs with Trust Layer gateway logging enabled.
+
+SELECT
+    id__c,
+    parent__c,
+    metadataType__c,
+    metadata__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGtwyRequestMetadata__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All metadata rows for a set of gateway request ids
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Only ToolCall-type metadata
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>')
+--            AND metadataType__c = 'ToolCall'

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_request_tags.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_request_tags.sql
@@ -1,0 +1,42 @@
+-- Gateway request tags — k/v metadata attached to a gateway request.
+-- DMO: GenAIGatewayRequestTag__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Many rows per request. Common tags include:
+--   - `prompt_template_dev_name` → which prompt template was used
+--   - `user_utterance`           → raw user input that triggered this request
+--
+-- Joined via `parent__c = GatewayRequest.gatewayRequestId__c`.
+-- No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    id__c,
+    parent__c,
+    tag__c,
+    tagValue__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGatewayRequestTag__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All tags for a set of request ids
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Only `prompt_template_dev_name` tags
+-- WHERE    → parent__c IN ('<req_id1>','<req_id2>')
+--            AND tag__c = 'prompt_template_dev_name'
+
+-- Find requests where the user utterance matched a pattern
+-- WHERE    → tag__c = 'user_utterance'
+--            AND tagValue__c LIKE '%refund%'

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_requests.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_requests.sql
@@ -1,0 +1,89 @@
+-- Gateway requests — one row per LLM request at the GenAI Gateway.
+-- DMO: GenAIGatewayRequest__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Richer than GenAIGeneration — carries the actual prompt text, token counts,
+-- model params (temperature/penalties), session/user IDs, bot version, and
+-- the masked-prompt variant.
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+--
+-- sessionId__c storage format (verified live): the value is stored as a
+-- literal 40-char string INCLUDING surrounding double-quotes, e.g.
+--   sessionId__c = "<session_uuid>"
+-- Non-session features (prompt-builder previews, eval harnesses, etc.) store
+-- the literal sentinel "no_session". Exact-match queries MUST include the
+-- double-quotes:
+--   WHERE sessionId__c = '"<session_uuid>"'
+-- Or use LIKE with wildcards (robust against format variants):
+--   WHERE sessionId__c LIKE '%<session_uuid>%'
+-- Raw-UUID exact match returns 0 rows — the quotes are part of the stored value.
+--
+-- Forward join path from a session:
+--   Session.ssot__Id__c  →  GatewayRequest.sessionId__c (LIKE or quoted match)
+-- This is the authoritative and only supported entry point. GatewayRequest is
+-- then the parent for all downstream audit-chain children — Response (via
+-- generationRequestId__c), Tag/ObjRecord/Metadata/LLM (via parent__c).
+-- See `scripts/fetch_dc.py` wave 3 and `references/dc_dmo_fields.md` "Cross-DMO
+-- join map" for the full forward tree.
+
+SELECT
+    gatewayRequestId__c,
+    generationGroupId__c,
+    sessionId__c,
+    userId__c,
+    botVersionId__c,
+    plannerId__c,
+    feature__c,
+    appType__c,
+    model__c,
+    provider__c,
+    promptTemplateDevName__c,
+    promptTemplateVersionNo__c,
+    prompt__c,
+    maskedPrompt__c,
+    parameters__c,
+    temperature__c,
+    frequencyPenalty__c,
+    presencePenalty__c,
+    stopSequences__c,
+    numGenerations__c,
+    promptTokens__c,
+    completionTokens__c,
+    totalTokens__c,
+    enableInputSafetyScoring__c,
+    enableOutputSafetyScoring__c,
+    enablePiiMasking__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGatewayRequest__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Requests for one session (direct FK; note the mandatory double-quoted form).
+-- Two equivalent WHERE forms — both verified live, both return the same rows:
+-- WHERE    → sessionId__c = '"<session_id>"'            (exact match on quoted string)
+-- WHERE    → sessionId__c LIKE '%<session_id>%'          (format-tolerant)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Requests for a specific set of gatewayRequestIds (e.g. narrowing after a
+-- session fetch, or lookup by ids harvested from another query)
+-- WHERE    → gatewayRequestId__c IN ('<req_id1>','<req_id2>',...)
+
+-- All requests for a bot version in a time window
+-- WHERE    → botVersionId__c = '<version_id>'
+--            AND timestamp__c >= '<iso_cutoff>'
+-- ORDER BY → ORDER BY timestamp__c DESC
+
+-- Requests using a specific prompt template
+-- WHERE    → promptTemplateDevName__c = '<template_dev_name>'
+--            AND timestamp__c >= '<iso_cutoff>'

--- a/skills/investigating-agentforce-d360/assets/dc/gateway_responses.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/gateway_responses.sql
@@ -1,0 +1,43 @@
+-- Gateway responses — one row per LLM call response at the GenAI Gateway.
+-- DMO: GenAIGatewayResponse__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- FK shape (small table; documented for reference only):
+--   generationRequestId__c   = GatewayRequest.gatewayRequestId__c
+--   generationResponseId__c  = Step.ssot__GenAiGatewayResponseId__c
+--                            = Generation.generationResponseId__c
+--
+-- Forward join path from a session:
+--   Session → GatewayRequest (sessionId__c LIKE)
+--           → GatewayResponse (generationRequestId__c IN {gw_req_ids})
+-- This is the canonical and only supported direction. 1:1 invariant holds
+-- in live data — every GatewayRequest for a session produces one Response
+-- row (modulo in-flight calls at fetch time).
+--
+-- NOTE: No `ssot__` prefix — fields end in `__c` directly.
+
+SELECT
+    generationResponseId__c,
+    generationRequestId__c,
+    parameters__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGatewayResponse__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Forward: Responses for the session's gateway requests (primary use case)
+-- WHERE    → generationRequestId__c IN ('<req_id1>','<req_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Ad-hoc lookup by specific response ids (not used by the waterfall)
+-- WHERE    → generationResponseId__c IN ('<resp_id1>','<resp_id2>',...)

--- a/skills/investigating-agentforce-d360/assets/dc/generations.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/generations.sql
@@ -1,0 +1,52 @@
+-- GenAI gateway generations — reusable for any WHERE filter.
+-- DMO: GenAIGeneration__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- One row per LLM call at the gateway (Trust Layer).
+--
+-- NOTE: No `ssot__` prefix on this DMO — fields end in `__c` directly.
+--
+-- Forward join to a session: this DMO has NO session/trace/turn column.
+-- The only supported path is Step.ssot__GenerationId__c → generationId__c,
+-- driven forward from the session:
+--   Session → Interaction (ssot__AiAgentSessionId__c)
+--           → Step        (ssot__AiAgentInteractionId__c)
+--           → Generation  (step.ssot__GenerationId__c IN {generationId__c})
+-- Pull step rows for the session's interactions first, collect non-empty
+-- `ssot__GenerationId__c` values (LLM_STEP rows populate it; others are
+-- NOT_SET), then query here with `generationId__c IN (...)`.
+
+SELECT
+    generationId__c,
+    generationResponseId__c,
+    responseText__c,
+    maskedResponseText__c,
+    responseParameters__c,
+    feature__c,
+    timestamp__c,
+    orgId__c,
+    cloud__c
+FROM GenAIGeneration__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Generations for a set of step generation ids
+-- WHERE    → generationId__c IN ('<gen_id1>','<gen_id2>',...)
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Generations in a time window for one org
+-- WHERE    → orgId__c = '<org_id_18>'
+--            AND timestamp__c >= '<iso_window_start>'
+--            AND timestamp__c <  '<iso_window_end>'
+-- ORDER BY → ORDER BY timestamp__c
+
+-- Filter by feature (e.g. Copilot vs guardrails)
+-- WHERE    → feature__c = 'CopilotForDigitalChannels'

--- a/skills/investigating-agentforce-d360/assets/dc/interactions.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/interactions.sql
@@ -1,0 +1,53 @@
+-- Session interactions (turns + session-end event) — reusable for any WHERE.
+-- DMO: ssot__AIAgentInteraction__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- One row per turn plus one SESSION_END row per session.
+-- Type enum: TURN | SESSION_END.
+--
+-- Casing gotcha: DMO name uses `AIAgent` (uppercase AI). Field names use
+-- `AiAgent` (lowercase i). See references/dc_dmo_fields.md.
+--
+-- trace_id gotcha: `ssot__TelemetryTraceId__c` is often empty on real orgs
+-- (verified live). The runtime trace_id lives inside
+-- `ssot__AttributeText__c` as HTML-escaped JSON, key `internalTraceId`.
+-- Consumers must `html.unescape()` + regex-extract. Used to join with
+-- GenAIGeneration (generationId via Step) and TelemetryTraceSpan.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentSessionId__c,
+    ssot__AiAgentInteractionType__c,
+    ssot__TopicApiName__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__PrevInteractionId__c,
+    ssot__SessionOwnerId__c,
+    ssot__IndividualId__c,
+    ssot__InternalOrganizationId__c,
+    ssot__TelemetryTraceId__c,
+    ssot__TelemetryTraceSpanId__c,
+    ssot__AttributeText__c
+FROM ssot__AIAgentInteraction__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All interactions for one session
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- TURN rows only (exclude SESSION_END)
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+--            AND ssot__AiAgentInteractionType__c = 'TURN'
+
+-- Interactions handled by a specific topic across sessions
+-- WHERE    → ssot__TopicApiName__c = 'Order_Management'
+--            AND ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'

--- a/skills/investigating-agentforce-d360/assets/dc/messages.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/messages.sql
@@ -1,0 +1,53 @@
+-- User/agent messages — reusable for any WHERE filter.
+-- DMO: ssot__AiAgentInteractionMessage__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- One row per user/agent message. Type enum: Input | Output.
+--
+-- This DMO has a direct session FK (`ssot__AiAgentSessionId__c`) — verified
+-- live against Data Cloud v66.0. Scope by session directly; no need to join through
+-- interactions. It also has a participant FK and a parent-message FK for
+-- threading, plus `MessageStartTimestamp__c` / `MessageEndTimestamp__c` for
+-- voice-modality durations (richer than the single `MessageSentTimestamp__c`).
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentSessionId__c,
+    ssot__AiAgentInteractionId__c,
+    ssot__AiAgentSessionParticipantId__c,
+    ssot__ParentMessageId__c,
+    ssot__ContentText__c,
+    ssot__AiAgentInteractionMessageType__c,
+    ssot__AiAgentInteractionMsgContentType__c,
+    Modality__c,
+    ssot__MessageSentTimestamp__c,
+    MessageStartTimestamp__c,
+    MessageEndTimestamp__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentInteractionMessage__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Messages for one session (direct FK — preferred)
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+-- ORDER BY → ORDER BY ssot__MessageSentTimestamp__c
+
+-- Messages for a specific interaction
+-- WHERE    → ssot__AiAgentInteractionId__c = '<interaction_id>'
+-- ORDER BY → ORDER BY ssot__MessageSentTimestamp__c
+
+-- Only user inputs for a session
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+--            AND ssot__AiAgentInteractionMessageType__c = 'Input'
+
+-- Voice-modality messages (use start/end timestamps for duration)
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+--            AND Modality__c = 'Voice'

--- a/skills/investigating-agentforce-d360/assets/dc/messaging_session.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/messaging_session.sql
@@ -1,0 +1,37 @@
+-- MessagingSession id → AI-agent session id lookup.
+-- DMO: ssot__AIAgentSession__dlm
+--
+-- Given a Salesforce MessagingSession id (0Mw... prefix, 15 or 18 chars),
+-- find every ssot__AIAgentSession__dlm row with matching
+-- RelatedMessagingSessionId. Used by scripts/resolve_session.py to map a
+-- messaging id to the canonical AI-agent session UUID that every other
+-- script keys on.
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   MSG_ID  — the MessagingSession id (pre-validated by the caller:
+--             is_messaging_id() enforces the `0Mw` key prefix plus an
+--             exact 15 or 18 char length before this template is loaded.
+--             A raw-UUID or free-text id can never reach this template.)
+--
+-- Returned rows:
+--   * zero rows  → caller raises SystemExit ("no messaging session found")
+--   * one row    → caller returns ssot__Id__c as the UUID
+--   * many rows  → caller prints every candidate with timestamps + end_type
+--                  + channel and exits non-zero so the user can pick one
+--                  and re-invoke with the specific UUID.
+--
+-- The `RelatedMessagingSessionId__c != 'NOT_SET'` clause is defensive —
+-- a real msg_id cannot equal the literal 'NOT_SET', but the guard lets
+-- the template be copy-pasted for other filters that might otherwise
+-- accidentally match the sentinel.
+
+SELECT
+    ssot__Id__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__AiAgentSessionEndType__c,
+    ssot__AiAgentChannelType__c
+FROM ssot__AIAgentSession__dlm
+WHERE ssot__RelatedMessagingSessionId__c = '{{MSG_ID}}'
+  AND ssot__RelatedMessagingSessionId__c != 'NOT_SET'
+ORDER BY ssot__StartTimestamp__c DESC;

--- a/skills/investigating-agentforce-d360/assets/dc/moment_interactions.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/moment_interactions.sql
@@ -1,0 +1,34 @@
+-- Moment ↔ Interaction junction — which turns belong to a moment.
+-- DMO: ssot__AiAgentMomentInteraction__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Agent Optimization add-on DMO. Provisioned only when Agent Optimization
+-- is enabled. Junction between AiAgentMoment and AIAgentInteraction.
+-- Observed live: one Moment per Interaction (N:1 direction). The junction
+-- schema supports true many-to-many; the assembler emits Moment.interaction_ids[]
+-- back-refs to preserve the schema-correct shape even when live data is 1:N.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentMomentId__c,
+    ssot__AiAgentInteractionId__c,
+    ssot__StartTimestamp__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentMomentInteraction__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Junction rows for a set of moments
+-- WHERE    → ssot__AiAgentMomentId__c IN ('<mom_id1>','<mom_id2>',...)
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Junction rows for a set of interactions (reverse lookup)
+-- WHERE    → ssot__AiAgentInteractionId__c IN ('<int_id1>','<int_id2>')

--- a/skills/investigating-agentforce-d360/assets/dc/moments.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/moments.sql
@@ -1,0 +1,39 @@
+-- Session-level agent moment rollup — reusable for any WHERE filter.
+-- DMO: ssot__AiAgentMoment__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- When present, carries agent identity + a request/response summary for
+-- the session. This is the only STDM DMO outside Participant that exposes
+-- AiAgentApiName__c. Moments are absent on orgs without Agent Optimization
+-- enabled; the assembler falls back to Participant (AGENT role) for agent
+-- identity in that case.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentSessionId__c,
+    ssot__AiAgentApiName__c,
+    ssot__AiAgentVersionApiName__c,
+    ssot__RequestSummaryText__c,
+    ssot__ResponseSummaryText__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentMoment__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Moment(s) for one session — usually 0 or 1 row
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+
+-- All sessions handled by a specific agent API name in a date range
+-- WHERE    → ssot__AiAgentApiName__c = 'MyAgent'
+--            AND ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c

--- a/skills/investigating-agentforce-d360/assets/dc/participants.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/participants.sql
@@ -1,0 +1,48 @@
+-- Session participants from Data Cloud — reusable for any WHERE filter.
+-- DMO: ssot__AiAgentSessionParticipant__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- One row per participant per session. Roles: USER, AGENT.
+-- AiAgentApiName__c is populated on AGENT rows only.
+--
+-- Casing gotcha: DMO name uses `AiAgent` (lowercase i), unlike the Session
+-- DMO which uses `AIAgent` (uppercase AI). See references/dc_dmo_fields.md.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentSessionId__c,
+    ssot__ParticipantId__c,
+    ssot__AiAgentApiName__c,
+    ssot__AiAgentType__c,
+    ssot__AiAgentTemplateApiName__c,
+    ssot__AiAgentVersionApiName__c,
+    ssot__AiAgentSessionParticipantRole__c,
+    ssot__ParticipantObject__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__IndividualId__c,
+    ssot__InternalOrganizationId__c,
+    ssot__ParticipantAttributeText__c
+FROM ssot__AiAgentSessionParticipant__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Participants for one session
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Only AGENT rows (carry agent identity)
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+--            AND ssot__AiAgentSessionParticipantRole__c = 'AGENT'
+
+-- All sessions handled by a specific agent
+-- WHERE    → ssot__AiAgentApiName__c = 'MyAgent'
+--            AND ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'

--- a/skills/investigating-agentforce-d360/assets/dc/sessions.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/sessions.sql
@@ -1,0 +1,78 @@
+-- Sessions from Data Cloud — reusable for any WHERE filter.
+-- DMO: ssot__AIAgentSession__dlm
+--
+-- Placeholders (substituted by scripts/dc.py._load):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- See EXAMPLE QUERIES below for common WHERE patterns.
+--
+-- This query extracts session-level data including:
+--   - Session ID and timestamps
+--   - Channel type (how user connected)
+--   - How the session ended (Completed, Abandoned, Escalated, etc.)
+--   - Related messaging session (if applicable)
+--
+-- NOTE: Agent name is NOT on Session table. Join with Moment to get agent info.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentChannelType__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__AiAgentSessionEndType__c,
+    ssot__RelatedMessagingSessionId__c,
+    ssot__RelatedVoiceCallId__c,
+    ssot__InternalOrganizationId__c,
+    ssot__SessionOwnerId__c,
+    ssot__SessionOwnerObject__c,
+    ssot__IndividualId__c,
+    ssot__PreviousSessionId__c,
+    ssot__VariableText__c
+FROM ssot__AIAgentSession__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE QUERIES (pass to sessions_sql via where_clause= / order_by=)
+-- ============================================================================
+
+-- One session by id (this skill's primary use case)
+-- WHERE    → ssot__Id__c = '<session_uuid>'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Last 7 days of sessions
+-- WHERE    → ssot__StartTimestamp__c >= '<iso_cutoff_7d_ago>'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Date range
+-- WHERE    → ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'
+--            AND ssot__StartTimestamp__c < '2026-02-01T00:00:00.000Z'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Failed / escalated sessions only
+-- WHERE    → ssot__AiAgentSessionEndType__c IN ('Escalated', 'Abandoned', 'Failed')
+--            AND ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Sessions by channel (e.g. embedded messaging only)
+-- WHERE    → ssot__AiAgentChannelType__c = 'SCRT2 - EmbeddedMessaging'
+--            AND ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Session count by end type (aggregate — SELECT list changes too; separate template)
+-- SELECT
+--     ssot__AiAgentSessionEndType__c,
+--     COUNT(*) as session_count
+-- FROM ssot__AIAgentSession__dlm
+-- WHERE ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z'
+-- GROUP BY ssot__AiAgentSessionEndType__c;
+
+-- Sessions by agent (requires Moment join — separate query shape, not this template)
+-- SELECT DISTINCT s.*
+-- FROM ssot__AIAgentSession__dlm s
+-- JOIN ssot__AiAgentMoment__dlm m
+--     ON m.ssot__AiAgentSessionId__c = s.ssot__Id__c
+-- WHERE m.ssot__AiAgentApiName__c = 'MyAgent'
+--   AND s.ssot__StartTimestamp__c >= '2026-01-01T00:00:00.000Z';

--- a/skills/investigating-agentforce-d360/assets/dc/steps.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/steps.sql
@@ -1,0 +1,64 @@
+-- Planner steps — reusable for any WHERE filter.
+-- DMO: ssot__AIAgentInteractionStep__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- One row per planner step within an interaction. Type enum (verified live):
+-- LLM_STEP | ACTION_STEP | TOPIC_STEP | TRUST_GUARDRAILS_STEP | SESSION_END.
+--
+-- NOTE: InputValueText__c / OutputValueText__c are HTML-escaped JSON.
+-- Callers should `html.unescape()` then `json.loads()` after fetch.
+-- No direct session FK — scope forward via ssot__AiAgentInteractionId__c
+-- (harvested from the session's Interaction rows).
+--
+-- ssot__GenAiGatewayRequestId__c / ssot__GenAiGatewayResponseId__c are
+-- included in the SELECT for completeness but are NOT used as join keys
+-- anywhere in the waterfall. Gateway audit rows are fetched forward from
+-- Session → GatewayRequest (via sessionId__c) — see gateway_requests.sql.
+-- ssot__ErrorMessageText__c uses the sentinel 'NOT_SET' (never NULL) to
+-- mean "no error"; filter with `!= 'NOT_SET'`, not `IS NOT NULL`.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentInteractionId__c,
+    ssot__AiAgentInteractionStepType__c,
+    ssot__Name__c,
+    ssot__InputValueText__c,
+    ssot__OutputValueText__c,
+    ssot__PreStepVariableText__c,
+    ssot__PostStepVariableText__c,
+    ssot__GenerationId__c,
+    ssot__ErrorMessageText__c,
+    ssot__StartTimestamp__c,
+    ssot__EndTimestamp__c,
+    ssot__PrevStepId__c,
+    ssot__InternalOrganizationId__c,
+    ssot__TelemetryTraceSpanId__c,
+    ssot__AttributeText__c,
+    ssot__GenAiGatewayRequestId__c,
+    ssot__GenAiGatewayResponseId__c
+FROM ssot__AIAgentInteractionStep__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Steps for a specific interaction
+-- WHERE    → ssot__AiAgentInteractionId__c = '<interaction_id>'
+-- ORDER BY → ORDER BY ssot__StartTimestamp__c
+
+-- Steps for a session (via interaction id IN list)
+-- WHERE    → ssot__AiAgentInteractionId__c IN ('<id1>','<id2>',...)
+
+-- Only action steps (exclude LLM + topic planning)
+-- WHERE    → ssot__AiAgentInteractionId__c IN ('<id1>','<id2>')
+--            AND ssot__AiAgentInteractionStepType__c = 'ACTION_STEP'
+
+-- Steps with errors (sentinel value; NOT null)
+-- WHERE    → ssot__AiAgentInteractionId__c IN ('<id1>','<id2>')
+--            AND ssot__ErrorMessageText__c != 'NOT_SET'

--- a/skills/investigating-agentforce-d360/assets/dc/tag_associations.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/tag_associations.sql
@@ -1,0 +1,46 @@
+-- Tag ↔ target association — which tag was applied to a moment/session/interaction.
+-- DMO: ssot__AiAgentTagAssociation__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Agent Optimization add-on DMO. THE applied-tag row — one per annotation.
+-- Points at a tag value (`ssot__AiAgentTagId__c`) + a target
+-- (moment | session | interaction) + the tag-definition-association that
+-- authorized it. `ssot__AssociationReasonText__c` carries the LLM's
+-- rationale for why it assigned this tag.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentTagId__c,
+    ssot__AiAgentTagDefinitionAssociationId__c,
+    ssot__AiAgentMomentId__c,
+    ssot__AiAgentSessionId__c,
+    ssot__AiAgentInteractionId__c,
+    ssot__IsPassed__c,
+    ssot__AssociationReasonText__c,
+    ssot__CreatedDate__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentTagAssociation__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All tag associations for one session
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+-- ORDER BY → ORDER BY ssot__CreatedDate__c
+
+-- Tags applied to a set of moments
+-- WHERE    → ssot__AiAgentMomentId__c IN ('<mom_id1>','<mom_id2>')
+
+-- Only passed evaluations (quality pass/fail)
+-- WHERE    → ssot__AiAgentSessionId__c = '<session_id>'
+--            AND ssot__IsPassed__c = true
+
+-- Associations by tag id (reverse lookup)
+-- WHERE    → ssot__AiAgentTagId__c IN ('<tag_id1>','<tag_id2>')

--- a/skills/investigating-agentforce-d360/assets/dc/tag_definition_associations.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/tag_definition_associations.sql
@@ -1,0 +1,37 @@
+-- Tag definition ↔ agent association — which tags are available for an agent.
+-- DMO: ssot__AiAgentTagDefinitionAssociation__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Agent Optimization add-on DMO. Binds a TagDefinition to a specific agent
+-- (by API name) and prompt template. This is what `AiAgentTagAssociation`
+-- actually points at via `ssot__AiAgentTagDefinitionAssociationId__c`.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentTagDefinitionId__c,
+    ssot__AiAgentApiName__c,
+    ssot__AiPromptTemplateId__c,
+    ssot__IsActive__c,
+    ssot__CreatedDate__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentTagDefinitionAssociation__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Active associations for a specific agent
+-- WHERE    → ssot__AiAgentApiName__c = '<agent_api_name>'
+--            AND ssot__IsActive__c = true
+
+-- Associations pointing at a set of tag definitions
+-- WHERE    → ssot__AiAgentTagDefinitionId__c IN ('<def_id1>','<def_id2>',...)
+
+-- Resolve by association id (from AiAgentTagAssociation)
+-- WHERE    → ssot__Id__c IN ('<assoc_id1>','<assoc_id2>',...)

--- a/skills/investigating-agentforce-d360/assets/dc/tag_definitions.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/tag_definitions.sql
@@ -1,0 +1,50 @@
+-- Tag definitions — the schema/vocabulary for tags applied to moments or sessions.
+-- DMO: ssot__AiAgentTagDefinition__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Agent Optimization add-on DMO. Defines a tag type (name, data type,
+-- input scope, engine type, source) that can then be applied via
+-- AiAgentTag + AiAgentTagAssociation.
+
+SELECT
+    ssot__Id__c,
+    ssot__DeveloperName__c,
+    ssot__Name__c,
+    ssot__Description__c,
+    ssot__TagIdentifier__c,
+    ssot__DataType__c,
+    ssot__Status__c,
+    ssot__VersionNumber__c,
+    ssot__EngineType__c,
+    ssot__SourceType__c,
+    ssot__SourceTagReferenceName__c,
+    ssot__InputScope__c,
+    ssot__CreatedDate__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentTagDefinition__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All active tag definitions
+--   Live orgs use 'Available' (not 'Active') — verified via live
+--   describe. Group by ssot__Status__c to confirm per-org.
+--   If 'Available' returns 0 rows, the waterfall retries unfiltered
+--   (`ssot__Id__c IS NOT NULL`). Callers replicating this template
+--   outside fetch_dc.py should apply the same fallback or expect
+--   empty catalogs on orgs where Status uses a different enum.
+-- WHERE    → ssot__Status__c = 'Available'
+-- ORDER BY → ORDER BY ssot__Name__c
+
+-- By developer name
+-- WHERE    → ssot__DeveloperName__c = 'IntentCategory'
+
+-- Definitions for a set of ids (resolves foreign keys from AiAgentTag)
+-- WHERE    → ssot__Id__c IN ('<def_id1>','<def_id2>',...)

--- a/skills/investigating-agentforce-d360/assets/dc/tags.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/tags.sql
@@ -1,0 +1,37 @@
+-- Tag instances — a specific tag value under a tag definition.
+-- DMO: ssot__AiAgentTag__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Agent Optimization add-on DMO. A `AiAgentTag` belongs to a definition
+-- (e.g. definition "IntentCategory" with tag value "Refund Request").
+-- The tag is applied to a moment/session/interaction via AiAgentTagAssociation.
+
+SELECT
+    ssot__Id__c,
+    ssot__AiAgentTagDefinitionId__c,
+    ssot__Value__c,
+    ssot__Description__c,
+    ssot__OrderNumber__c,
+    ssot__IsActive__c,
+    ssot__IsFallback__c,
+    ssot__CreatedDate__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__AiAgentTag__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- Tags for a specific definition (all allowed values)
+-- WHERE    → ssot__AiAgentTagDefinitionId__c = '<def_id>'
+--            AND ssot__IsActive__c = true
+-- ORDER BY → ORDER BY ssot__OrderNumber__c
+
+-- Resolve tags by id (from AiAgentTagAssociation.ssot__AiAgentTagId__c)
+-- WHERE    → ssot__Id__c IN ('<tag_id1>','<tag_id2>',...)

--- a/skills/investigating-agentforce-d360/assets/dc/telemetry_spans.sql
+++ b/skills/investigating-agentforce-d360/assets/dc/telemetry_spans.sql
@@ -1,0 +1,55 @@
+-- Agent Platform Tracing spans — OpenTelemetry span tree per trace.
+-- DMO: ssot__TelemetryTraceSpan__dlm
+--
+-- Placeholders (substituted by scripts/dc.py.load_sql):
+--   WHERE_CLAUSE  — the filter expression, no "WHERE" keyword
+--   ORDER_BY      — full "ORDER BY <col>" or empty string
+--
+-- Provisioned only when **Agent Platform Tracing** is enabled (Setup →
+-- Einstein Audit, Analytics, and Monitoring Setup). Captures spans from
+-- Apex, Flows, Prompt Builder, Invocable Actions, Planner, AI Gateway,
+-- LLM Gateway, DC Query Federator.
+--
+-- Join to STDM: `ssot__TelemetryTrace__c = Interaction.ssot__TelemetryTraceId__c`.
+-- Parent/child within a trace: `ssot__TelemetryParentSpanId__c = <another span>.ssot__Id__c`.
+
+SELECT
+    ssot__Id__c,
+    ssot__TelemetryTrace__c,
+    ssot__TelemetryParentSpanId__c,
+    ssot__OperationName__c,
+    ssot__ServiceName__c,
+    ssot__SpanKind__c,
+    ssot__StatusCode__c,
+    ssot__StartDateTime__c,
+    ssot__EndDateTime__c,
+    ssot__DurationNumber__c,
+    ssot__TelemetrySpanAttributeText__c,
+    ssot__InternalOrganizationId__c
+FROM ssot__TelemetryTraceSpan__dlm
+WHERE {{WHERE_CLAUSE}}
+{{ORDER_BY}};
+
+
+-- ============================================================================
+-- EXAMPLE WHERE clauses (pass via where_clause=)
+-- ============================================================================
+
+-- All spans for one trace (joins to Interaction.ssot__TelemetryTraceId__c)
+-- WHERE    → ssot__TelemetryTrace__c = '<trace_id>'
+-- ORDER BY → ORDER BY ssot__StartDateTime__c
+
+-- All spans for a set of traces (whole session)
+-- WHERE    → ssot__TelemetryTrace__c IN ('<trace_id1>','<trace_id2>',...)
+
+-- Only root spans (no parent)
+-- WHERE    → ssot__TelemetryTrace__c = '<trace_id>'
+--            AND ssot__TelemetryParentSpanId__c = null
+
+-- Only spans from a specific service
+-- WHERE    → ssot__TelemetryTrace__c = '<trace_id>'
+--            AND ssot__ServiceName__c = 'Atlas Reasoning Engine'
+
+-- Slow spans — duration > 1s (nanoseconds in DurationNumber)
+-- WHERE    → ssot__TelemetryTrace__c = '<trace_id>'
+--            AND ssot__DurationNumber__c > 1000000000

--- a/skills/investigating-agentforce-d360/references/artifacts.md
+++ b/skills/investigating-agentforce-d360/references/artifacts.md
@@ -1,0 +1,50 @@
+# Artifacts reference
+
+Every successful trace lands artifacts under
+`~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<ver>/<sid>/`.
+Re-running the same `(org, sid)` overwrites in place. Listed below in
+the order they're produced.
+
+```
+~/.claude/data/investigating-agentforce-d360/<org_id15>/<agent>__<ver>/<sid>/
+├── dc._session_manifest.json ← per-query counts + session_shape + empties
+├── dc._session_tree.json ← hierarchical join (primary artifact)
+├── dc._session_summary.md ← human-readable summary, up to 11 sections (varies with session_shape + identity bootstrap + --show-prompts opt-in)
+├── dc.sessions.json ← 1 row (STDM session)
+├── dc.interactions.json ← N rows (TURN + SESSION_END)
+├── dc.messages.json ← USER + AGENT messages
+├── dc.steps.json ← LLM_STEP / ACTION_STEP / TOPIC_STEP / TRUST_GUARDRAILS_STEP / SESSION_END
+├── dc.participants.json ← USER + AGENT participants
+├── dc.generations.json ← LLM generations
+├── dc.gateway_requests.json ← gateway-logged LLM calls
+├── dc.gateway_responses.json ← 1:1 with gateway_requests
+├── dc.gateway_request_tags.json ← tag rows (bot_id, agent_version_api_name, etc.)
+├── dc.gateway_request_metadata.json ← per-call metadata
+├── dc.content_quality.json ← Trust Layer quality scores
+├── dc.content_category.json ← toxicity + other category rows
+├── dc.feedback.json ← user thumbs-up/down (often empty)
+├── dc.feedback_details.json ← feedback text (often empty)
+├── dc.moments.json ← optional Agent Optimization rollup (often empty)
+├── dc.moment_interactions.json ← moment→interaction junction (often empty)
+├── dc.tag_*.json ← org-wide agent tag catalog (often empty)
+├── dc.telemetry_spans.json ← usually empty (Agent Platform Tracing off)
+├── dc.app_generation.json ← reserved, always empty today
+├── dc.gateway_records.json ← grounded attachments (rare)
+├── dc.gateway_request_llm.json ← writer inactive on observed orgs
+└── dc.tag_associations.json ← agent↔tag links (often empty)
+```
+
+## Read order
+
+1. **`dc._session_summary.md`** — human-readable, top-to-bottom answers
+ "what happened in this session?"
+2. **`dc._session_tree.json`** — single source of truth, the
+ hierarchical join the summary was rendered from. Open this when the
+ summary is missing a detail you need.
+3. **`dc._session_manifest.json`** — per-DMO row counts, classified
+ `session_shape`, and empty-by-design reasons for any DMO that
+ returned zero rows. Open this when something looks missing in the
+ tree.
+4. **`dc.<name>.json`** — raw per-DMO rows. Only needed when the
+ manifest reports an unexpected count or the assembler logs a parse
+ warning.

--- a/skills/investigating-agentforce-d360/references/dc_dmo_fields.md
+++ b/skills/investigating-agentforce-d360/references/dc_dmo_fields.md
@@ -1,0 +1,823 @@
+# STDM + GenAI DMO field reference
+
+> **Convention.** Executable SQL literals live under `assets/dc/*.sql`
+> and are loaded by scripts via `dc.load_sql`. Reference docs (including
+> this one) describe query shape, column meaning, and join topology in
+> prose — they do **not** contain the literal the engine would execute.
+> Rationale: loaders parse, comment-strip, and placeholder-substitute
+> the asset files; `.md` code fences are inert. A query literal in
+> `.md` is orphan code with no linter coverage and no guarantee it
+> matches the live schema.
+
+Field reference for the DMOs this skill touches. **24 queried** by the
+`scripts/fetch_dc.py` waterfall (one `.sql` template each under
+`assets/dc/`). All field lists are copy-pasteable into `assets/dc/*.sql`
+SELECT lists. Schemas verified against live Data Cloud v66.0 via
+`sf ssot/metadata` describes; join paths verified by running the
+waterfall end-to-end on live sessions.
+
+**Source of truth: the live org** (`sf ssot/metadata?entityName=<dmo>`).
+Official Salesforce Help pages list *logical* API names and aspirational
+enum values that frequently diverge from the physical names and runtime
+values the Data Cloud API actually exposes. When a Help page disagrees
+with a live describe, trust the live describe — the names and enums in
+this reference are what you query.
+
+Official doc pointers (for context, not authority — Session Tracing doc
+uses logical API names and aspirational enum values that diverge from
+what the live `sf ssot/metadata` describe returns; trust the live describe):
+- Session Tracing DMOs: https://help.salesforce.com/s/articleView?id=ai.generative_ai_session_trace_data_model.htm&type=5
+- Generative AI Audit and Feedback DMOs: https://help.salesforce.com/s/articleView?id=ai.generative_ai_feedback_data_model.htm&type=5
+- Agent Optimization DMOs: https://help.salesforce.com/s/articleView?id=ai.generative_ai_optimize_data_model.htm&type=5
+- Agent Platform Tracing (`ssot__TelemetryTraceSpan__dlm`): https://help.salesforce.com/s/articleView?id=ai.generative_ai_platform_trace.htm&type=5
+
+**Casing gotchas (important):**
+- DMO table casing is **mixed** — don't assume a single rule. Three STDM DMOs use uppercase `AIAgent` (`ssot__AIAgentSession__dlm`, `ssot__AIAgentInteraction__dlm`, `ssot__AIAgentInteractionStep__dlm`); all other `ssot__*AiAgent*__dlm` tables use lowercase `AiAgent`. Trust the exact name in each section header or the live `describe`.
+- Field names consistently use **`AiAgent`** (lowercase `i`), e.g. `ssot__AiAgentSessionId__c`, across every DMO.
+- Generative AI Audit and Feedback DMOs (`GenAIGeneration`, `GenAIContentQuality`, `GenAIContentCategory`, and the 9 other DMOs in that family — see below) do **not** use the `ssot__` prefix. Their fields end in `__c`, not `ssot__*__c`.
+
+---
+
+## Cross-DMO join map
+
+Every edge is strictly **forward** from Session. `scripts/fetch_dc.py` runs
+the tree as a 5-wave waterfall; each child query keys off ids harvested
+from parents in earlier waves. No backward lookups, no cross-validation
+paths — if a DMO can't be reached by a forward FK from Session, it's not
+fetched.
+
+The audit/cost chain (GatewayRequest and its children) enters the tree
+forward through `GenAIGatewayRequest.sessionId__c`. Storage gotcha: the
+value is stored as a literal 40-char string INCLUDING surrounding
+double-quotes, e.g. `"<session_uuid>"`. Non-session features store the
+sentinel `"no_session"`. A raw-UUID exact match returns 0 rows; use
+`sessionId__c LIKE '%<sid>%'` or `sessionId__c = '"<sid>"'`.
+
+Per-run row counts, empty reasons, and join paths are recorded in
+`dc._session_manifest.json`.
+
+Legend: ★ = session-FK direct (one hop) ▸ = polymorphic `parent__c`
+ ⚠ = requires feature provisioning
+
+```
+Session (ssot__AIAgentSession__dlm, PK ssot__Id__c)
+ │
+ ├── ★ Participant (ssot__AiAgentSessionId__c)
+ │
+ ├── ★ Message (ssot__AiAgentSessionId__c)
+ │ └── Message.participant (ssot__AiAgentSessionParticipantId__c → Participant.ssot__Id__c)
+ │
+ ├── ★ Moment (ssot__AiAgentSessionId__c)
+ │ └── MomentInteraction (ssot__AiAgentMomentId__c, ssot__AiAgentInteractionId__c)
+ │
+ ├── ★ TagAssociation ▸ (ssot__AiAgentSessionId__c when target is session;
+ │ ssot__AiAgentInteractionId__c when target is turn;
+ │ ssot__AiAgentMomentId__c when target is moment —
+ │ exactly one of the three is populated per row)
+ │ ├── → AiAgentTag (ssot__AiAgentTagId__c = Tag.ssot__Id__c)
+ │ │ └── TagDefinition (Tag.ssot__AiAgentTagDefinitionId__c =
+ │ │ TagDefinition.ssot__Id__c)
+ │ │ — catalog, not session-keyed; query with
+ │ │ ssot__Status__c = 'Available' (verified live;
+ │ │ Help docs' 'Active' value does not match live data)
+ │ └── → TagDefinitionAssociation
+ │ (ssot__AiAgentTagDefinitionAssociationId__c = TagDefAssoc.ssot__Id__c)
+ │ — catalog, not session-keyed; query by ssot__AiAgentApiName__c IN
+ │ {agent_api_names from Participant(role='AGENT') ∪ Moment}
+ │ (Participant is the primary source — Moment rows may be absent on
+ │ orgs without Agent Optimization enabled)
+ │
+ ├── ★ Interaction (ssot__AiAgentSessionId__c)
+ │ ├── Step (ssot__AiAgentInteractionId__c)
+ │ │ └── GenAIGeneration (step.ssot__GenerationId__c IN {generationId__c})
+ │ │ │ (assembly bridge → references/dc_pipeline_contract.md:
+ │ │ │ Generation.generationResponseId__c =
+ │ │ │ GatewayResponse.generationResponseId__c)
+ │ │ ├── GenAIContentQuality (parent__c = generationId__c)
+ │ │ │ └── GenAIContentCategory ▸ (parent__c = Quality.id__c;
+ │ │ │ toxicity sub-category rows)
+ │ │ ├── GenAIContentCategory ▸ (parent__c = generationId__c;
+ │ │ │ non-toxicity detector rows)
+ │ │ ├── GenAIAppGeneration (generationId__c = Gen.generationId__c;
+ │ │ │ sibling record, often empty on observed orgs)
+ │ │ └── GenAIFeedback (generationId__c)
+ │ │ ├── GenAIFeedbackDetail (parent__c = feedback.feedbackId__c)
+ │ │ └── GenAIGtwyObjRecord ▸ (parent__c = feedback.feedbackId__c
+ │ │ when type__c is a feedback attachment)
+ │ └── ⚠ TelemetryTraceSpan (ssot__TelemetryTrace__c IN {trace_ids};
+ │ trace_ids extracted from Interaction.ssot__AttributeText__c via
+ │ html.unescape() + regex "internalTraceId":"([a-f0-9]+)" —
+ │ Interaction.ssot__TelemetryTraceId__c column is usually empty.
+ │ Requires Agent Platform Tracing enabled on the org.)
+ │
+ └── ★ GenAIGatewayRequest (sessionId__c LIKE '%<sid>%')
+ │ — one row per LLM call owned by the session,
+ │ across all features (plannerservice,
+ │ PromptTemplateGenerationsInvocable, etc.)
+ │
+ ├── GenAIGatewayResponse (generationRequestId__c = gatewayRequestId__c)
+ ├── GenAIGatewayRequestTag (parent__c = gatewayRequestId__c)
+ ├── GenAIGtwyObjRecord ▸ (parent__c = gatewayRequestId__c
+ │ when type__c = grounded record attachment;
+ │ populated only for grounding features —
+ │ planner-only sessions produce 0 rows)
+ ├── GenAIGtwyRequestMetadata (parent__c = gatewayRequestId__c;
+ │ typed metadata rows, e.g. ToolCall payloads)
+ └── ⚠ GenAIGtwyRequestLLM (parent__c = gatewayRequestId__c;
+ per-call LLM diagnostics; schema provisioned
+ but writer inactive on every sandbox observed
+ — treat as aspirational)
+```
+
+### How to "join all 24" from one session id
+
+All 24 entries below are in the `scripts/fetch_dc.py` waterfall — the
+join expressions are exactly what the script runs, and each one has a
+`.sql` template under `assets/dc/`.
+
+```
+ 1. sessions WHERE ssot__Id__c = {sid}
+ 2. interactions WHERE ssot__AiAgentSessionId__c = {sid}
+ 3. messages WHERE ssot__AiAgentSessionId__c = {sid}
+ 4. moments WHERE ssot__AiAgentSessionId__c = {sid}
+ 5. participants WHERE ssot__AiAgentSessionId__c = {sid}
+ 6. tag_associations WHERE ssot__AiAgentSessionId__c = {sid}
+ 7. gateway_requests WHERE sessionId__c LIKE '%{sid}%'
+ — sessionId__c is stored quoted (e.g. '"<sid>"');
+ raw-UUID exact match returns 0. Equivalent
+ exact form: sessionId__c = '"{sid}"'
+ 8. steps WHERE ssot__AiAgentInteractionId__c IN {interaction_ids}
+ 9. moment_interactions WHERE ssot__AiAgentInteractionId__c IN {interaction_ids}
+10. telemetry_spans WHERE ssot__TelemetryTrace__c IN {trace_ids_from_AttributeText}
+11. generations WHERE generationId__c IN {step.ssot__GenerationId__c values}
+12. gateway_request_tags WHERE parent__c IN {gateway_request_ids}
+13. gateway_responses WHERE generationRequestId__c IN {gateway_request_ids}
+14. gateway_records (→ GenAIGtwyObjRecord__dlm) WHERE parent__c IN {gateway_request_ids}
+15. feedback WHERE generationId__c IN {generation_ids}
+16. content_quality WHERE parent__c IN {generation_ids}
+17. content_category WHERE parent__c IN ({generation_ids} ∪ {content_quality.id__c})
+18. feedback_details WHERE parent__c IN {feedback.feedbackId__c}
+19. tag_definitions WHERE ssot__Status__c = 'Available'
+ — not keyed by session (tag vocabulary)
+20. tag_definition_associations WHERE ssot__AiAgentApiName__c IN
+ {agent_api_names from Participant(role='AGENT') ∪ Moment}
+ — keyed by agent, not session. Participant is primary
+ (Moment rows may be absent without Agent Optimization)
+21. tags WHERE ssot__AiAgentTagDefinitionId__c IN
+ {tag_definition.ssot__Id__c}
+ — tag VALUES; session reaches them via TagAssociation
+
+22. app_generation WHERE generationId__c IN {step.ssot__GenerationId__c values}
+ — app-layer twin of GenAIGeneration
+23. gateway_request_metadata WHERE parent__c IN {gateway_request_ids}
+ — verified live: parent__c → GatewayRequest.gatewayRequestId__c
+24. gateway_request_llm WHERE parent__c IN {gateway_request_ids}
+ — same parent pattern as Metadata; writer inactive on
+ observed sandboxes (0 rows expected until enabled)
+```
+
+---
+
+### DMO materialization timing
+
+Data Cloud DMOs don't all appear at the same time. Gateway DMOs
+materialize within minutes; STDM Interaction/Step/Message DMOs can
+take hours to days.
+
+| DMO | Table | Materializes | Notes |
+|---|---|---|---|
+| Session | `ssot__AIAgentSession__dlm` | Minutes | Always query first |
+| Participant | `ssot__AiAgentSessionParticipant__dlm` | Minutes | Fast |
+| GatewayRequest | `GenAIGatewayRequest__dlm` | Minutes | Direct FK via `sessionId__c LIKE` |
+| GatewayResponse | `GenAIGatewayResponse__dlm` | Minutes | Joins via `generationRequestId__c` |
+| GatewayRequestTag | `GenAIGatewayRequestTag__dlm` | Minutes | `parent__c = gatewayRequestId__c` |
+| GtwyRequestMetadata | `GenAIGtwyRequestMetadata__dlm` | Minutes | `parent__c = gatewayRequestId__c` |
+| Moment | `ssot__AiAgentMoment__dlm` | Hours–days | Often empty on same-day |
+| Interaction | `ssot__AIAgentInteraction__dlm` | **Hours–days** | Do NOT use as query anchor for fresh sessions — `fetch_dc.py` classifies this as `session_shape=interactions_not_materialized_yet` and renders the gateway-direct view |
+| Message | `ssot__AiAgentSessionMessage__dlm` | Hours–days | Downstream of Interaction |
+| Step | `ssot__AIAgentInteractionStep__dlm` | Hours–days | Downstream of Interaction |
+| Generation | `GenAIGeneration__dlm` | Hours–days | Downstream of Step |
+| GtwyRequestLLM | `GenAIGtwyRequestLLM__dlm` | N/A | Writer inactive on sandboxes |
+
+---
+
+## Session Tracing DMOs (5)
+
+### `ssot__AIAgentSession__dlm` — one row per session
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | Session UUID (what users pass in) |
+| `ssot__StartTimestamp__c` | string (ISO UTC) | |
+| `ssot__EndTimestamp__c` | string (ISO UTC) | null while active |
+| `ssot__AiAgentSessionEndType__c` | string | Completed / Abandoned / Escalated / etc. |
+| `ssot__AiAgentChannelType__c` | string | e.g. "SCRT2 - EmbeddedMessaging", "Voice" |
+| `ssot__RelatedMessagingSessionId__c` | string | |
+| `ssot__RelatedVoiceCallId__c` | string | |
+| `ssot__InternalOrganizationId__c` | string | 18-char org id |
+| `ssot__SessionOwnerId__c` | string | |
+| `ssot__SessionOwnerObject__c` | string | Owner type, e.g. "User" |
+| `ssot__IndividualId__c` | string | Data 360 individual id |
+| `ssot__PreviousSessionId__c` | string | Conversation-chain link to prior session |
+| `ssot__VariableText__c` | string | Session-level variables, JSON. Channel-specific bootstrap dict (e.g. `__resolved_locale__`, `__supports_result_display__`, `__user_dst_offset_ms__`). Parsed at assemble time into `session.identity.bootstrap_variables`. The presence of Builder-Previewer-only keys (`__supports_result_display__` etc.) is one input to the derived `session.identity.mode` field — see dc_pipeline_contract.md §2.9a. |
+
+Note: **agent API name is NOT on Session**. Join with Moment to get agent info.
+
+### `ssot__AiAgentSessionParticipant__dlm` — one row per participant per session
+
+Roles: `USER`, `AGENT`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentSessionId__c` | string (FK) | → Session.Id |
+| `ssot__ParticipantId__c` | string | MessagingEndUser id (USER) or GenAiPlannerDefinition id (AGENT) |
+| `ssot__AiAgentApiName__c` | string | Bot identity — omit on USER rows |
+| `ssot__AiAgentType__c` | string | e.g. "DemoAgentType" |
+| `ssot__AiAgentTemplateApiName__c` | string | |
+| `ssot__AiAgentVersionApiName__c` | string | e.g. "v5" |
+| `ssot__AiAgentSessionParticipantRole__c` | string | USER \| AGENT |
+| `ssot__ParticipantObject__c` | string | e.g. "MessagingEndUser", "GenAiPlannerDefinition" |
+| `ssot__StartTimestamp__c` | string | |
+| `ssot__EndTimestamp__c` | string | |
+| `ssot__IndividualId__c` | string | Data 360 individual id |
+| `ssot__InternalOrganizationId__c` | string | 18-char org id |
+| `ssot__ParticipantAttributeText__c` | string | JSON — per-participant metadata |
+
+### `ssot__AIAgentInteraction__dlm` — one row per turn (and session-end event)
+
+Types: `TURN`, `SESSION_END`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | Turn/interaction UUID |
+| `ssot__AiAgentSessionId__c` | string (FK) | → Session.Id |
+| `ssot__AiAgentInteractionType__c` | string | TURN \| SESSION_END |
+| `ssot__TopicApiName__c` | string | Which topic handled this turn |
+| `ssot__StartTimestamp__c` | string | |
+| `ssot__EndTimestamp__c` | string | |
+| `ssot__PrevInteractionId__c` | string | |
+| `ssot__SessionOwnerId__c` | string | |
+| `ssot__IndividualId__c` | string | |
+| `ssot__InternalOrganizationId__c` | string | |
+| `ssot__TelemetryTraceId__c` | string | Often empty on real orgs (verified live). See note below. |
+| `ssot__TelemetryTraceSpanId__c` | string | Often empty — same caveat as above. |
+| `ssot__AttributeText__c` | string | HTML-escaped JSON. Holds `internalTraceId` + `internalSpanId` — the real runtime trace_id when `TelemetryTraceId__c` is empty. Consumers: `html.unescape()` + regex `"internalTraceId":"([a-f0-9]+)"`. |
+
+### `ssot__AiAgentInteractionMessage__dlm` — one row per user/agent message
+
+Types: `Input`, `Output`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentSessionId__c` | string (FK) | → Session.Id — direct session FK (verified v66.0) |
+| `ssot__AiAgentInteractionId__c` | string (FK) | → Interaction.Id |
+| `ssot__AiAgentSessionParticipantId__c` | string (FK) | → Participant.Id — who sent/received the message |
+| `ssot__ParentMessageId__c` | string | Threading — prior message in a nested conversation |
+| `ssot__ContentText__c` | string | The actual message text |
+| `ssot__AiAgentInteractionMessageType__c` | string | Input \| Output |
+| `ssot__AiAgentInteractionMsgContentType__c` | string | Content MIME/type (text/audio/etc.) |
+| `Modality__c` | string | e.g. Text, Voice — no `ssot__` prefix |
+| `ssot__MessageSentTimestamp__c` | string | Single-point timestamp (text channels) |
+| `MessageStartTimestamp__c` | datetime | Start of message (voice/streaming) — no `ssot__` prefix |
+| `MessageEndTimestamp__c` | datetime | End of message (voice/streaming) — no `ssot__` prefix |
+| `ssot__InternalOrganizationId__c` | string | 18-char org id |
+
+**Messages have a direct session FK** (`ssot__AiAgentSessionId__c`) — scope by session directly; earlier docs claiming otherwise were wrong. The interaction FK is still useful for per-turn joins.
+
+### `ssot__AIAgentInteractionStep__dlm` — one row per planner step
+
+Types observed in live data:
+`LLM_STEP`, `ACTION_STEP`, `TOPIC_STEP`, `TRUST_GUARDRAILS_STEP`, `SESSION_END`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentInteractionId__c` | string (FK) | → Interaction.Id |
+| `ssot__AiAgentInteractionStepType__c` | string | LLM_STEP \| ACTION_STEP \| TOPIC_STEP \| TRUST_GUARDRAILS_STEP \| SESSION_END |
+| `ssot__Name__c` | string | step/action name (e.g. "AiCopilot__ReactTopicPrompt") |
+| `ssot__InputValueText__c` | string | HTML-escaped JSON; parse after `html.unescape` |
+| `ssot__OutputValueText__c` | string | HTML-escaped JSON; parse after `html.unescape` |
+| `ssot__PreStepVariableText__c` | string | |
+| `ssot__PostStepVariableText__c` | string | |
+| `ssot__GenerationId__c` | string | → `GenAIGeneration.generationId__c`. Populated only on `LLM_STEP` rows (in live samples, most LLM_STEP rows populate it); `NOT_SET` on every other step type. This is the only Step→Generation join key used by the waterfall. |
+| `ssot__ErrorMessageText__c` | string | Sentinel `NOT_SET` when no error (never NULL). Filter errors with `!= 'NOT_SET'`, not `IS NOT NULL`. |
+| `ssot__StartTimestamp__c` | string | |
+| `ssot__EndTimestamp__c` | string | |
+| `ssot__PrevStepId__c` | string | |
+| `ssot__InternalOrganizationId__c` | string | |
+| `ssot__TelemetryTraceSpanId__c` | string | |
+| `ssot__AttributeText__c` | string | |
+| `ssot__GenAiGatewayRequestId__c` | string | Schema-only FK. Live data shows this is frequently `NOT_SET` even on `LLM_STEP` rows. **Not used by the waterfall** — GatewayRequest is fetched forward from Session via `sessionId__c`, which is the authoritative set and covers requests this FK doesn't reach. |
+| `ssot__GenAiGatewayResponseId__c` | string | Schema-only FK. Same as above — documented for schema completeness, not used as a join key. Following it back to GatewayResponse is a backward-reasoning pattern and rejected by the skill design. |
+
+Join: steps lack a direct session FK — go through Interaction.
+
+**Step Gateway FKs are not join keys.** The three Gateway-related FK
+columns (`ssot__GenAiGatewayRequestId__c`, `ssot__GenAiGatewayResponseId__c`)
+are included in the SELECT for schema completeness but are not used to
+reach any downstream DMO. GatewayRequest is entered forward from Session
+via `GatewayRequest.sessionId__c` (see gateway_requests section); its
+children flow forward from there. Only `ssot__GenerationId__c` is used
+as a forward Step → Generation key.
+
+---
+
+## Generative AI Audit and Feedback DMOs (12 of 13 documented)
+
+Canonical umbrella per the Salesforce Help article
+[Data Model for Generative AI Audit and Feedback](https://help.salesforce.com/s/articleView?id=ai.generative_ai_feedback_data_model.htm&type=5).
+Spans the full Einstein generative AI audit chain: LLM requests and responses
+at the gateway, trust-layer safety scoring, and user-side feedback on
+generations.
+
+**No `ssot__` prefix.** Fields end in `__c` directly.
+
+Data 360 Data Lake Objects (DLOs) that contain generative AI audit and
+feedback data map to custom DMOs (legacy) and standard DMOs. The 13 DMOs
+in this family per the Help article:
+
+| DLO | Custom DMO (legacy) | Standard DMO | Queried by `fetch_dc.py`? |
+|---|---|---|---|
+| GenAIAppGeneration | `GenAIAppGeneration__dlm` | Ai Response App Generation | ✓ |
+| GenAIContentCategory | `GenAIContentCategory__dlm` | Ai Content Quality Category | ✓ |
+| GenAIContentQuality | `GenAIContentQuality__dlm` | Ai Content Quality | ✓ |
+| GenAIFeedback | `GenAIFeedback__dlm` | Ai Feedback | ✓ |
+| GenAIFeedbackDetail | `GenAIFeedbackDetail__dlm` | Ai Feedback Additional Info | ✓ |
+| GenAIGatewayRequest | `GenAIGatewayRequest__dlm` | Ai Gateway Request | ✓ |
+| GenAIGatewayRequestTag | `GenAIGatewayRequestTag__dlm` | Ai Gateway Request Tag | ✓ |
+| GenAIGatewayResponse | `GenAIGatewayResponse__dlm` | Ai Gateway Response | ✓ |
+| GenAIGeneration | `GenAIGeneration__dlm` | Ai Response Generation | ✓ |
+| GenAIGtwyRequestMetadata | `GenAIGtwyRequestMetadata__dlm` | Ai Gateway Req Additional Info | ✓ |
+| GenAIGtwyRequestLLM | `GenAIGtwyRequestLLM__dlm` | Ai Gateway Request Model Diagnostic | ✓ |
+| GenAIGtwyObjRecord | `GenAIGtwyObjRecord__dlm` | Ai Gateway Request Object Record | ✓ |
+
+The Help article lists one additional DMO in this family —
+`GenAIGtwyObjRecCitation__dlm` (standard DMO: **Ai Gateway Req Object
+Record Citation**). It is not documented here: live `describe` returns
+"DMO with developerName 'GenAIGtwyObjRecCitation' not found" on the
+tested org, so we have no verified schema or join column. Bring it in
+once it's provisioned on a test org.
+
+All 12 DMOs marked ✓ above are queried by the 24-query `fetch_dc.py`
+waterfall. Their `.sql` templates are under `assets/dc/` and their full
+schemas are documented in the per-DMO sections below.
+
+### `GenAIGeneration__dlm` — one row per LLM call at the gateway
+
+**Joining to a session:** this DMO has NO `sessionId__c`, `traceId__c`, or
+`turnId__c` column (verified via live `describe`; 11 fields total,
+none reference session/trace/turn). The canonical join path is:
+
+```
+Session → Interaction → Step (.ssot__GenerationId__c) → Generation (.generationId__c)
+```
+
+Pull session steps, collect non-empty `ssot__GenerationId__c` values
+(many steps have `NOT_SET`), then filter by `generationId__c IN (...)`.
+
+There is no backward chain to this DMO from GatewayRequest/Response.
+The waterfall only reaches `GenAIGeneration__dlm` via the forward
+Step→Generation path above; Generation rows for LLM calls that aren't
+owned by an LLM_STEP are not fetched by this skill.
+
+| Field | Type | Notes |
+|---|---|---|
+| `generationId__c` | string (PK) | Forward join key from `Step.ssot__GenerationId__c`. |
+| `generationResponseId__c` | string | Provider-issued response id (OpenAI-style `chatcmpl-*`, Gemini/Anthropic use their own prefixes). Not used as a join key. |
+| `responseText__c` | string | HTML-escaped JSON for tool-calling outputs; `html.unescape()` before parsing. |
+| `maskedResponseText__c` | string | PII-masked version |
+| `responseParameters__c` | string | JSON |
+| `feature__c` | string | e.g. "plannerservice", "Guardrails and Citations" |
+| `timestamp__c` | string | |
+| `orgId__c` | string | |
+| `cloud__c` | string | e.g. "Platform" |
+
+### `GenAIContentQuality__dlm` — per-generation quality row
+
+Joined to a generation via `parent__c = generationId__c`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GenAIGeneration.generationId__c` |
+| `isToxicityDetected__c` | string | "true" / "false" — populated only on OUTPUT rows |
+| `contentType__c` | string | INPUT \| OUTPUT |
+| `feature__c` | string | |
+| `timestamp__c` | string | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIContentCategory__dlm` — per-category detector row
+
+Joined either to a generation (direct, non-TOXICITY detectors like
+`InstructionAdherence`) or to a quality row (TOXICITY sub-categories).
+The `parent__c` FK points to whichever parent emitted it.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GenAIGeneration.generationId__c` OR `GenAIContentQuality.id__c` |
+| `detectorType__c` | string | TOXICITY \| PII \| PROMPT_DEFENSE \| InstructionAdherence \| TaskResolution |
+| `category__c` | string | e.g. "violence", "safety_score", "Low" / "Medium" / "High" |
+| `value__c` | string | "0.0" – "1.0" as string; convert to float in analysis |
+| `timestamp__c` | string | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGatewayRequest__dlm` — one row per LLM request at the gateway
+
+Richer than `GenAIGeneration` — carries prompt text, tokens, model, and
+session/user/bot identifiers. **Forward entry point for the entire audit
+chain**, reached from Session via `sessionId__c`:
+
+```
+Session.ssot__Id__c → GatewayRequest.sessionId__c LIKE '%<sid>%'
+```
+
+`sessionId__c` is stored as a literal quoted string (e.g. `"<uuid>"`), so a
+raw-UUID exact match returns 0 rows; use LIKE or `sessionId__c = '"<sid>"'`.
+See `assets/dc/gateway_requests.sql` for details.
+
+GatewayRequest is the parent for all downstream audit DMOs — Response,
+RequestTag, GtwyObjRecord, RequestMetadata, RequestLLM — each keyed by
+`generationRequestId__c` or `parent__c = gatewayRequestId__c`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `gatewayRequestId__c` | string (PK) | |
+| `generationGroupId__c` | string | Groups multiple generations for one user-visible turn |
+| `sessionId__c` | string | Session FK — the forward entry point. Stored as a quoted string (e.g. `"<uuid>"`) or sentinel `"no_session"`. Query with `sessionId__c LIKE '%<sid>%'` or exact `sessionId__c = '"<sid>"'`; raw-UUID match returns 0 rows. |
+| `userId__c` | string | End-user id |
+| `botVersionId__c` | string | Agent version id |
+| `plannerId__c` | string | Planner id (ReAct etc.) |
+| `feature__c` | string | e.g. `CopilotForDigitalChannels` |
+| `appType__c` | string | |
+| `model__c` | string | e.g. `gpt-4o-2024-11-20` |
+| `provider__c` | string | e.g. `openai`, `azureOpenAI`, `salesforce` |
+| `promptTemplateDevName__c` | string | e.g. `AiCopilot__ReactTopicPrompt`, `Atlas__AgentGraphReasoningPrompt`. Surfaced through the hierarchical view as `gateway_request.prompt_template_dev_name`. |
+| `promptTemplateVersionNo__c` | string | |
+| `prompt__c` | string | **Full input prompt sent to the model** — `role: system` / `role: user` / `role: assistant` segments, tool definitions, conversation history. Up to 30 KB+ on observed sessions. Carried through the hierarchical view as `gateway_request.prompt_text`; surfaced verbatim by `render_dc.py --show-prompts` (off by default; per-prompt display capped at 64 KB). HTML-escaped on the wire (`&quot;` etc.) — renderer unescapes before display. |
+| `maskedPrompt__c` | string | PII-masked variant of `prompt__c`. Empty when `enablePiiMasking__c = "false"`; populated when masking is enabled. |
+| `parameters__c` | string | JSON — extra invocation params |
+| `temperature__c` | number | |
+| `frequencyPenalty__c` | number | |
+| `presencePenalty__c` | number | |
+| `stopSequences__c` | string | |
+| `numGenerations__c` | number | |
+| `promptTokens__c` | number | |
+| `completionTokens__c` | number | |
+| `totalTokens__c` | number | |
+| `enableInputSafetyScoring__c` | string | "true" / "false" |
+| `enableOutputSafetyScoring__c` | string | "true" / "false" |
+| `enablePiiMasking__c` | string | "true" / "false" |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGatewayResponse__dlm` — one row per LLM call response
+
+Forward join: from GatewayRequest via `generationRequestId__c IN {gw_req_ids}`.
+Every GatewayRequest has one Response (modulo in-flight calls at fetch time) —
+1:1 invariant verified live.
+
+| Field | Type | Notes |
+|---|---|---|
+| `generationResponseId__c` | string (PK) | Provider-issued response id (e.g. OpenAI `chatcmpl-*`). Same value also appears on `Step.ssot__GenAiGatewayResponseId__c` and `Generation.generationResponseId__c`, but those are not used as join keys. |
+| `generationRequestId__c` | string (FK) | → `GatewayRequest.gatewayRequestId__c`. The forward join key. |
+| `parameters__c` | string | JSON |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGatewayRequestTag__dlm` — k/v tags per request
+
+Joined via `parent__c = GatewayRequest.gatewayRequestId__c`. Multiple rows per request.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GatewayRequest.gatewayRequestId__c` |
+| `tag__c` | string | e.g. `prompt_template_dev_name`, `user_utterance` |
+| `tagValue__c` | string | |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIFeedback__dlm` — user thumbs up/down on a generation
+
+Joined via `generationId__c = Generation.generationId__c`. PK `feedbackId__c`
+is the parent for `GenAIFeedbackDetail` rows.
+
+| Field | Type | Notes |
+|---|---|---|
+| `feedbackId__c` | string (PK) | |
+| `generationId__c` | string (FK) | → `Generation.generationId__c` |
+| `generationUpdateId__c` | string | |
+| `generationGroupId__c` | string | |
+| `userId__c` | string | |
+| `feedback__c` | string | e.g. `UP`, `DOWN` |
+| `action__c` | string | Richer action, e.g. `REGENERATE`, `COPY` |
+| `source__c` | string | Channel/app that captured the feedback |
+| `feature__c` | string | |
+| `appType__c` | string | |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIFeedbackDetail__dlm` — free-text / structured detail per feedback
+
+Joined via `parent__c = Feedback.feedbackId__c`. Zero or more rows per feedback.
+
+| Field | Type | Notes |
+|---|---|---|
+| `feedbackDetailId__c` | string (PK) | |
+| `parent__c` | string (FK) | → `Feedback.feedbackId__c` |
+| `feedbackText__c` | string | Free-text user input |
+| `appFeedback__c` | string | App-layer reason bucket |
+| `feature__c` | string | |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGtwyObjRecord__dlm` — grounded record attachments on gateway requests
+
+Polymorphic. `parent__c` is the id of whatever owns this record (GatewayRequest
+for grounded-content attachments, GenAIFeedback for feedback attachments, etc.)
+and `type__c` names the DMO the attached record lives in
+(e.g. `ssot__KnowledgeArticleVersion__dlm`).
+
+**Populated only on planners that perform grounded retrieval.** Join path is
+clean and forward (`Session → GatewayRequest → GtwyObjRecord`), but the child
+table is planner-dependent — a planner that doesn't attach grounded records
+produces zero rows even when the session is fully traced. Verified live:
+
+- Tool-calling / planner-style Agentforce sessions (request `feature__c =
+ 'plannerservice'` only): 0 rows across all observed sessions. The planner
+ doesn't emit grounded-record attachments.
+- Sessions whose requests include `PromptTemplateGenerationsInvocable` or
+ `PromptBuilderPreview` features *do* produce rows — e.g. one live turn
+ produced a `type__c = ssot__KnowledgeArticleVersion__dlm` attachment via
+ the forward chain.
+
+If fetch returns 0 for an Agentforce agent session, first check the
+GatewayRequest rows' `plannerId__c` and `feature__c` — a planner that only
+shows `plannerservice` feature will not produce child records. This DMO is
+also org-gated: across a set of observed sandboxes with ~400K total
+GatewayRequest rows, only a minority had any GtwyObjRecord rows at all.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GatewayRequest.gatewayRequestId__c` (forward from session) or `GenAIFeedback.feedbackId__c` (feedback attachment) |
+| `recordId__c` | string | Attached record's id in its home DMO |
+| `type__c` | string | DMO the record lives in, e.g. `ssot__KnowledgeArticleVersion__dlm` |
+| `name__c` | string | |
+| `value__c` | string | Often a deep-link URL to the record in the org |
+| `metadata__c` | string | JSON |
+| `feature__c` | string | |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+The 3 DMOs below are wired into the `fetch_dc.py` waterfall as entries
+22–24 with matching `.sql` templates under `assets/dc/` (`app_generation`,
+`gateway_request_metadata`, `gateway_request_llm`). Field schemas below are
+from live `describe`. Population varies by DMO:
+- `GenAIAppGeneration__dlm` — provisioned but not populated on observed orgs.
+- `GenAIGtwyRequestMetadata__dlm` — populated whenever the session's
+ GatewayRequest rows are populated; one row per request on Agentforce
+ sessions (e.g. `ToolCall` payloads for `plannerservice`).
+- `GenAIGtwyRequestLLM__dlm` — **0 rows on every sandbox observed**
+ (multiple orgs checked; total GatewayRequest rows ~400K, total
+ GtwyRequestLLM rows 0). Schema exists, writer appears inactive.
+
+### `GenAIAppGeneration__dlm` — app-layer generation record
+
+Standard DMO: **Ai Response App Generation**. Sibling of
+`GenAIGeneration__dlm`: where `GenAIGeneration` is the raw gateway
+response, `GenAIAppGeneration` appears to be the app/feature-layer view
+of the same generation (separate `id__c` from `generationId__c`).
+
+**Executable query:** `assets/dc/app_generation.sql`.
+
+**Join path:** `generationId__c → GenAIGeneration.generationId__c → AiAgentInteractionStep.ssot__GenerationId__c → Interaction → Session`. Same Step → Generation bridge used for `GenAIGeneration__dlm`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | App-generation row id — distinct from `generationId__c` |
+| `generationId__c` | string (FK) | → `GenAIGeneration.generationId__c` (session join path) |
+| `generationUpdate__c` | string | Likely a later revision of the generation |
+| `generationUpdateId__c` | string | id of the update row |
+| `feature__c` | string | |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGtwyRequestMetadata__dlm` — additional per-request metadata
+
+Standard DMO: **Ai Gateway Req Additional Info**. Child of
+`GenAIGatewayRequest__dlm`: holds typed metadata rows for a request.
+On live data a sampled row showed `metadataType__c = "ToolCall"` and
+`feature__c = "plannerservice"`, so it's where tool-call/planner-side
+per-request metadata lives.
+
+**Executable query:** `assets/dc/gateway_request_metadata.sql`.
+
+**Join verified live:** `parent__c → GatewayRequest.gatewayRequestId__c`. A sampled `parent__c` value matched exactly one row in `GenAIGatewayRequest__dlm WHERE gatewayRequestId__c = …`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GatewayRequest.gatewayRequestId__c` (verified live) |
+| `metadataType__c` | string | Observed: `ToolCall`; other values likely |
+| `metadata__c` | string | JSON — the actual metadata payload |
+| `feature__c` | string | Observed: `plannerservice` |
+| `timestamp__c` | datetime | |
+| `orgId__c` | string | |
+| `cloud__c` | string | |
+
+### `GenAIGtwyRequestLLM__dlm` — per-request LLM call diagnostics
+
+Standard DMO: **Ai Gateway Request Model Diagnostic**. Child of
+`GenAIGatewayRequest__dlm`: captures LLM invocation diagnostics (latency,
+status, endpoint, region).
+
+**Cross-org reality check: 0 rows on every sandbox observed.** Checked
+multiple sandboxes with a combined ~400K GatewayRequest rows — every one
+returned 0 GtwyRequestLLM rows. The schema is provisioned everywhere, but
+the writer appears inactive. Treat as aspirational until the feature is
+enabled and populated somewhere we can verify. The join path is declared
+(by analogy with `GenAIGtwyRequestMetadata`) but not live-verified.
+
+**Executable query:** `assets/dc/gateway_request_llm.sql`.
+
+**Join:** `parent__c → GatewayRequest.gatewayRequestId__c` (inferred from schema symmetry with `GenAIGtwyRequestMetadata`; not verifiable until an org populates the table).
+
+| Field | Type | Notes |
+|---|---|---|
+| `id__c` | string (PK) | |
+| `parent__c` | string (FK) | → `GatewayRequest.gatewayRequestId__c` (by analogy) |
+| `endpoint__c` | string | LLM endpoint URL / name |
+| `region__c` | string | Cloud region the call ran in |
+| `genAILLM__c` | string | Model/LLM identifier |
+| `llmCallStatus__c` | string | e.g. success / error |
+| `llmCallLatency__c` | number | Latency of the LLM call |
+| `llmErrorTrace__c` | string | Error trace when the call failed |
+| `metadata__c` | string | JSON — extra diagnostic info |
+| `feature__c` | string | |
+| `salesforceOrgId__c` | string | Note: `salesforceOrgId__c`, not `orgId__c` |
+| `timestamp__c` | datetime | |
+| `cloud__c` | string | |
+
+---
+
+## Agent Optimization DMOs (6)
+
+Provisioned only when **Agent Optimization** is enabled (Enterprise/Performance/
+Unlimited + an Einstein add-on). Extends STDM with moment clustering and LLM-driven
+tag annotations. See: https://help.salesforce.com/s/articleView?id=ai.generative_ai_optimize_data_model.htm&type=5
+
+### `ssot__AiAgentMoment__dlm` — session-level rollup
+
+Carries agent identity.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentSessionId__c` | string (FK) | → Session.Id |
+| `ssot__AiAgentApiName__c` | string | e.g. "MyAgent" |
+| `ssot__AiAgentVersionApiName__c` | string | e.g. "v5" — observed `NOT_SET` in some live samples |
+| `ssot__RequestSummaryText__c` | string | |
+| `ssot__ResponseSummaryText__c` | string | |
+| `ssot__StartTimestamp__c` | string | |
+| `ssot__EndTimestamp__c` | string | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+### `ssot__AiAgentMomentInteraction__dlm` — junction: moment ↔ interactions
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentMomentId__c` | string (FK) | → `Moment.Id` |
+| `ssot__AiAgentInteractionId__c` | string (FK) | → `Interaction.Id` |
+| `ssot__StartTimestamp__c` | datetime | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+### `ssot__AiAgentTagDefinition__dlm` — tag schema / vocabulary
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__DeveloperName__c` | string | |
+| `ssot__Name__c` | string | |
+| `ssot__Description__c` | string | |
+| `ssot__TagIdentifier__c` | string | |
+| `ssot__DataType__c` | string | |
+| `ssot__Status__c` | string | Live enum observed: `Available` (verified via live describe; all sampled rows used this value). Help docs say `Active/Inactive` but no `'Active'` rows exist on tested orgs — query by `'Available'` or omit filter. |
+| `ssot__VersionNumber__c` | number | |
+| `ssot__EngineType__c` | string | LLM engine that applies the tag |
+| `ssot__SourceType__c` | string | |
+| `ssot__SourceTagReferenceName__c` | string | |
+| `ssot__InputScope__c` | string | |
+| `ssot__CreatedDate__c` | datetime | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+### `ssot__AiAgentTagDefinitionAssociation__dlm` — definition ↔ agent binding
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentTagDefinitionId__c` | string (FK) | → `TagDefinition.Id` |
+| `ssot__AiAgentApiName__c` | string | Agent API name this definition binds to |
+| `ssot__AiPromptTemplateId__c` | string | |
+| `ssot__IsActive__c` | boolean | |
+| `ssot__CreatedDate__c` | datetime | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+### `ssot__AiAgentTag__dlm` — tag instance (a specific value under a definition)
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentTagDefinitionId__c` | string (FK) | → `TagDefinition.Id` |
+| `ssot__Value__c` | string | Tag value text |
+| `ssot__Description__c` | string | |
+| `ssot__OrderNumber__c` | number | Display order |
+| `ssot__IsActive__c` | boolean | |
+| `ssot__IsFallback__c` | boolean | True when this tag is the fallback for the definition |
+| `ssot__CreatedDate__c` | datetime | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+### `ssot__AiAgentTagAssociation__dlm` — applied annotation
+
+One row per tag applied to a target. Target is a moment, session, or interaction —
+only one of those FKs is populated per row.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | |
+| `ssot__AiAgentTagId__c` | string (FK) | → `AiAgentTag.Id` — the tag value |
+| `ssot__AiAgentTagDefinitionAssociationId__c` | string (FK) | → `TagDefinitionAssociation.Id` |
+| `ssot__AiAgentMomentId__c` | string (FK) | → `Moment.Id` — populated when target is a moment |
+| `ssot__AiAgentSessionId__c` | string (FK) | → `Session.Id` — populated when target is a session |
+| `ssot__AiAgentInteractionId__c` | string (FK) | → `Interaction.Id` — populated when target is a turn |
+| `ssot__IsPassed__c` | boolean | Pass/fail for evaluation-style tags |
+| `ssot__AssociationReasonText__c` | string | LLM rationale for applying this tag |
+| `ssot__CreatedDate__c` | datetime | |
+| `ssot__InternalOrganizationId__c` | string | |
+
+---
+
+## Agent Platform Tracing DMO (1)
+
+Provisioned only when **Agent Platform Tracing** is enabled (Setup → Einstein
+Audit, Analytics, and Monitoring Setup → Agent Platform Tracing toggle; requires
+Agentforce Session Tracing already on). Captures OpenTelemetry-style spans from
+Apex, Flows, Prompt Builder, Invocable Actions, Planner, AI Gateway, LLM Gateway,
+and DC Query Federator. Data collection runs every 5 minutes.
+
+Joined to STDM via `ssot__TelemetryTrace__c = Interaction.ssot__TelemetryTraceId__c`.
+
+### `ssot__TelemetryTraceSpan__dlm` — one row per span
+
+| Field | Type | Notes |
+|---|---|---|
+| `ssot__Id__c` | string (PK) | Span id |
+| `ssot__TelemetryTrace__c` | string (FK) | → `Interaction.ssot__TelemetryTraceId__c` |
+| `ssot__TelemetryParentSpanId__c` | string | Parent span id (within the same trace); null on root |
+| `ssot__OperationName__c` | string | e.g. `run.interaction`, `run.llmstep`, `run.action.<name>`, `run.invokeActions.<name>`, `run.hybridsearch.<index>` |
+| `ssot__ServiceName__c` | string | e.g. `Atlas Reasoning Engine`, `InvocableAction`, `PromptTemplate`, `Einstein AI Gateway`, `Data Cloud` |
+| `ssot__SpanKind__c` | string | OpenTelemetry span kind |
+| `ssot__StatusCode__c` | string | Execution result |
+| `ssot__StartDateTime__c` | datetime | Span start |
+| `ssot__EndDateTime__c` | datetime | Span end |
+| `ssot__DurationNumber__c` | number | Duration in nanoseconds |
+| `ssot__TelemetrySpanAttributeText__c` | string | JSON key/value span attributes (e.g. `prompt_template.api.name`, `retriever.retrievername`) |
+| `ssot__InternalOrganizationId__c` | string | |
+
+---
+
+## Known enum values (live-API verified)
+
+| DMO | Field | Values |
+|---|---|---|
+| Session | `AiAgentChannelType__c` | `E & O`, `Builder`, `SCRT2 - EmbeddedMessaging`, `Voice`, `NGC` |
+| Participant | `AiAgentType__c` | `DemoAgentType`, `AgentforceEmployeeAgent`, `AgentforceMyAgent` |
+| Participant | `AiAgentSessionParticipantRole__c` | `USER`, `AGENT` |
+| Interaction | `AiAgentInteractionType__c` | `TURN`, `SESSION_END` |
+| Message | `AiAgentInteractionMessageType__c` | `Input`, `Output` |
+| Step | `AiAgentInteractionStepType__c` | `LLM_STEP`, `ACTION_STEP`, `TOPIC_STEP`, `TRUST_GUARDRAILS_STEP`, `SESSION_END` (verified live) |
+| ContentCategory | `detectorType__c` | `TOXICITY`, `PII`, `PROMPT_DEFENSE`, `InstructionAdherence`, `TaskResolution` |
+
+---
+
+## Tooling
+
+DMO queries are executable; one CLI wrapper ships with the skill for
+common operator needs:
+
+| Script | Use case | Args |
+|---|---|---|
+| `scripts/discover_sessions.py` | Find sessions by time / agent / channel / outcome / grep; newest-first picker. | `--org`, optional `--since / --agent / --channel / --outcome / --grep / --tz / --limit` |

--- a/skills/investigating-agentforce-d360/references/dc_pipeline_contract.md
+++ b/skills/investigating-agentforce-d360/references/dc_pipeline_contract.md
@@ -1,0 +1,608 @@
+# DC Pipeline Contract
+
+The DC pipeline for a single Agentforce session runs as three stages in
+sequence:
+
+```
+fetch_dc.py → 24 dc.<name>.json artifacts + dc._session_manifest.json
+assemble_dc.py → dc._session_tree.json (pure in-memory join)
+render_dc.py → dc._session_summary.md (pure tree reader)
+```
+
+Each stage is independently runnable. `fetch_dc.py` chains the two
+downstream stages by default; `--no-assemble` / `--no-render` opt out of
+each. The renderer can also run standalone against a tree produced by a
+prior invocation.
+
+This document owns the shape + invariants of stages 2 and 3. For per-DMO
+field reference of what stage 1 produces, see
+[`dc_dmo_fields.md`](./dc_dmo_fields.md).
+
+---
+
+## 1. Pipeline overview
+
+| Stage | Script | Input | Output | Scope |
+|---|---|---|---|---|
+| Fetch | `scripts/fetch_dc.py` | org + session id | 24 `dc.<name>.json` + `dc._session_manifest.json` | DC Query REST API, 5-wave waterfall |
+| Assemble | `scripts/assemble_dc.py` | fetch outputs | `dc._session_tree.json` | pure in-memory join, no fetches |
+| Render | `scripts/render_dc.py` | tree + manifest | `dc._session_summary.md` | pure tree reader, no DMO loads |
+
+Nothing downstream of fetch issues DC queries. Everything after fetch is
+pure compute over files on disk, which means the renderer can iterate
+on markdown format without re-fetching.
+
+---
+
+## 2. Assembly stage
+
+`scripts/assemble_dc.py` joins the fetched DC rows into a hierarchical
+tree.
+
+### 2.1 Purpose + scope
+
+**Inputs:** 24 `dc.<name>.json` artifacts + `dc._session_manifest.json`
+produced by `scripts/fetch_dc.py`, under `DATA_ROOT/<sid>/`.
+
+**Output:** `dc._session_tree.json` — session-rooted hierarchical view.
+Interaction → Step → Generation → GatewayRequest; audit rows (Tag,
+ObjRecord, Metadata, LLM, Quality, Category, Feedback, FeedbackDetail)
+nested under the right parent.
+
+**Contract:** pure in-memory compute, no new DMO queries, forward-only
+joins on already-fetched rows. Chain-orphan GW calls fall through to a
+timestamp-window rule with an explicit `binding_method` flag.
+
+### 2.2 Inputs
+
+The assembler does **not** hard-code the 24 template names. It reads
+`dc._session_manifest.json` first, then iterates
+`manifest["queries"][*]["name"]` to populate the row map. When
+`fetch_dc.py` adds a 25th template, the row loader picks it up
+automatically — the tree logic only references names it knows how to
+place, so a new DMO is loaded but not rendered until the assembler is
+taught what to do with it.
+
+Per-field schema for every DMO lives in
+[`dc_dmo_fields.md`](./dc_dmo_fields.md).
+
+### 2.3 Declared binding chain
+
+The "normal" path that nests a `GatewayRequest` under its owning
+`LLM_STEP` in the tree. Every edge is a platform-sanctioned forward FK:
+
+```
+Step.ssot__GenerationId__c → Generation.generationId__c
+Generation.generationResponseId__c → GatewayResponse.generationResponseId__c
+GatewayResponse.generationRequestId__c → GatewayRequest.gatewayRequestId__c
+```
+
+**Which Step types populate `ssot__GenerationId__c`?** Only `LLM_STEP`
+(verified live). `ACTION_STEP`, `TOPIC_STEP`, `TRUST_GUARDRAILS_STEP`,
+and `SESSION_END` always have `NOT_SET` here; the chain never resolves
+for them.
+
+**Expected declared-share on typical Agentforce sessions:** minority.
+Most gateway calls on a real session land via the timestamp-window
+fallback, not the declared chain. Sessions that rely on Flow-invoked
+prompt-template actions produce zero declared bindings and many
+timestamp_window bindings — normal, not a defect.
+
+### 2.4 Timestamp-window fallback
+
+Any `GatewayRequest` not reached via the declared chain is placed by
+timestamp containment.
+
+**Window semantics:**
+- **Closed-closed:** `start_ts <= gw_req.timestamp__c <= end_ts`.
+- **Null end_ts** (active session / interaction / step) is treated as
+ `+∞`.
+- **Missing start_ts**: fall through to the next preference tier; never
+ match on start alone.
+- Boundary ties bind to the earlier parent (Step) in preference to the
+ later one (Interaction).
+
+**Tier dominates containment.** Selection order is:
+
+1. Find all Step windows containing the GW timestamp.
+2. Restrict to the highest-preference tier present: `ACTION_STEP` →
+ `TOPIC_STEP` → `TRUST_GUARDRAILS_STEP` → any other (catch-all:
+ LLM_STEP without declared binding, SESSION_END, unknown types —
+ never excluded).
+3. Among those, pick the innermost (shortest-window) Step.
+4. On exact window-size ties, pick the latest `start_ts`.
+
+Example: if both a wide `ACTION_STEP` and a narrower nested `TOPIC_STEP`
+contain the GW timestamp, the `ACTION_STEP` wins because its tier
+dominates — even though TOPIC is innermost.
+
+**Placement fallbacks:**
+- If no Step window matches, attach to the enclosing `Interaction` as a
+ `timestamp_bound_gateway_calls[]` entry (`bound_to_step_id` is null).
+- If no Interaction window matches, land in
+ `session.unbound_gateway_calls[]`.
+
+**Never declared-bound twice.** A Step that already owns a GW via the
+declared chain is excluded from timestamp-window candidates.
+
+### 2.5 `binding_method` enum
+
+Every GatewayRequest in the tree carries exactly one of these:
+
+| Value | When emitted |
+|---|---|
+| `declared` | Placed under a Step via the declared chain in §2.3. |
+| `timestamp_window` | Placed by §2.4 (under a Step or an Interaction). |
+| `unbound` | Neither chain nor window matched; landed in `session.unbound_gateway_calls[]`. |
+
+**Collision handling.** When two Steps' Generation chains resolve to
+the same GatewayRequest (`Step.ssot__GenerationId__c` collisions at the
+upstream DMO), first-step-wins: the earlier Step in walk order claims
+the GW. Subsequent Steps get `"gateway_request": null` with an adjacent
+`"gateway_request_collision": true` marker on the Step view, so readers
+can see why the GW is absent. The session-level
+`counts.gw_binding.declared_collisions` integer tracks the aggregate.
+On observed data this is 0; non-zero values indicate a real defect in
+the upstream DMO writers.
+
+### 2.6 Moment placement
+
+`session.moments[]` lives at the root of the session, not nested under
+`Interaction`. Each moment carries `interaction_ids[]`, a sorted list
+derived from `MomentInteraction` (the junction table). Rationale: the
+schema supports many-to-many (one moment can span multiple
+interactions; one interaction can belong to multiple moments), even
+though observed live data is 1:N. Nesting under Interaction would
+duplicate rows.
+
+Moments are absent on orgs without Agent Optimization enabled; the
+assembler never requires their presence.
+
+### 2.7 1:1 audit chain invariant
+
+For every `GatewayRequest` in the session, exactly one
+`GatewayResponse` exists (in live data, modulo in-flight calls at
+fetch time). `counts.audit_chain_1to1_ok` is `true` iff
+`len(gateway_requests) == len(gateway_responses)`. Drift is flagged in
+the counts block but does not crash the assembler — a caller
+re-fetching during an active session can still produce a partial tree.
+
+Note: this is Req↔Resp 1:1, not Req↔LLM_STEP. The typical session has
+more GatewayRequests than LLM_STEPs because prompt-template /
+plannerservice calls emit GatewayRequest rows without owning Step rows.
+
+### 2.8 `session_shape` enum
+
+Lifted verbatim from `dc._session_manifest.json.session_shape` into
+`dc._session_tree.json counts.session_shape`. Six values, classified
+by `fetch_dc.py` after the 5-wave waterfall; rules evaluated
+top-to-bottom, first match wins:
+
+| Value | Rule | Added |
+|---|---|---|
+| `session_not_found` | `sessions.json` returned 0 rows (bad sid or STDM not yet materialized) | original |
+| `interactions_not_materialized_yet` | sessions row present, but interactions/steps/messages all 0 (fresh session — STDM hierarchy hasn't materialized yet, but gateway_requests may exist) — assembler takes the gateway-direct path; see §2.9 | |
+| `gateway_requests_dropped_by_stdm` | DC `gateway_requests == 0` while runtime telemetry outside Data Cloud confirms ≥1 LLM call for the session — i.e. the STDM exporter has dropped writes the platform did emit. Distinct from `planner_ran_no_gateway_logs` (which means logging disabled at the source). This skill cannot disambiguate this state by itself; the operator must check runtime telemetry to reclassify. | |
+| `abandoned_before_llm` | steps > 0, LLM_STEP count == 0, gw_reqs == 0 (user typed, planner didn't reach an LLM call) | original |
+| `planner_ran_no_gateway_logs` | LLM_STEP > 0 AND steps_with_generation_id > 0 AND gw_reqs == 0 (Trust Layer gateway logging disabled; extra guard prevents misclassification from broken generations-IN clauses) | original |
+| `complete` | everything else (the "normal" bucket, including partial chain-orphan sessions) | original |
+
+The enum names only the operator-actionable states. For finer shape,
+read `counts.gw_binding`: if `declared == 0` but `gateway_requests > 0`,
+the session relied entirely on prompt-template / Flow-invoked LLM
+calls — normal but worth noticing.
+
+`gateway_requests_dropped_by_stdm` is the only shape that this skill
+cannot definitively classify on its own — disambiguating from
+`planner_ran_no_gateway_logs` requires a runtime telemetry probe
+outside Data Cloud. In this skill the session is reported as
+`planner_ran_no_gateway_logs`; the operator with access to the
+platform's runtime LLM-gateway telemetry can check for a matching
+gateway-call event to distinguish a real STDM exporter defect from
+"logging genuinely disabled at the source."
+
+### 2.9 Output: `dc._session_tree.json` schema
+
+Root shape:
+
+```jsonc
+{
+ "session": {
+ "id": "<sid>",
+ "_schema_version": 1, // see §2.9b
+ "identity": { ... }, // see §2.9a
+ "org": { "alias": "...", "instance_url": "..." },
+ "start_ts": "...",
+ "end_ts": null, // null while active
+ "end_type": "Completed | Abandoned | ...",
+ "channel": "...",
+ "participants": [
+ { "participant_id": "...", "role": "USER | AGENT",
+ "agent_api_name": "<null for USER>",
+ "agent_version": "...", "agent_type": "..." }
+ ],
+ "moments": [
+ { "moment_id": "...",
+ "agent_api_name": "...", "agent_version": "...",
+ "request_summary_text": "...", "response_summary_text": "...",
+ "interaction_ids": ["..."], // [] if no bridging rows; never omitted
+ "start_ts": "...", "end_ts": "...",
+ "tag_associations": [ ... ] // moment-scope only
+ }
+ ],
+ "interactions": [
+ {
+ "id": "...", "type": "TURN | SESSION_END", "topic": "...",
+ "trace_id": "...", // primary column or extracted from AttributeText
+ "start_ts": "...", "end_ts": "...",
+ "messages": [
+ { "message_id": "...", "type": "Input | Output",
+ "role": "USER | AGENT", // derived via participant join
+ "participant_id": "...", "text": "...",
+ "content_type": "...", "modality": "...", "ts": "..." }
+ ],
+ "telemetry_spans": [ ... ], // usually []
+ "steps": [
+ {
+ "id": "...",
+ "type": "LLM_STEP | ACTION_STEP | TOPIC_STEP | TRUST_GUARDRAILS_STEP | SESSION_END",
+ "name": "...",
+ "start_ts": "...", "end_ts": "...",
+ "error_text": null, // NOT_SET → null
+ "generation": { // present iff ssot__GenerationId__c != NOT_SET
+ "generation_id": "...",
+ "response_id": "...",
+ "response_text": "...", "masked_response_text": "...",
+ "feature": "...",
+ "quality": [ ... ], // ContentQuality rows parented on generationId__c
+ "categories": [ ... ], // ContentCategory rows parented on generationId__c
+ "feedback": [
+ { "feedback_id": "...", "feedback": "UP | DOWN", "action": "...",
+ "details": [ ... ], "records": [ ... ] }
+ ]
+ },
+ "gateway_request": { // present only when declared chain resolves
+ "binding_method": "declared",
+ "gateway_request_id": "...",
+ "feature": "...", "model": "...", "provider": "...",
+ "prompt_template_dev_name": "...", // "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0,
+ "prompt_text": "...", // raw input prompt
+ "response": { ... },
+ "tags": [ ... ], "records": [ ... ],
+ "metadata": [ ... ], "llm": []
+ },
+ "gateway_request_collision": true // present only when a prior step
+ // claimed this step's declared GW;
+ // gateway_request is null in this case
+ }
+ ],
+ "timestamp_bound_gateway_calls": [ // chain-orphans placed by ts-window
+ { "binding_method": "timestamp_window",
+ "bound_to_step_id": "...", // null if bound to Interaction, not a Step
+ "gateway_request_id": "...", "feature": "...", "model": "...",
+ "response": { ... }, "tags": [...], "records": [...],
+ "metadata": [...], "llm": [] }
+ ],
+ "tag_associations": [ ... ] // interaction-scope only
+ }
+ ],
+ "session_tag_associations": [ ... ], // session-scope only
+ "unbound_gateway_calls": [ // chain-orphans with no window match
+ { "binding_method": "unbound", "gateway_request_id": "...", /* ... */ }
+ ],
+ "counts": {
+ "interactions_total": 0, "interactions_turn": 0, "interactions_session_end": 0,
+ "steps_total": 0,
+ "steps_by_type": { "LLM_STEP": 0, "ACTION_STEP": 0, "TOPIC_STEP": 0,
+ "TRUST_GUARDRAILS_STEP": 0, "SESSION_END": 0 },
+ "generations": 0,
+ "gateway_requests": 0, "gateway_responses": 0,
+ "gateway_metadata": 0, "gateway_llm": 0,
+ "gateway_records_grounded": 0, "gateway_records_feedback": 0,
+ "feedback": 0,
+ "audit_chain_1to1_ok": true,
+ "gw_binding": { "declared": 0, "timestamp_window": 0, "unbound": 0,
+ "declared_collisions": 0 },
+ "session_shape": "complete | abandoned_before_llm | planner_ran_no_gateway_logs | gateway_requests_dropped_by_stdm | interactions_not_materialized_yet | session_not_found",
+ "pk_collisions": [ ], // {dmo, key} records; first-write-wins applied
+ "parse_warnings": [ ] // dc.<name>.json files that failed to parse
+ }
+ },
+ "catalog": { // session-filtered, not full org vocabulary
+ "agents_observed": [ "..." ],
+ "tag_definitions": [ ... ],
+ "tag_definition_associations": [ ... ],
+ "tags": [ ... ]
+ },
+ "_doc": "Assembled from DATA_ROOT/<sid>/dc.*.json. See dc._session_manifest.json."
+}
+```
+
+**Polymorphic dispatch:**
+- `GenAIGtwyObjRecord.parent__c` — if in `gw_req_by_id` → attached as
+ `GatewayRequest.records[]` (grounded attachments); if in
+ `feedback_by_id` → attached as `Feedback.records[]`; else silently
+ dropped.
+- `GenAIContentCategory.parent__c` — if in `generations_by_id` →
+ attached as `Generation.categories[]` (non-TOXICITY detectors); if
+ in `quality_by_id` → nested under the Quality row as
+ `_toxicity_subcategories[]`; else silently dropped.
+- `GenAIAiAgentTagAssociation` — routed by which of the three scope FKs
+ (`SessionId`, `InteractionId`, `MomentId`) is populated. Rows with
+ none are silently dropped.
+
+**Polymorphic dispatch failures are silent by design.** If these id
+spaces collide in future (they don't today — `gatewayRequestId__c`,
+`feedbackId__c`, `generationId__c`, and `quality.id__c` are all
+distinct UUID namespaces), the first-branch-wins behavior records the
+defect nowhere. Revisit if a real org ever shows a cross-namespace id.
+
+#### 2.9a `session.identity` sub-object
+
+Harvested from already-fetched rows. Fields that require values absent
+from every observed DMO row come out as `null`. Every string harvested
+from `tagValue__c` is piped through `html.unescape()` → quote-strip →
+`_clean()` to coerce `""`/`NOT_SET`/`UNSET_VALUE` to `None`.
+
+| Field | Source DMO | Source column / lookup |
+|---|---|---|
+| `org_id` | gateway_requests | `orgId__c`, first non-null after sort |
+| `platform_user_id` | gateway_requests | `userId__c`, first non-null after sort |
+| `planner_id` | gateway_requests | `plannerId__c`, first non-null after sort |
+| `bot_version_id` | gateway_requests | `botVersionId__c`, first non-null after sort |
+| `app_type` | gateway_requests | `appType__c`, first non-null after sort |
+| `bot_id` | gateway_request_tags | `tagValue__c` where `tag__c == "bot_id"` |
+| `bot_name` | gateway_request_tags | `tagValue__c` where `tag__c == "bot_name"` |
+| `agent_api_name` | gateway_request_tags | `tagValue__c` where `tag__c == "agent_developer_name"` (no fallback; MyAgent has no developer-name tag — look at `bot_name` + `agent_label` instead) |
+| `agent_label` | gateway_request_tags | `tagValue__c` where `tag__c == "agent_label"` |
+| `agent_version` | gateway_request_tags | `tagValue__c` where `tag__c == "agent_version_api_name"`, fallback `"version_api_name"` |
+| `agent_type` | gateway_request_tags | `tagValue__c` where `tag__c == "agent_type"` |
+| `planner_name` | gateway_request_tags | `tagValue__c` where `tag__c == "planner_name"` |
+| `planner_type` | gateway_request_tags | `tagValue__c` where `tag__c == "planner_type"` |
+| `configured_model` | gateway_request_tags | `tagValue__c` where `tag__c == "configured_model_name"` |
+| `messaging_session_id` | sessions[0] | `ssot__RelatedMessagingSessionId__c` |
+| `messaging_end_user_id` | participants | `ssot__ParticipantId__c` on the first USER-role row (sorted by `ssot__Id__c`) |
+| `voice_call_id` | sessions[0] | `ssot__RelatedVoiceCallId__c` |
+| `individual_id` | sessions[0] | `ssot__IndividualId__c` |
+| `bootstrap_variables` | sessions[0] | parsed from `ssot__VariableText__c` — channel-specific bootstrap key→value dict (e.g. `__resolved_locale__`, `__supports_result_display__`); empty `{}` when the column is null/empty/unparseable |
+| `mode` | derived | one of `production_messaging` / `builder_previewer` / `voice` / `unknown` — derived from `(channel, RelatedMessagingSessionId__c, RelatedVoiceCallId__c, bootstrap_variables.keys)`. See `_derive_mode` + `_BUILDER_PREVIEWER_INDICATOR_KEYS` in `assemble_dc.py`. |
+
+**Sorting (required for idempotence):**
+- `gateway_requests` — sort by `(timestamp__c, gatewayRequestId__c)`
+ ascending, then take first non-null.
+- `gateway_request_tags` — sort by `(parent__c, tag__c, tagValue__c)`
+ ascending, then filter by tag name and take first non-null.
+- `participants` — sort by `ssot__Id__c` ascending, then take the first
+ USER-role row.
+- `sessions[0]` — by contract, one row per session; no sort needed.
+
+**Trimmed fields:** `user_location`, `user_context` are not promoted
+(low debugging value, opaque without a decoder ring).
+
+**Minimal tree exclusion.** The session-not-found short-circuit path
+(§2.11) does **not** emit an `identity` sub-object — identity
+harvesters need non-empty gateway rows, which are guaranteed empty in
+this branch. Renderer's minimal branch handles absent identity
+gracefully.
+
+#### 2.9b `session._schema_version`
+
+Current value: `1`. Emitted on both the full tree and the minimal
+session-not-found tree. Additive changes (new sub-objects, new fields)
+do NOT bump this. Breaking changes (rename or remove a top-level key,
+change the shape of `interactions[]`, etc.) bump it.
+
+Renderer refuses to render a tree with an incompatible version; see
+§3.10.
+
+### 2.10 Idempotence
+
+Running the assembler N times on the same `DATA_ROOT/<sid>/` produces
+a byte-identical `dc._session_tree.json`. Rules:
+
+- Arrays sort by source timestamp ascending; on ties, by primary-key
+ string.
+- Any set-derived array (`agents_observed`, `interaction_ids[]`, etc.)
+ is emitted via `sorted(...)` before serialization.
+- `json.dumps(..., sort_keys=True)` for all dict output.
+- Identity harvest uses the explicit sort keys in §2.9a for
+ first-non-null picks.
+- Verified on the live test fixture: `diff` of two runs returns empty.
+
+### 2.11 Session-not-found short-circuit
+
+If `sessions.json` returned 0 rows, the assembler writes a minimal
+tree with only `session.id`, `session.org`,
+`session._schema_version: 1`, and
+`counts.session_shape = "session_not_found"`. No `identity`, no
+`interactions[]`, no `catalog{}`.
+
+---
+
+## 3. Render stage
+
+`scripts/render_dc.py` turns `dc._session_tree.json` into a human
+markdown file.
+
+### 3.1 Purpose + scope
+
+**Input:** `dc._session_tree.json` + `dc._session_manifest.json` (the
+latter only for the Empties diagnostics section).
+
+**Output:** `dc._session_summary.md` — 11 top-level sections, with `Session bootstrap` and `Planner LLM calls` conditionally suppressed (see §3.3).
+
+**Contract:** pure tree reader. No DMO loads. No fetches. Everything
+the renderer displays either lives directly on `tree.session.*` or is
+composed from tree fields in the renderer's presentation layer.
+
+### 3.2 Inputs
+
+- `dc._session_tree.json` — primary input. Renderer SystemExits with a
+ clear "tree not found" message if absent.
+- `dc._session_manifest.json` — consulted for the Empties diagnostics
+ section. If absent, that section renders empty.
+
+The 24 raw `dc.<name>.json` artifacts are NOT loaded by the renderer.
+
+### 3.3 Output: section order
+
+The full-tree branch emits these top-level sections in order. The
+gateway-direct branch (§2.8 `interactions_not_materialized_yet`) and
+the minimal session-not-found branch use abbreviated section sets;
+see `_render_gateway_direct` / `_render_minimal` in `render_dc.py`.
+
+1. `## Session identity` — identity fields from `tree.session.identity`
+ plus display-only cells (Agent, Total duration) composed in-renderer.
+2. `## Session bootstrap` — channel mode + bootstrap variables
+ (`identity.mode`, `identity.bootstrap_variables`).to make MIAW vs Builder Previewer distinguishable
+ at-a-glance — `ssot__AiAgentChannelType__c` alone collides between
+ the two. Section is suppressed (not rendered) when both `mode` and
+ `bootstrap_variables` are absent — backwards-compat with older
+ trees.
+3. `## ID reference` — full UUIDs for everything truncated in the
+ hierarchical trace.
+4. `## Transcript` — USER ↔ AGENT narrative per TURN interaction.
+ SESSION_END interactions have no messages and are skipped.
+5. `## Complete hierarchical trace` — Interaction → Step → Generation →
+ GatewayRequest, with `+start + duration = +end` math on Interaction
+ and Step lines. Single timestamps on Generation and GatewayRequest
+ (no computed latencies; see §3.6). UUIDs truncated to 8 chars + `…`;
+ full forms in §2 above.
+6. `## Per-turn summary` — one row per interaction.
+7. `## Planner LLM calls (full prompts + responses)` — **opt-in via
+ `--show-prompts`; suppressed by default**.. Walks `interactions[].steps[]`, builds one
+ `#### LLM call N — <short-id>` block per step that has a
+ `gateway_request`. Renders the full input prompt (from
+ `gateway_request.prompt_text`) and full response (from
+ `generation.response_text`, HTML-unescaped) inside fenced code
+ blocks. Per-payload display capped at 64 KB; full payloads always
+ remain authoritative on disk in `dc.gateway_requests.json` /
+ `dc.generations.json`. Off by default because multi-turn sessions
+ with 30 KB+ prompts would dominate the summary.
+8. `## Visual analysis` — gantt + LLM-call overlay.
+9. `## Session counts` — engineer-facing table of manifest counts.
+10. `## Empties diagnostics` — one row per DMO with `rows == 0` and a
+ populated `_unavailable_reason` lifted verbatim from the manifest.
+11. `## Catalog (session-filtered)` — TagDefinitions /
+ TagDefinitionAssociations / Tags filtered to agents observed in the
+ session.
+
+DC alone does not expose per-turn LLM latency in a useful form, so this
+skill emits no `## Latency rollups` section. Generation and
+GatewayRequest carry single-write timestamps (see §3.6); they are not
+start/end pairs.
+
+### 3.4 Ellipsis rule
+
+In the `## Complete hierarchical trace`:
+
+- All UUIDs (interaction_id, step_id, generation_id,
+ gateway_request_id) render as the first 8 characters followed by `…`.
+- Full UUIDs live in the `## ID reference` table above, keyed by the
+ same 8-char prefix.
+
+This keeps the trace scannable while preserving the ability to
+cross-reference by ID.
+
+### 3.5 Session-end derivation
+
+`session.end_ts` can be null for two reasons:
+
+1. The session is still active.
+2. The session ended but STDM hasn't materialized the `end_ts` column
+ yet.
+
+Renderer display rule: if `session.end_ts` is non-null, render it
+directly with `✓ materialized` suffix. If null, look at the last
+interaction by timestamp:
+
+- If a SESSION_END interaction exists, use its `start_ts` as the
+ derived end with `from SESSION_END interaction` suffix.
+- Otherwise, use the last TURN interaction's `end_ts` (or `start_ts`
+ if its end is null) with `session still open (last TURN)` suffix.
+
+The derivation is display-only; the tree's `session.end_ts` is not
+modified.
+
+### 3.6 Why we don't compute latencies on generation/gateway_request
+
+`Generation.timestamp__c` and `GatewayRequest.timestamp__c` are
+single timestamps representing when the DC row was written. They are
+NOT `start_ts`/`end_ts` pairs. Treating the delta between two of them
+as a "latency" is misleading — the gap reflects how DC serialized the
+audit, not how long the LLM call took.
+
+Interaction and Step DMOs DO expose start_ts + end_ts pairs; the
+renderer computes `+offset + duration = +end` math for those.
+
+### 3.7 Empties diagnostics
+
+Walk `manifest["queries"]` for entries with `rows == 0` and a
+populated `_unavailable_reason`. Render each as a row:
+`| <dmo_name> | <rows> | <verbatim reason> |`. The renderer does not
+infer reasons.
+
+Artifacts that failed to parse go into `tree.counts.parse_warnings` and
+surface in the `## Session counts` section, not here.
+
+### 3.8 Idempotence
+
+Running `render_dc.py --session <sid>` N times on the same
+`dc._session_tree.json` produces a byte-identical
+`dc._session_summary.md`. Rules:
+
+- All section builders walk tree arrays in the order the tree provides
+ them; the tree itself is already sorted.
+- No timestamps of "now" embedded in the output.
+- No set-derived ordering; any set-to-list conversion goes through
+ `sorted(...)`.
+- Verified on the live test fixture: `diff` of two runs returns empty.
+
+### 3.9 Session-not-found short-path
+
+If the tree has `_schema_version: 1` but no `interactions[]` key, the
+renderer emits a minimal markdown file:
+
+```markdown
+# Session <sid>
+
+## Session identity
+
+| Field | Value |
+|---|---|
+| Session id | <sid> |
+| Session shape | session_not_found |
+
+_No interactions resolved in Data Cloud. Check the session id, or
+wait for STDM materialization._
+```
+
+No transcript, no trace, no counts, no catalog.
+
+### 3.10 Tree schema version check
+
+First check in `main_for_session()`:
+
+- `tree.session._schema_version == 1` → render.
+- `tree.session._schema_version` missing → stderr WARN, render anyway
+ (treat as best-effort for older trees).
+- Any other value → `SystemExit("render_dc: unsupported tree
+ _schema_version=<v>; expected 1")`. Refuses rather than risking a
+ silent schema mismatch.
+
+---
+
+## 4. Reading order for a new skill author
+
+1. Read this file (contract).
+2. Run the pipeline once against a fresh session: `python3
+ scripts/fetch_dc.py --session <sid> --org <alias>`. Inspect
+ `DATA_ROOT/<sid>/` — you get the 24 `dc.<name>.json`, the manifest,
+ the tree, and the summary.
+3. Open `dc._session_tree.json` and trace the declared chain for one
+ LLM_STEP end-to-end.
+4. Read the matching `dc._session_summary.md`.
+5. Read `scripts/assemble_dc.py` (module docstring points back here),
+ then `scripts/render_dc.py`.
+6. Cross-reference [`dc_dmo_fields.md`](./dc_dmo_fields.md) when you
+ hit a field whose origin is unclear.

--- a/skills/investigating-agentforce-d360/scripts/_shared/__init__.py
+++ b/skills/investigating-agentforce-d360/scripts/_shared/__init__.py
@@ -1,0 +1,2 @@
+# Shared module for the investigating-agentforce-d360 skill.
+# Three siblings live in this package: paths, fs_guard, sql.

--- a/skills/investigating-agentforce-d360/scripts/_shared/fs_guard.py
+++ b/skills/investigating-agentforce-d360/scripts/_shared/fs_guard.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+r"""Filesystem-safety and input-validation guard.
+
+One script, six check types. Emits a STATUS=INVALID_INPUT RESULT block on
+failure + tees to $ERROR_TEE on disk + exits 1.
+
+Guiding principle: the agent MUST suffix every call with `|| exit 1` — Python
+`sys.exit(1)` only terminates this subprocess, not the parent bash. A bare
+call without `|| exit 1` silently continues past a failed guard, which is
+the worst possible failure mode for a security check.
+
+Check types:
+    symlink     — path must NOT be a symlink (rejects pre-planted attacker bait)
+    owned       — path must be owned by current UID (rejects foreign-owned dirs)
+    uuid          — value must match ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
+    org_id_15     — value must match ^[A-Za-z0-9]{15}$ (Salesforce org ID slice)
+    api_name      — value must match ^[A-Za-z0-9_]+$ (Salesforce API identifier)
+    api_version   — value must match ^v[0-9]+\.[0-9]+$ (e.g. v60.0)
+    agent_version — value must match ^v[0-9]+$ (e.g. v5 — Agentforce agent version, no dot-minor)
+    not_empty     — value must be non-empty string
+
+Python-importable API:
+    validate_api_name(value, label="...")      — raises ValidationError on bad input
+    validate_api_version(value, label="...")   — raises ValidationError on bad input
+    validate_agent_version(value, label="...") — raises ValidationError on bad input
+    validate_org_id_15(value, label="...")     — raises ValidationError on bad input
+    ValidationError                            — carries (label, reason)
+
+The Python API is used by in-process callers (SOQL loader, path builders in
+config.py) that need a raise-based boundary rather than the process-exit
+CLI behavior. Regex is shared — do NOT duplicate API_NAME_RE / API_VERSION_RE.
+
+Usage:
+    python3 fs_guard.py <value> <label> <check> || exit 1
+
+    # Input validation
+    python3 fs_guard.py "$AGENT_API_NAME" agent_api_name api_name || exit 1
+    python3 fs_guard.py "$ORG_ALIAS"      org_alias      not_empty || exit 1
+
+    # Filesystem safety
+    python3 fs_guard.py "$WORK_DIR"  WORK_DIR  symlink || exit 1
+    python3 fs_guard.py "$WORK_DIR"  WORK_DIR  owned   || exit 1
+    python3 fs_guard.py "$ORG_ID_15" ORG_ID_15 org_id_15 || exit 1
+
+Inputs:
+    argv[1]     value or path to check
+    argv[2]     label (appears in ERROR_DETAIL; used to identify which guard tripped)
+    argv[3]     check type (one of the 6 above)
+    env         $ERROR_TEE (optional): path to disk-tee file. Defaults to
+                $HOME/.claude/data/investigating-agentforce-d360/_last_error_result.txt.
+                Also reads $AGENT_API_NAME / $ORG_ID_18 / $ORG_ID_15 for
+                RESULT-block context if set.
+
+Outputs:
+    on failure: STATUS=INVALID_INPUT RESULT block on stdout + tee to disk, exit 1
+    on success: silent, exit 0
+    on bad argv: exit 1 with a minimal ERROR_DETAIL ("fs_guard internal: ...")
+"""
+import os
+import pathlib
+import re
+import sys
+
+# Anchored \A...\Z (not ^...$) — Python's `$` matches before a trailing
+# newline, so "00DTESTORG12345\n" passes ^...$ + .match(). Every call
+# site below MUST use .fullmatch() for the same reason; .match() is
+# unsafe even with \A...\Z anchors. Mirrors the pattern in
+# _shared/paths.py SESSION_ID_RE.
+UUID_RE = re.compile(r"\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+ORG_ID_15_RE = re.compile(r"\A[A-Za-z0-9]{15}\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+API_NAME_RE = re.compile(r"\A[A-Za-z0-9_]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+# P0-5: api_version check — matches `v60.0`, `v66.0`, etc. Used before any
+# Path composition that embeds the api_version segment.
+API_VERSION_RE = re.compile(r"\Av[0-9]+\.[0-9]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+# Agent-version check — matches Agentforce version identifiers (`v1`, `v5`,
+# `v12`). Deliberately stricter than api_name (rejects free-form names like
+# `release_1`) and looser than api_version (rejects `v66.0` which is a REST
+# API version, never an agent version). Lives on its own so callers that
+# embed agent_version in a filesystem path get the tight regex, not the
+# permissive api_name fallback.
+AGENT_VERSION_RE = re.compile(r"\Av[0-9]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+VALID_CHECKS = {"symlink", "owned", "uuid", "org_id_15", "api_name", "api_version", "agent_version", "not_empty"}
+
+
+# -----------------------------------------------------------------------------
+# Python-importable API (P0-1, P0-5)
+# -----------------------------------------------------------------------------
+# In-process callers (soql_loader.load_soql, config.build_*_dir) need a
+# raise-based validation boundary, distinct from the CLI script's exit-1
+# behavior. The regexes are shared with the CLI checks above — do NOT
+# duplicate. If a regex changes, both surfaces update in lockstep.
+
+
+class ValidationError(ValueError):
+    """Raised by the Python-importable validators on bad input.
+
+    Carries the label (which field failed) + reason. Callers (e.g.
+    soql_loader.load_soql) convert this into `_unresolved[]` entries or
+    RESULT-level INVALID_INPUT responses as appropriate.
+    """
+
+    def __init__(self, label: str, reason: str) -> None:
+        self.label = label
+        self.reason = reason
+        super().__init__(f"{label}: {reason}")
+
+
+def validate_api_name(value, label: str = "value") -> None:
+    """Validate `value` against ^[A-Za-z0-9_]+$ (Salesforce API identifier).
+
+    P0-1: used by soql_loader.load_soql at the substitution boundary to catch
+    injection attempts in names pulled from Bot XML, Flow.Metadata, ApexClass
+    SymbolTable, etc.
+
+    P0-5: used by config.build_*_dir helpers for path components that must
+    not contain `..`, `/`, or other traversal characters.
+
+    Raises ValidationError on any of: None, non-string, empty, regex miss.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not API_NAME_RE.fullmatch(value):
+        # Preview first 20 chars so logs/_unresolved entries carry enough
+        # context to debug, without dumping an unbounded attacker-controlled
+        # string into output.
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match [A-Za-z0-9_]+ (preview={preview!r})",
+        )
+
+
+def validate_api_version(value, label: str = "api_version") -> None:
+    """Validate `value` against ^v[0-9]+\\.[0-9]+$ (Salesforce API version).
+
+    P0-5: used by config.build_*_dir helpers. api_version is returned by
+    `sf org display` and later embedded in cache paths; reject anything that
+    could escape the cache subtree.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not API_VERSION_RE.fullmatch(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match v<major>.<minor> (preview={preview!r})",
+        )
+
+
+def validate_agent_version(value, label: str = "agent_version") -> None:
+    """Validate `value` against ^v[0-9]+$ (Agentforce agent version).
+
+    Strictly `v<digits>` with no dot-minor — matches the shape Agentforce
+    actually uses (`v1`, `v5`, `v12`). Rejects `release_1`, `v66.0`, `FOO`,
+    and anything else that could silently slip past a permissive api_name
+    check and land in a filesystem path.
+
+    P0-5: used by path-builder helpers for the agent_version segment.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not AGENT_VERSION_RE.fullmatch(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"does not match v<digits> (preview={preview!r})",
+        )
+
+
+def validate_org_id_15(value, label: str = "org_id_15") -> None:
+    """Validate `value` against ^[A-Za-z0-9]{15}$ (Salesforce 15-char org ID).
+
+    P0-5: stricter than validate_api_name — enforces exact 15 chars AND
+    no underscores. `org_id_15` always comes from a Salesforce-generated
+    field, never from free-form input.
+    """
+    if value is None:
+        raise ValidationError(label, "is None")
+    if not isinstance(value, str):
+        raise ValidationError(label, f"must be str, got {type(value).__name__}")
+    if not value:
+        raise ValidationError(label, "must not be empty")
+    if not ORG_ID_15_RE.fullmatch(value):
+        preview = value[:20]
+        raise ValidationError(
+            label,
+            f"must be exactly 15 alphanumeric chars (preview={preview!r})",
+        )
+
+
+def scrub(s: str) -> str:
+    # Same rules as sanitize.py; duplicated locally so this script has no
+    # intra-skill imports. Keeps the agent-script boundary clean.
+    bad = set("`$\"\\\r\t\0\n")
+    return "".join(c for c in (s or "") if c not in bad)
+
+
+def emit_failure(reason: str, label: str) -> None:
+    agent_api_name = scrub(os.environ.get("AGENT_API_NAME", ""))
+    org_id_18 = scrub(os.environ.get("ORG_ID_18", ""))
+    org_id_15 = scrub(os.environ.get("ORG_ID_15", ""))
+    label_safe = scrub(label)
+    reason_safe = scrub(reason)
+
+    block = (
+        "=== RESULT ===\n"
+        "STATUS=INVALID_INPUT\n"
+        f"ERROR_DETAIL={label_safe}: {reason_safe}\n"
+        f"AGENT_API_NAME={agent_api_name}\n"
+        f"ORG_ID_18={org_id_18}\n"
+        f"ORG_ID_15={org_id_15}\n"
+    )
+
+    # Default ERROR_TEE lives under the skill-scoped data root.
+    tee_default = str(
+        pathlib.Path.home()
+        / ".claude"
+        / "data"
+        / "investigating-agentforce-d360"
+        / "_last_error_result.txt"
+    )
+    tee_path = os.environ.get("ERROR_TEE") or tee_default
+    try:
+        p = pathlib.Path(tee_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(block)
+    except OSError:
+        pass
+
+    sys.stdout.write(block)
+    sys.exit(1)
+
+
+def check_symlink(value: str, label: str) -> None:
+    if pathlib.Path(value).is_symlink():
+        emit_failure(f"path is a symlink (refusing to follow): {value}", label)
+
+
+def check_owned(value: str, label: str) -> None:
+    p = pathlib.Path(value)
+    if not p.exists():
+        return
+    try:
+        st = p.stat()
+    except OSError as e:
+        emit_failure(f"stat failed: {e}", label)
+        return
+    if st.st_uid != os.getuid():
+        emit_failure(f"foreign-owned (uid {st.st_uid} != current {os.getuid()}): {value}", label)
+
+
+def check_uuid(value: str, label: str) -> None:
+    if not UUID_RE.fullmatch(value):
+        emit_failure("does not match UUID pattern (8-4-4-4-12 lowercase hex)", label)
+
+
+def check_org_id_15(value: str, label: str) -> None:
+    if not ORG_ID_15_RE.fullmatch(value):
+        emit_failure("must be exactly 15 alphanumeric characters", label)
+
+
+def check_api_name(value: str, label: str) -> None:
+    if not API_NAME_RE.fullmatch(value):
+        emit_failure("does not match [A-Za-z0-9_]+ (Salesforce API name rules)", label)
+
+
+def check_api_version(value: str, label: str) -> None:
+    # P0-5: api_version must be `vNN.N` — no slashes, no dots beyond the one,
+    # no path-traversal sequences.
+    if not API_VERSION_RE.fullmatch(value):
+        emit_failure("does not match v<major>.<minor> (e.g. v60.0)", label)
+
+
+def check_agent_version(value: str, label: str) -> None:
+    # Agent version must be `v<digits>` — no dots, no slashes.
+    if not AGENT_VERSION_RE.fullmatch(value):
+        emit_failure("does not match v<digits> (e.g. v5)", label)
+
+
+def check_not_empty(value: str, label: str) -> None:
+    if not value:
+        emit_failure("must not be empty", label)
+
+
+CHECKS = {
+    "symlink": check_symlink,
+    "owned": check_owned,
+    "uuid": check_uuid,
+    "org_id_15": check_org_id_15,
+    "api_name": check_api_name,
+    "api_version": check_api_version,
+    "agent_version": check_agent_version,
+    "not_empty": check_not_empty,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stdout.write(
+            "=== RESULT ===\n"
+            "STATUS=INVALID_INPUT\n"
+            "ERROR_DETAIL=fs_guard internal: wrong argv count (need value, label, check)\n"
+        )
+        return 1
+    value, label, check = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    for arg in (value, label, check):
+        if any(c == "\0" or (ord(c) < 0x20 and c not in "\t\n") for c in arg):
+            emit_failure("argv contains control characters", label or "argv")
+
+    if check not in VALID_CHECKS:
+        emit_failure(f"unknown check type '{check}' (valid: {', '.join(sorted(VALID_CHECKS))})", label)
+
+    CHECKS[check](value, label)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-d360/scripts/_shared/paths.py
+++ b/skills/investigating-agentforce-d360/scripts/_shared/paths.py
@@ -1,0 +1,151 @@
+"""Canonical path helpers for investigating-agentforce-d360.
+
+Layout:
+
+    ~/.claude/data/investigating-agentforce-d360/
+    └── <org_id_15>/
+        └── <agent_api_name>__<agent_version>/
+            └── <session_id>/                          ← per-session DC artifacts
+                ├── dc.*.json
+                ├── dc._session_manifest.json
+                ├── dc._session_tree.json
+                └── dc._session_summary.md
+
+Validation strategy
+-------------------
+The three "agent-identity" segments (org_id_15, agent_api_name, agent_version)
+are validated by the regex helpers in the sibling ``fs_guard`` module. Any
+segment containing ``..``, ``/``, or characters outside its regex charclass
+raises ``PathValidationError`` — direct ``Path`` composition from unvalidated
+input would be a path-traversal vulnerability and is prohibited.
+
+``session_id`` is validated locally via ``SESSION_ID_RE.fullmatch`` because
+fs_guard's ``api_name`` rule is too permissive for it (session IDs can contain
+hyphens, which API names cannot). The regex is fully anchored (``\\A...\\Z``)
+and call sites MUST use ``fullmatch`` — ``match`` would silently accept a
+traversal suffix like ``abc\\n../etc``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import fs_guard
+
+
+# -----------------------------------------------------------------------------
+# Roots
+# -----------------------------------------------------------------------------
+
+DATA_ROOT: Path = Path.home() / ".claude" / "data" / "investigating-agentforce-d360"
+CACHE_ROOT: Path = Path.home() / ".claude" / "cache" / "investigating-agentforce-d360"
+
+
+# -----------------------------------------------------------------------------
+# Session-ID validation
+# -----------------------------------------------------------------------------
+
+# Fully anchored — call sites MUST use fullmatch (tested). Characters allowed:
+# alphanumeric + underscore + hyphen, matching both UUIDs and MessagingSession
+# IDs.
+SESSION_ID_RE = re.compile(r"\A[A-Za-z0-9_\-]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+
+
+class PathValidationError(ValueError):
+    """Raised when a path segment fails validation.
+
+    Wraps fs_guard's ``ValidationError`` as well as local ``session_id``
+    rejections so callers have a single exception type to catch.
+    """
+
+    def __init__(self, label: str, reason: str) -> None:
+        self.label = label
+        self.reason = reason
+        super().__init__(f"{label}: {reason}")
+
+
+# -----------------------------------------------------------------------------
+# Validation helpers
+# -----------------------------------------------------------------------------
+
+
+def _validate_agent_triple(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> None:
+    """Validate the three identity segments. Raises PathValidationError on
+    failure, wrapping fs_guard's ValidationError so callers don't need to
+    know about fs_guard internals."""
+    try:
+        fs_guard.validate_org_id_15(org_id_15, label="org_id_15")
+        fs_guard.validate_api_name(agent_api_name, label="agent_api_name")
+        fs_guard.validate_agent_version(agent_version, label="agent_version")
+    except fs_guard.ValidationError as e:
+        raise PathValidationError(e.label, e.reason) from e
+
+
+def validate_session_id(session_id: str) -> None:
+    """Validate session_id via SESSION_ID_RE.fullmatch.
+
+    Raises :class:`PathValidationError` on any of: None, non-string, empty,
+    regex miss. This is the public validator every caller that composes a
+    Path segment from a session-id MUST go through — direct
+    ``Path / session_id`` composition bypasses the anchored-regex check.
+    """
+    if session_id is None:
+        raise PathValidationError("session_id", "is None")
+    if not isinstance(session_id, str):
+        raise PathValidationError(
+            "session_id", f"must be str, got {type(session_id).__name__}"
+        )
+    if not session_id:
+        raise PathValidationError("session_id", "must not be empty")
+    if not SESSION_ID_RE.fullmatch(session_id):
+        preview = session_id[:40]
+        raise PathValidationError(
+            "session_id",
+            f"does not match {SESSION_ID_RE.pattern} (preview={preview!r})",
+        )
+
+
+_validate_session_id = validate_session_id  # backward-compat alias
+
+
+# -----------------------------------------------------------------------------
+# Path builders
+# -----------------------------------------------------------------------------
+
+
+def agent_dir(
+    org_id_15: str, agent_api_name: str, agent_version: str
+) -> Path:
+    """Return ``DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/``.
+
+    All three segments are regex-validated before being joined. Any segment
+    containing ``..``, ``/``, or characters outside its regex charclass
+    raises ``PathValidationError``.
+    """
+    _validate_agent_triple(org_id_15, agent_api_name, agent_version)
+    return DATA_ROOT / org_id_15 / f"{agent_api_name}__{agent_version}"
+
+
+def session_dir(
+    org_id_15: str,
+    agent_api_name: str,
+    agent_version: str,
+    session_id: str,
+) -> Path:
+    """Return
+    ``DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/<session_id>/``.
+
+    All four segments are validated. The first three go through fs_guard;
+    ``session_id`` goes through ``SESSION_ID_RE.fullmatch``. Any rejection
+    raises ``PathValidationError``.
+    """
+    _validate_agent_triple(org_id_15, agent_api_name, agent_version)
+    validate_session_id(session_id)
+    return (
+        DATA_ROOT
+        / org_id_15
+        / f"{agent_api_name}__{agent_version}"
+        / session_id
+    )

--- a/skills/investigating-agentforce-d360/scripts/_shared/sql.py
+++ b/skills/investigating-agentforce-d360/scripts/_shared/sql.py
@@ -1,0 +1,14 @@
+"""Canonical SQL-escaping helpers for investigating-agentforce-d360.
+
+Single source of truth for DC-SQL string-literal escaping. Behavioral contract
+is fixed — do not change the escape strategy without updating every caller and
+its tests.
+"""
+from __future__ import annotations
+
+
+def _escape_sql_literal(s: str) -> str:
+    """Double single quotes per DC SQL escaping rule. Handles O'Brien →
+    O''Brien, `'; DROP --` → `''; DROP --` (still harmless because it's
+    wrapped in surrounding single quotes)."""
+    return s.replace("'", "''")

--- a/skills/investigating-agentforce-d360/scripts/assemble_dc.py
+++ b/skills/investigating-agentforce-d360/scripts/assemble_dc.py
@@ -1,0 +1,1621 @@
+"""Assemble dc._session_tree.json from fetched DC artifacts.
+
+Given `DATA_ROOT/<sid>/dc.*.json` + `dc._session_manifest.json` (produced by
+`scripts/fetch_dc.py`), this module joins the rows in memory and emits:
+
+  - dc._session_tree.json    — session-rooted hierarchical view
+                                (Interaction → Step → Generation →
+                                GatewayRequest, with audit rows nested)
+
+The human-readable markdown summary is produced by a separate stage,
+`scripts/render_dc.py`, which reads only the tree.
+
+Design contract (see references/dc_pipeline_contract.md):
+
+  - No DMO fetches. Pure in-memory compute over already-fetched artifacts.
+  - Driven off `manifest["queries"][*]["name"]` — adding a 25th DMO to
+    fetch_dc.py doesn't require changes here (it just won't be placed in
+    the tree until the logic is extended).
+  - Declared binding chain nests GatewayRequest under LLM_STEP via
+    `Step.ssot__GenerationId__c → Generation → GatewayResponse → Request`.
+  - Chain-orphan GW calls fall through to a timestamp-window rule
+    (tier dominates: ACTION → TOPIC → TRUST_GUARDRAILS → any other;
+    innermost Step wins within a tier).
+  - PK collisions and parse warnings surface in `counts.*`, not stderr-only.
+
+Invocation:
+    python3 scripts/assemble_dc.py --session <sid>
+"""
+from __future__ import annotations
+
+import argparse
+import functools
+import html
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import DATA_ROOT, paths
+
+
+# ---- sentinels + constants -------------------------------------------------
+
+_NOT_SET = {"", "NOT_SET", None}
+_INTERNAL_TRACE_RE = re.compile(r'"internalTraceId":"([a-f0-9]+)"')  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+
+# Real, non-placeholder agent version. Matches the canonical `^v[0-9]+$`
+# shape that paths.session_dir requires AND excludes the `v0` placeholder
+# stamped by fetch_dc's MyAgent fallback (fetch_dc.py:570-597).
+# Used by `_promote_identity` to decide whether session_identity carries
+# a richer agent_version that should win over a manifest placeholder.
+_REAL_VERSION_RE = re.compile(r'^v[0-9]+$')  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+
+# Tier order for timestamp-window fallback. "any other" is an implicit last-resort
+# catch-all covering LLM_STEP (without declared binding), SESSION_END, and any
+# future step types not explicitly listed.
+_TIER_ORDER = ("ACTION_STEP", "TOPIC_STEP", "TRUST_GUARDRAILS_STEP")
+
+# Canonical identity-field name → ordered list of `gateway_request_tags.tag__c`
+# values that carry it, tried in order. Agent versions emit different tag
+# names: newer Atlas ReAct agents use `agent_developer_name` /
+# `agent_version_api_name`; legacy MyAgent builds omit the developer
+# name entirely and use the unprefixed `version_api_name`. First non-null
+# value wins. A single-element list means "no fallback known."
+_TAG_KEY_ALIASES: Dict[str, Tuple[str, ...]] = {
+    "agent_api_name": ("agent_developer_name",),
+    "agent_version": ("agent_version_api_name", "version_api_name"),
+}
+
+
+# ---- typed namespaces ------------------------------------------------------
+#
+# Four frozen dataclasses replace the former dict-bags. frozen=True guards
+# attribute re-assignment, not mutation of the dict values themselves — the
+# producers are responsible for handing in plain dicts (not defaultdicts) so
+# downstream helpers don't rely on auto-creation the type doesn't promise.
+
+@dataclass(frozen=True)
+class Indexes:
+    interactions_by_id: Dict[str, dict]
+    participants_by_id: Dict[str, dict]
+    generations_by_id: Dict[str, dict]
+    gw_req_by_id: Dict[str, dict]
+    gw_resp_by_resp_id: Dict[str, dict]
+    feedback_by_id: Dict[str, dict]
+    gw_resp_by_req_id: Dict[str, List[dict]]
+    steps_by_interaction: Dict[str, List[dict]]
+    messages_by_interaction: Dict[str, List[dict]]
+    gw_tags_by_parent: Dict[str, List[dict]]
+    gw_md_by_parent: Dict[str, List[dict]]
+    gw_llm_by_parent: Dict[str, List[dict]]
+    quality_by_parent: Dict[str, List[dict]]
+    quality_by_id: Dict[str, dict]
+    feedback_by_gen: Dict[str, List[dict]]
+    feedback_details_by_parent: Dict[str, List[dict]]
+    participant_role_by_id: Dict[str, Optional[str]]
+
+
+@dataclass(frozen=True)
+class PolymorphicSplits:
+    categories_by_generation: Dict[str, List[dict]]
+    categories_by_quality: Dict[str, List[dict]]
+    gw_records_by_gw_req: Dict[str, List[dict]]
+    gw_records_by_feedback: Dict[str, List[dict]]
+    tag_assoc_session: List[dict]
+    tag_assoc_by_interaction: Dict[str, List[dict]]
+    tag_assoc_by_moment: Dict[str, List[dict]]
+
+
+@dataclass(frozen=True)
+class BindingResults:
+    declared_gw_ids: Set[str]
+    declared_steps_with_gw: frozenset
+    step_id_to_gw_id: Dict[str, Optional[str]]
+    declared_collisions: int
+
+
+@dataclass(frozen=True)
+class Catalog:
+    agents_observed: List[str]
+    tag_definitions: List[dict]
+    tag_definition_associations: List[dict]
+    tags: List[dict]
+
+
+@dataclass
+class BinderCtx:
+    """Per-interaction scratch state used only by the timestamp-window pass.
+
+    Kept in a parallel `Dict[iid, BinderCtx]` instead of stashed on the
+    interaction view, so binder state can never leak into the emitted tree.
+    """
+    start_ts: Optional[datetime]
+    end_ts: Optional[datetime]
+    steps_with_ts: List[Tuple[dict, Optional[datetime], Optional[datetime]]]
+    reserved_step_ids: frozenset
+
+
+# ---- session-dir resolution ----------------------------------------------
+
+def _find_session_dir(sid: str) -> Path:
+    """Locate the session dir under the nested layout.
+
+    Given only a session id, we don't know ``(org, agent, version)`` upfront.
+    Strategy:
+
+    1. Validate ``sid`` against ``paths.SESSION_ID_RE`` at entry. ``sid`` comes
+       in via argv / resolve_session and flows directly into path composition
+       (``<org>/_sessions/<sid>.link``) and glob patterns; an unvalidated
+       value here would undo the traversal guard added in PR #657 BLOCKER-2.
+    2. Breadcrumb lookup: ``DATA_ROOT/<org>/_sessions/<sid>.link`` is a plain-
+       text relative-path pointer written by ``storage.save``. Iterate all
+       orgs, read each ``.link``, resolve against the breadcrumb's parent,
+       and **enforce containment** — a tampered or stale breadcrumb whose
+       target escapes ``DATA_ROOT`` is skipped (not raised) so a single
+       malicious breadcrumb can't DoS the whole resolver. Falls through to
+       the glob fallback on any breadcrumb miss.
+    3. Glob fallback: ``DATA_ROOT/*/*/<sid>/`` — ``sid`` is now validated at
+       entry so the pattern is fixed-depth and cannot glob outside its
+       intended 2-level subtree.
+    4. Raise ``SystemExit`` with a clear hint to run fetch_dc.py first.
+
+    Returns the absolute directory path.
+    """
+    # Validate first — rejects "../etc", "a/b", "", None, and control chars.
+    # ``sid`` from here on is safe to use as a path segment and as the tail
+    # of a fixed-depth glob.
+    paths.validate_session_id(sid)
+    root = paths.DATA_ROOT
+    if root.is_dir():
+        # Resolve DATA_ROOT once so containment checks don't repeat the walk.
+        root_resolved = root.resolve()
+        for org_dir in root.iterdir():
+            if not org_dir.is_dir():
+                continue
+            link = org_dir / "_sessions" / f"{sid}.link"
+            if link.is_file():
+                try:
+                    rel = link.read_text().strip()
+                except OSError:
+                    continue
+                # Resolve relative to the breadcrumb's parent (_sessions/),
+                # then enforce that the resolved path stays inside
+                # DATA_ROOT. ``.link`` contents are user-writable — a planted
+                # breadcrumb with ``../../../../etc/passwd`` must NOT pivot
+                # the assembler outside the plugin's data tree.
+                target = (link.parent / rel).resolve()
+                if not target.is_relative_to(root_resolved):
+                    # Stale or malicious breadcrumb. Skip — fall through to
+                    # the glob fallback rather than raising, so one bad
+                    # breadcrumb in one org doesn't block discovery in
+                    # another.
+                    continue
+                if target.is_dir():
+                    return target
+        # Glob fallback. ``sid`` is validated; the pattern is fixed-depth.
+        matches = list(root.glob(f"*/*/{sid}"))
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            # Placeholder agent dirs (leading-underscore name like
+            # ``<org>/_agent_<botid>__v0/``) mark provisional sessions
+            # whose identity wasn't fully resolved at first write. When a
+            # real (agent, version) dir also exists for the same session,
+            # it's the authoritative home; the placeholder is stale.
+            # Prefer the real dir.
+            real = [p for p in matches if not p.parent.name.startswith("_")]
+            if len(real) == 1:
+                return real[0]
+            raise SystemExit(
+                f"assemble_dc: session {sid} resolves to {len(matches)} dirs "
+                f"under {root} — ambiguous. Check for duplicate sessions "
+                f"across agents."
+            )
+    raise SystemExit(
+        f"assemble_dc: session dir for {sid} not found under {root}; "
+        f"run fetch_dc.py first"
+    )
+
+
+# ---- loaders ---------------------------------------------------------------
+
+def _load(session_dir: Path, name: str, parse_warnings: List[str]) -> List[dict]:
+    """Load dc.<name>.json from session_dir. Missing → []. Malformed → [] + warning."""
+    p = session_dir / f"dc.{name}.json"
+    if not p.is_file():
+        return []
+    try:
+        return json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"assemble_dc: WARN dc.{name}.json unreadable: {str(e).splitlines()[0]}",
+              file=sys.stderr)
+        parse_warnings.append(name)
+        return []
+
+
+def _load_manifest(session_dir: Path) -> dict:
+    p = session_dir / "dc._session_manifest.json"
+    if not p.is_file():
+        raise SystemExit(
+            f"assemble_dc: manifest not found at {p}; run fetch_dc.py first"
+        )
+    manifest = json.loads(p.read_text())
+    if "queries" not in manifest:
+        raise SystemExit("assemble_dc: manifest schema changed — no 'queries' key")
+    return manifest
+
+
+def _load_all(sid: str) -> Tuple[dict, Dict[str, List[dict]], List[str], Path]:
+    """Return (manifest, rows_by_name, parse_warnings, session_dir).
+
+    Iterates manifest["queries"][*]["name"] rather than a hard-coded list —
+    a new DMO added to fetch_dc.py is picked up automatically.
+    """
+    session_dir = _find_session_dir(sid)
+    manifest = _load_manifest(session_dir)
+    parse_warnings: List[str] = []
+    rows = {
+        q["name"]: _load(session_dir, q["name"], parse_warnings)
+        for q in manifest["queries"]
+    }
+    return manifest, rows, parse_warnings, session_dir
+
+
+# ---- small helpers ---------------------------------------------------------
+
+def _clean(value: Any) -> Any:
+    """NOT_SET sentinel → None. Other values pass through."""
+    return None if value in _NOT_SET else value
+
+
+def _harvest_str(value: Any) -> Optional[str]:
+    """Harvest-layer string normalizer for the session-identity block.
+
+    Handles three quirks that `_clean` deliberately does not:
+    1. **html.unescape** — tag values arrive double-escaped
+       (`"&quot;0Xx…&quot;"`).
+    2. **Quote-strip** — after unescape most tag values are wrapped in
+       literal `"` characters; strip them.
+    3. **`UNSET_VALUE` sentinel** — Data Cloud emits this on a small set
+       of optional columns (e.g. `gateway_requests.promptTemplateVersionNo__c`,
+       certain `tag_first` values on cold-start sessions). Not observed
+       on the columns `_build_session_identity` currently reads, but
+       included defensively since the sentinel is part of the DC schema
+       contract and a harvest-layer reader should collapse it to None.
+
+    The binding / index layer uses `_clean()` / `_NOT_SET` which
+    intentionally omits these rules — they would be noise there.
+    """
+    if value is None:
+        return None
+    s = html.unescape(str(value)).strip()
+    if len(s) >= 2 and s.startswith('"') and s.endswith('"'):
+        s = s[1:-1]
+    return None if s in ("", "NOT_SET", "UNSET_VALUE") else s
+
+
+def _promote_identity(
+    manifest_value: Any,
+    session_identity_value: Any,
+    *,
+    kind: Literal["api_name", "version"],
+) -> Any:
+    """Pick the richer of (manifest, session_identity) for a top-level identity slot.
+
+    Background. ``fetch_dc._resolve_identity`` walks AGENT-role participant
+    rows for ``(api_name, version)``. On agent shapes like MyAgent the
+    AGENT rows can leave both fields NOT_SET, so the resolver falls back
+    (fetch_dc.py:570-597) to picking ``api_name`` from any participant row
+    and stamping ``version="v0"`` as a placeholder satisfying
+    ``paths.session_dir``'s ``^v[0-9]+$`` shape. The placeholder is enough
+    to land the session in a directory, but it's wrong: by wave 5 the
+    fetch has materialized ``gateway_request_tags`` rows carrying the real
+    ``agent_version_api_name`` (e.g. ``v24``), and ``_build_session_identity``
+    correctly harvests it onto ``session.identity``. The top-level
+    ``identity`` block was previously copied verbatim from the manifest,
+    so the placeholder leaked downstream while the right value sat
+    visible in the same JSON.
+
+    Policy:
+
+    - ``kind="version"``: if manifest is the ``"v0"`` placeholder AND
+      session_identity carries a non-``v0`` value matching ``^v[0-9]+$``,
+      promote. Otherwise keep manifest.
+    - ``kind="api_name"``: if manifest is NOT_SET-ish (None / "" / "NOT_SET"
+      / "NOT SET") AND session_identity has a real value, promote.
+      Otherwise keep manifest. (Crucially, when session_identity is None
+      and manifest has a value, we keep manifest — the strict AGENT-row
+      pick is intentional on healthy sessions.)
+    - When manifest and session_identity both carry real-but-disagreeing
+      values, the manifest wins. The strict AGENT-row pick is the
+      authoritative source on a normal session; we only promote in the
+      narrow case where the manifest carries a known placeholder /
+      NOT_SET sentinel and the harvest layer has something better.
+    """
+    if kind == "version":
+        if manifest_value != "v0":
+            return manifest_value
+        if not isinstance(session_identity_value, str):
+            return manifest_value
+        if session_identity_value == "v0":
+            return manifest_value
+        if not _REAL_VERSION_RE.match(session_identity_value):
+            return manifest_value
+        return session_identity_value
+    # kind == "api_name"
+    if manifest_value not in (None, "", "NOT_SET", "NOT SET"):
+        return manifest_value
+    if isinstance(session_identity_value, str) and session_identity_value:
+        return session_identity_value
+    return manifest_value
+
+
+def _reconcile_top_identity(
+    manifest: dict, session_identity: dict, org_id_15: Any,
+) -> dict:
+    """Build the top-level ``identity`` block, promoting placeholders.
+
+    Centralizes the policy in one place so the happy path
+    (`_assemble_session`) and the gateway-direct fallback don't drift
+    apart. Emits a stderr note when promotion fires so an investigator
+    sees the divergence at run time.
+    """
+    manifest_api = manifest.get("agent_api_name")
+    manifest_ver = manifest.get("agent_version")
+    session_api = session_identity.get("agent_api_name")
+    session_ver = session_identity.get("agent_version")
+
+    promoted_api = _promote_identity(manifest_api, session_api, kind="api_name")
+    promoted_ver = _promote_identity(manifest_ver, session_ver, kind="version")
+
+    if promoted_api != manifest_api:
+        print(
+            f"assemble_dc: identity promoted: agent_api_name "
+            f"{manifest_api!r} -> {promoted_api!r} (from session.identity)",
+            file=sys.stderr,
+        )
+    if promoted_ver != manifest_ver:
+        print(
+            f"assemble_dc: identity promoted: agent_version "
+            f"{manifest_ver} -> {promoted_ver} (from session.identity)",
+            file=sys.stderr,
+        )
+
+    return {
+        "org_id_15": org_id_15,
+        "agent_api_name": promoted_api,
+        "agent_version": promoted_ver,
+    }
+
+
+def _resolve_end_type(session_row: dict, rows: dict) -> Optional[str]:
+    """Resolve the session's terminal outcome with a Session→Step fallback.
+
+    Session DMO's ``ssot__AiAgentSessionEndType__c`` is authoritative when
+    populated, but on Messaging-channel and short E&O sessions it stays
+    ``NOT_SET`` even after the SESSION_END interaction has materialized.
+    The runtime writes the actual outcome (``CLOSED_USER_REQUEST``,
+    ``USER_ENDED``, ``ESCALATED``, ``TRANSFERRED``, ``TIMEOUT``) onto the
+    SESSION_END step's ``ssot__Name__c`` instead. Fall through to that
+    step when Session.EndType is missing, so the rendered summary stops
+    saying "session end not yet materialized in STDM" for sessions that
+    actually completed cleanly.
+    """
+    primary = _clean(session_row.get("ssot__AiAgentSessionEndType__c"))
+    if primary:
+        return primary
+    for step in rows.get("steps", []) or ():
+        if step.get("ssot__AiAgentInteractionStepType__c") == "SESSION_END":
+            name = _clean(step.get("ssot__Name__c"))
+            if name:
+                return name
+    return None
+
+
+def _ts(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp. NOT_SET / non-string → None (unbounded)."""
+    if not isinstance(value, str) or value in _NOT_SET:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _index_unique(rows: Iterable[dict], key: str,
+                  collisions: List[dict], dmo_label: str) -> Dict[str, dict]:
+    """Build a {key_value: row} dict. On collision: first-write-wins + record."""
+    out: Dict[str, dict] = {}
+    for r in rows:
+        k = r.get(key)
+        if k in _NOT_SET:
+            continue
+        if k in out:
+            collisions.append({"dmo": dmo_label, "key": k})
+        else:
+            out[k] = r
+    return out
+
+
+def _groupby(rows: Iterable[dict], key: str) -> Dict[str, List[dict]]:
+    out: Dict[str, List[dict]] = defaultdict(list)
+    for r in rows:
+        k = r.get(key)
+        if k not in _NOT_SET:
+            out[k].append(r)
+    return dict(out)
+
+
+def _extract_trace_id(interaction: dict) -> Optional[str]:
+    """Prefer the primary column; fall back to AttributeText regex."""
+    tid = interaction.get("ssot__TelemetryTraceId__c")
+    if tid and tid not in _NOT_SET:
+        return tid
+    attr = interaction.get("ssot__AttributeText__c") or ""
+    if not attr:
+        return None
+    m = _INTERNAL_TRACE_RE.search(html.unescape(attr))
+    return m.group(1) if m else None
+
+
+# ---- declared binding chain ------------------------------------------------
+
+def _declared_gw_for_step(step: dict,
+                          generations_by_id: Dict[str, dict],
+                          gw_resp_by_resp_id: Dict[str, dict],
+                          gw_req_by_id: Dict[str, dict]) -> Optional[dict]:
+    """Step → Generation → Response → Request. Returns the GatewayRequest row or None."""
+    gen_id = step.get("ssot__GenerationId__c")
+    if gen_id in _NOT_SET:
+        return None
+    gen = generations_by_id.get(gen_id)
+    if not gen:
+        return None
+    resp_id = gen.get("generationResponseId__c")
+    if resp_id in _NOT_SET:
+        return None
+    resp = gw_resp_by_resp_id.get(resp_id)
+    if not resp:
+        return None
+    req_id = resp.get("generationRequestId__c")
+    if req_id in _NOT_SET:
+        return None
+    return gw_req_by_id.get(req_id)
+
+
+# ---- timestamp-window fallback --------------------------------------------
+
+def _tier(step_type: str) -> int:
+    """Lower is better. 0 = ACTION, 1 = TOPIC, 2 = GUARDRAIL, 3 = any other."""
+    try:
+        return _TIER_ORDER.index(step_type)
+    except ValueError:
+        return len(_TIER_ORDER)  # "any other"
+
+
+def _window_contains(gw_ts: datetime, start: Optional[datetime],
+                     end: Optional[datetime]) -> bool:
+    """Closed-closed containment. None end_ts → +∞. Missing start → no match."""
+    if start is None:
+        return False
+    if gw_ts < start:
+        return False
+    if end is None:
+        return True  # open-ended upward
+    return gw_ts <= end
+
+
+def _bind_ts_window(gw_req: dict,
+                    steps_with_ts: List[Tuple[dict, datetime, Optional[datetime]]],
+                    interaction_window: Tuple[Optional[datetime], Optional[datetime]],
+                    reserved_step_ids: "frozenset[str]") -> Tuple[str, Optional[str]]:
+    """Return (placement, bound_step_id).
+
+    placement ∈ {"step", "interaction", "unbound"}.
+    bound_step_id is set only when placement == "step".
+    """
+    gw_ts_raw = gw_req.get("timestamp__c")
+    gw_ts = _ts(gw_ts_raw)
+    if gw_ts is None:
+        return ("unbound", None)
+
+    # Step candidates: contains gw_ts AND not already declared-bound.
+    candidates = [
+        (step, start, end)
+        for step, start, end in steps_with_ts
+        if step["ssot__Id__c"] not in reserved_step_ids
+           and _window_contains(gw_ts, start, end)
+    ]
+    if candidates:
+        # Best tier → innermost (shortest window) → latest start_ts.
+        def sort_key(c):
+            step, start, end = c
+            tier = _tier(step.get("ssot__AiAgentInteractionStepType__c", ""))
+            # Window size; treat None end_ts as "longest" (so nested closed wins).
+            if end is None:
+                width = float("inf")
+            else:
+                width = (end - start).total_seconds()
+            # Invert latest-start-wins by negating seconds since epoch.
+            return (tier, width, -start.timestamp())
+        candidates.sort(key=sort_key)
+        winner = candidates[0][0]
+        return ("step", winner["ssot__Id__c"])
+
+    # Interaction window.
+    i_start, i_end = interaction_window
+    if _window_contains(gw_ts, i_start, i_end):
+        return ("interaction", None)
+    return ("unbound", None)
+
+
+# ---- gateway-request view builder -----------------------------------------
+
+def _build_gw_view(gw_req: dict, binding_method: str, *,
+                   idx: Indexes, dispatch: PolymorphicSplits,
+                   bound_step_id: Optional[str] = None) -> dict:
+    """Build one GatewayRequest view row.
+
+    `idx` and `dispatch` are kw-only so `functools.partial(_build_gw_view,
+    idx=..., dispatch=...)` bindings don't collide with positional args at
+    the 3 call sites (declared / timestamp_window / unbound).
+    """
+    gw_id = gw_req["gatewayRequestId__c"]
+    responses = idx.gw_resp_by_req_id.get(gw_id, [])
+    view: Dict[str, Any] = {
+        "binding_method": binding_method,
+        "gateway_request_id": gw_id,
+        "feature": _clean(gw_req.get("feature__c")),
+        "model": _clean(gw_req.get("model__c")),
+        "provider": _clean(gw_req.get("provider__c")),
+        "prompt_template_dev_name": _clean(gw_req.get("promptTemplateDevName__c")),
+        "prompt_tokens": gw_req.get("promptTokens__c"),
+        "completion_tokens": gw_req.get("completionTokens__c"),
+        "total_tokens": gw_req.get("totalTokens__c"),
+        # Carry the raw input prompt through the hierarchical view so the
+        # renderer can surface it in the opt-in "Planner LLM calls" section.
+        # The 64 KB display cap lives in render_dc, not here — the tree
+        # stores the authoritative payload.
+        "prompt_text": gw_req.get("prompt__c"),
+        "response": responses[0] if responses else None,
+        "tags": idx.gw_tags_by_parent.get(gw_id, []),
+        "records": dispatch.gw_records_by_gw_req.get(gw_id, []),
+        "metadata": idx.gw_md_by_parent.get(gw_id, []),
+        "llm": idx.gw_llm_by_parent.get(gw_id, []),
+    }
+    if bound_step_id is not None:
+        view["bound_to_step_id"] = bound_step_id
+    return view
+
+
+# ---- main assembly ---------------------------------------------------------
+
+def _build_indexes(rows: Dict[str, List[dict]], collisions: List[dict]) -> Indexes:
+    """Build all primary-key dicts and groupby tables. Returns a frozen Indexes."""
+    return Indexes(
+        interactions_by_id=_index_unique(
+            rows.get("interactions", []), "ssot__Id__c", collisions, "interactions_by_id"),
+        participants_by_id=_index_unique(
+            rows.get("participants", []), "ssot__Id__c", collisions, "participants_by_id"),
+        generations_by_id=_index_unique(
+            rows.get("generations", []), "generationId__c", collisions, "generations_by_id"),
+        gw_req_by_id=_index_unique(
+            rows.get("gateway_requests", []), "gatewayRequestId__c", collisions, "gw_req_by_id"),
+        gw_resp_by_resp_id=_index_unique(
+            rows.get("gateway_responses", []), "generationResponseId__c",
+            collisions, "gw_resp_by_resp_id"),
+        feedback_by_id=_index_unique(
+            rows.get("feedback", []), "feedbackId__c", collisions, "feedback_by_id"),
+        gw_resp_by_req_id=_groupby(rows.get("gateway_responses", []), "generationRequestId__c"),
+        steps_by_interaction=_groupby(rows.get("steps", []), "ssot__AiAgentInteractionId__c"),
+        messages_by_interaction=_groupby(rows.get("messages", []), "ssot__AiAgentInteractionId__c"),
+        gw_tags_by_parent=_groupby(rows.get("gateway_request_tags", []), "parent__c"),
+        gw_md_by_parent=_groupby(rows.get("gateway_request_metadata", []), "parent__c"),
+        gw_llm_by_parent=_groupby(rows.get("gateway_request_llm", []), "parent__c"),
+        quality_by_parent=_groupby(rows.get("content_quality", []), "parent__c"),
+        quality_by_id={q["id__c"]: q for q in rows.get("content_quality", []) if q.get("id__c")},
+        feedback_by_gen=_groupby(rows.get("feedback", []), "generationId__c"),
+        feedback_details_by_parent=_groupby(rows.get("feedback_details", []), "parent__c"),
+        participant_role_by_id={
+            p["ssot__Id__c"]: p.get("ssot__AiAgentSessionParticipantRole__c")
+            for p in rows.get("participants", []) if p.get("ssot__Id__c")
+        },
+    )
+
+
+def _dispatch_polymorphic(rows: Dict[str, List[dict]], idx: Indexes) -> PolymorphicSplits:
+    """Split ContentCategory, GtwyObjRecord, and TagAssociation by polymorphic parent.
+
+    Producers accumulate into defaultdicts for ergonomics, but the returned
+    dataclass stores plain dicts — frozen `Dict[...]` typing can't promise
+    auto-creation, so don't let it leak.
+    """
+    # ContentCategory: parent is either a generation or a quality row.
+    cat_by_gen: Dict[str, List[dict]] = defaultdict(list)
+    cat_by_qual: Dict[str, List[dict]] = defaultdict(list)
+    for cat in rows.get("content_category", []):
+        parent = cat.get("parent__c")
+        if parent in _NOT_SET:
+            continue
+        if parent in idx.generations_by_id:
+            cat_by_gen[parent].append(cat)
+        elif parent in idx.quality_by_id:
+            cat_by_qual[parent].append(cat)
+
+    # GtwyObjRecord: parent is either a gateway_request or a feedback row.
+    rec_by_gw: Dict[str, List[dict]] = defaultdict(list)
+    rec_by_fb: Dict[str, List[dict]] = defaultdict(list)
+    for rec in rows.get("gateway_records", []):
+        parent = rec.get("parent__c")
+        if parent in _NOT_SET:
+            continue
+        if parent in idx.gw_req_by_id:
+            rec_by_gw[parent].append(rec)
+        elif parent in idx.feedback_by_id:
+            rec_by_fb[parent].append(rec)
+
+    # TagAssociation: exactly one of session/interaction/moment FK is populated.
+    ta_session: List[dict] = []
+    ta_by_int: Dict[str, List[dict]] = defaultdict(list)
+    ta_by_mom: Dict[str, List[dict]] = defaultdict(list)
+    for ta in rows.get("tag_associations", []):
+        if ta.get("ssot__AiAgentSessionId__c") not in _NOT_SET:
+            ta_session.append(ta)
+        elif ta.get("ssot__AiAgentInteractionId__c") not in _NOT_SET:
+            ta_by_int[ta["ssot__AiAgentInteractionId__c"]].append(ta)
+        elif ta.get("ssot__AiAgentMomentId__c") not in _NOT_SET:
+            ta_by_mom[ta["ssot__AiAgentMomentId__c"]].append(ta)
+
+    return PolymorphicSplits(
+        categories_by_generation=dict(cat_by_gen),
+        categories_by_quality=dict(cat_by_qual),
+        gw_records_by_gw_req=dict(rec_by_gw),
+        gw_records_by_feedback=dict(rec_by_fb),
+        tag_assoc_session=ta_session,
+        tag_assoc_by_interaction=dict(ta_by_int),
+        tag_assoc_by_moment=dict(ta_by_mom),
+    )
+
+
+def _filter_catalog(rows: Dict[str, List[dict]]) -> Catalog:
+    """Filter org-wide tag vocabulary to only what's reachable from session agents."""
+    agents = {
+        p.get("ssot__AiAgentApiName__c") for p in rows.get("participants", [])
+        if p.get("ssot__AiAgentSessionParticipantRole__c") == "AGENT"
+           and p.get("ssot__AiAgentApiName__c") not in _NOT_SET
+    } | {
+        m.get("ssot__AiAgentApiName__c") for m in rows.get("moments", [])
+        if m.get("ssot__AiAgentApiName__c") not in _NOT_SET
+    }
+    # Mirror fetch_dc._resolve_identity's USER-row fallback. On agent shapes
+    # like MyAgent, AGENT-role rows leave api_name=NOT_SET while USER
+    # rows correctly carry the agent's api_name. Without this fallback, the
+    # session lands in a `<api_name>__v0/` directory but `agents_observed`
+    # is empty — directory and rendered catalog disagree. Only fires when the
+    # primary (AGENT + moments) sources turned up nothing usable; in normal
+    # sessions the USER and AGENT rows agree and the union is idempotent.
+    if not agents:
+        agents = {
+            p.get("ssot__AiAgentApiName__c") for p in rows.get("participants", [])
+            if p.get("ssot__AiAgentApiName__c") not in _NOT_SET
+        }
+    agents_observed = sorted(a for a in agents if a)
+    relevant_assocs = [
+        a for a in rows.get("tag_definition_associations", [])
+        if a.get("ssot__AiAgentApiName__c") in agents_observed
+    ]
+    relevant_def_ids = {
+        a["ssot__AiAgentTagDefinitionId__c"] for a in relevant_assocs
+        if a.get("ssot__AiAgentTagDefinitionId__c") not in _NOT_SET
+    }
+    return Catalog(
+        agents_observed=agents_observed,
+        tag_definitions=[d for d in rows.get("tag_definitions", [])
+                         if d.get("ssot__Id__c") in relevant_def_ids],
+        tag_definition_associations=relevant_assocs,
+        tags=[t for t in rows.get("tags", [])
+              if t.get("ssot__AiAgentTagDefinitionId__c") in relevant_def_ids],
+    )
+
+
+def _build_session_identity(rows: Dict[str, List[dict]], manifest: dict) -> dict:
+    """Harvest 18 identity fields from 4 DMOs for the `session.identity` block.
+
+    All row iteration is preceded by a deterministic sort so repeated runs
+    produce byte-identical output regardless of fetch order. `_harvest_str()` is
+    the shared normalizer — html.unescape + quote-strip + NOT_SET /
+    UNSET_VALUE / empty coercion. See references/dc_pipeline_contract.md
+    §2.9a for the field-to-column mapping.
+    """
+    # --- gateway_requests: sort by (timestamp__c, gatewayRequestId__c) ---
+    gwr_sorted = sorted(
+        rows.get("gateway_requests", []),
+        key=lambda r: (r.get("timestamp__c") or "",
+                       r.get("gatewayRequestId__c") or ""),
+    )
+
+    def _first_gwr(key: str) -> Optional[str]:
+        for r in gwr_sorted:
+            v = _harvest_str(r.get(key))
+            if v is not None:
+                return v
+        return None
+
+    org_id = _first_gwr("orgId__c")
+    platform_user_id = _first_gwr("userId__c")
+    planner_id = _first_gwr("plannerId__c")
+    bot_version_id = _first_gwr("botVersionId__c")
+    app_type = _first_gwr("appType__c")
+
+    # --- gateway_request_tags: sort by (parent__c, tag__c, tagValue__c) ---
+    tags_sorted = sorted(
+        rows.get("gateway_request_tags", []),
+        key=lambda r: (r.get("parent__c") or "",
+                       r.get("tag__c") or "",
+                       r.get("tagValue__c") or ""),
+    )
+    tag_first: Dict[str, Optional[str]] = {}
+    for t in tags_sorted:
+        k = t.get("tag__c")
+        if not k or k in tag_first:
+            continue
+        tag_first[k] = _harvest_str(t.get("tagValue__c"))
+
+    # --- sessions[0] — always exactly one row per session on this path ---
+    sessions = rows.get("sessions", [])
+    session_row = sessions[0] if sessions else {}
+
+    # --- participants: first USER-role row by ssot__Id__c ---
+    participants_sorted = sorted(
+        rows.get("participants", []),
+        key=lambda r: r.get("ssot__Id__c") or "",
+    )
+    messaging_end_user_id = None
+    for p in participants_sorted:
+        if p.get("ssot__AiAgentSessionParticipantRole__c") == "USER":
+            v = _harvest_str(p.get("ssot__ParticipantId__c"))
+            if v is not None:
+                messaging_end_user_id = v
+                break
+
+    def _aliased(identity_key: str) -> Optional[str]:
+        """Resolve an identity field via its tag-name fallback chain.
+
+        Parameter name intentionally avoids shadowing `dataclasses.field`.
+        """
+        for tag_key in _TAG_KEY_ALIASES[identity_key]:
+            v = tag_first.get(tag_key)
+            if v is not None:
+                return v
+        return None
+
+    # Expose VariableText__c bootstrap variables. Production messaging
+    # sessions leave this NOT_SET; Builder Previewer populates it with
+    # test-harness keys (__resolved_locale__, __supports_result_display__,
+    # etc.). Surfacing this is what makes channel-mode visible in the
+    # renderer.
+    messaging_session_id = _harvest_str(session_row.get("ssot__RelatedMessagingSessionId__c"))
+    voice_call_id = _harvest_str(session_row.get("ssot__RelatedVoiceCallId__c"))
+    bootstrap_variables = _parse_bootstrap_variables(
+        session_row.get("ssot__VariableText__c")
+    )
+
+    # Derive a `mode` field. ssot__AiAgentChannelType__c is identical for
+    # MIAW production and Builder Previewer (`SCRT2 - EmbeddedMessaging`);
+    # we have to look at related-id population and bootstrap_variables to
+    # tell them apart.
+    mode = _derive_mode(messaging_session_id, voice_call_id, bootstrap_variables)
+
+    # `voice_call_id` + `individual_id` are null on EmbeddedMessaging sessions.
+    # They populate on authenticated channels (voice, Experience Cloud with
+    # linked Individual). Kept for schema parallelism with messaging_session_id.
+    return {
+        "org_id": org_id,
+        "platform_user_id": platform_user_id,
+        "planner_id": planner_id,
+        "bot_version_id": bot_version_id,
+        "app_type": app_type,
+        "bot_id": tag_first.get("bot_id"),
+        "bot_name": tag_first.get("bot_name"),
+        "agent_api_name": _aliased("agent_api_name"),
+        "agent_label": tag_first.get("agent_label"),
+        "agent_version": _aliased("agent_version"),
+        "agent_type": tag_first.get("agent_type"),
+        "planner_name": tag_first.get("planner_name"),
+        "planner_type": tag_first.get("planner_type"),
+        "configured_model": tag_first.get("configured_model_name"),
+        "messaging_session_id": messaging_session_id,
+        "messaging_end_user_id": messaging_end_user_id,
+        "voice_call_id": voice_call_id,
+        "individual_id": _harvest_str(session_row.get("ssot__IndividualId__c")),
+        "bootstrap_variables": bootstrap_variables,
+        "mode": mode,
+    }
+
+
+# Test-harness bootstrap keys that are observed in Builder Previewer sessions
+# but NOT in MIAW production. The presence of any of these in
+# `ssot__VariableText__c` is the strongest at-rest signal that a session was
+# run through the Previewer rather than against a real customer messaging
+# session. Listed here as a frozenset so it's read-only at module level.
+# Builder Previewer adds these keys to ssot__VariableText__c at session
+# bootstrap; MIAW production sessions don't seed them. Used by _derive_mode
+# to distinguish previewer runs from real customer messaging sessions.
+_BUILDER_PREVIEWER_INDICATOR_KEYS: frozenset[str] = frozenset({
+    "__resolved_locale__",
+    "__locale_instruction__",
+    "__supports_result_display__",
+    "__show_tool_results_invoked__",
+})
+
+
+def _parse_bootstrap_variables(raw: Any) -> Optional[dict]:
+    """Parse `ssot__VariableText__c` defensively.
+
+    On real sessions this field can be:
+      - missing / None / NOT_SET / UNSET_VALUE         → returns None
+      - well-formed JSON (Builder Previewer)            → returns the dict
+      - HTML-entity-encoded JSON (some surfaces emit
+        the `&quot;`-escaped form)                      → unescaped, returns the dict
+      - truncated or malformed JSON                     → returns
+        `{"_parse_error": True, "_raw": <first 200 chars>}` so the renderer
+        can still flag that a bootstrap exists, just not parseable.
+
+    Returns None for the empty cases so the caller can treat None as
+    "no bootstrap" without distinguishing missing from sentinel.
+    """
+    if raw is None:
+        return None
+    s = html.unescape(str(raw)).strip()
+    if not s or s in _NOT_SET or s in ("NOT_SET", "UNSET_VALUE"):
+        return None
+    try:
+        parsed = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return {"_parse_error": True, "_raw": s[:200]}
+    # Defensive: VariableText__c is documented as a JSON object; if a future
+    # version emits a JSON array or scalar, surface it under `_raw` rather
+    # than letting downstream code crash on `.get()`.
+    if not isinstance(parsed, dict):
+        return {"_parse_error": True, "_raw": s[:200]}
+    return parsed
+
+
+def _derive_mode(
+    messaging_session_id: Optional[str],
+    voice_call_id: Optional[str],
+    bootstrap_variables: Optional[dict],
+) -> str:
+    """Distinguish MIAW production from Builder Previewer from voice.
+
+    `ssot__AiAgentChannelType__c` is identical (`SCRT2 - EmbeddedMessaging`)
+    for MIAW and Builder Previewer — useless for distinguishing them. The
+    real signals, in priority order:
+
+    1. `ssot__RelatedVoiceCallId__c` set ↔ voice channel.
+    2. `ssot__RelatedMessagingSessionId__c` set ↔ MIAW production
+       (a real MessagingSession record exists).
+    3. `RelatedMessagingSessionId__c` NOT_SET AND bootstrap_variables
+       contains test-harness keys ↔ Builder Previewer.
+    4. None of the above ↔ unknown (e.g. headless API runs, agent script
+       previewer cases that don't seed VariableText__c).
+
+    Return a stable enum string the renderer can match on.
+    """
+    if voice_call_id:
+        return "voice"
+    if messaging_session_id:
+        return "production_messaging"
+    if isinstance(bootstrap_variables, dict):
+        if set(bootstrap_variables) & _BUILDER_PREVIEWER_INDICATOR_KEYS:
+            return "builder_previewer"
+    return "unknown"
+
+
+def _declared_binding_pass(rows: Dict[str, List[dict]], idx: Indexes) -> BindingResults:
+    """Walk every step; claim GWs reachable via the declared chain.
+
+    Returns BindingResults(declared_gw_ids, declared_steps_with_gw,
+    step_id_to_gw_id, declared_collisions). `declared_steps_with_gw` is a
+    frozenset so downstream consumers can't accidentally mutate it.
+    `step_id_to_gw_id[step_id]` is the GW id when declared, or None when this
+    step's declared GW was already claimed by an earlier step (collision sentinel).
+    `declared_collisions` is the aggregate count of collision-sentinel entries.
+    """
+    declared_gw_ids: set = set()
+    declared_steps_with_gw: set = set()
+    step_id_to_gw_id: Dict[str, Optional[str]] = {}
+    for step in rows.get("steps", []):
+        gw_req = _declared_gw_for_step(
+            step, idx.generations_by_id, idx.gw_resp_by_resp_id, idx.gw_req_by_id)
+        if gw_req is None:
+            continue
+        gw_id = gw_req["gatewayRequestId__c"]
+        if gw_id in declared_gw_ids:
+            # Collision: second+ step reaches a GW already claimed.
+            step_id_to_gw_id[step["ssot__Id__c"]] = None
+            continue
+        declared_gw_ids.add(gw_id)
+        declared_steps_with_gw.add(step["ssot__Id__c"])
+        step_id_to_gw_id[step["ssot__Id__c"]] = gw_id
+    return BindingResults(
+        declared_gw_ids=declared_gw_ids,
+        declared_steps_with_gw=frozenset(declared_steps_with_gw),
+        step_id_to_gw_id=step_id_to_gw_id,
+        declared_collisions=sum(1 for v in step_id_to_gw_id.values() if v is None),
+    )
+
+
+def _build_step_view(step: dict, idx: Indexes, dispatch: PolymorphicSplits,
+                     step_id_to_gw_id: Dict[str, Optional[str]],
+                     build_gw) -> dict:
+    """Emit one Step view, including its Generation and (if declared) GatewayRequest.
+
+    `build_gw` is a `functools.partial` pre-bound with `idx`/`dispatch`
+    (see `assemble()`); call sites only supply `gw_req`, `binding_method`,
+    and optionally `bound_step_id`.
+    """
+    sid_step = step["ssot__Id__c"]
+    gen_id = step.get("ssot__GenerationId__c")
+    gen = idx.generations_by_id.get(gen_id) if gen_id not in _NOT_SET else None
+    generation_view = _build_generation_view(
+        gen, idx.quality_by_parent, dispatch.categories_by_generation,
+        dispatch.categories_by_quality, idx.feedback_by_gen,
+        idx.feedback_details_by_parent, dispatch.gw_records_by_feedback,
+    ) if gen is not None else None
+
+    gw_id = step_id_to_gw_id.get(sid_step)
+    gw_view = None
+    collision_flag = gw_id is None and sid_step in step_id_to_gw_id
+    if gw_id is not None:
+        gw_view = build_gw(idx.gw_req_by_id[gw_id], "declared")
+
+    # Mirror the bound gateway_request's model identifier onto the step
+    # itself so renderers can show "LLM_STEP <name> · <model>" without
+    # dereferencing the nested gateway view. The mirror is None when no
+    # gateway_request is bound (declared chain didn't reach, or the STDM
+    # exporter dropped writes — see the `gateway_requests_dropped_by_stdm`
+    # session_shape).
+    step_model_name = gw_view.get("model") if gw_view else None
+
+    step_view: Dict[str, Any] = {
+        "id": sid_step,
+        "type": step.get("ssot__AiAgentInteractionStepType__c"),
+        "name": step.get("ssot__Name__c"),
+        "start_ts": step.get("ssot__StartTimestamp__c"),
+        "end_ts": step.get("ssot__EndTimestamp__c"),
+        "error_text": _clean(step.get("ssot__ErrorMessageText__c")),
+        "model_name": step_model_name,
+        "generation": generation_view,
+        "gateway_request": gw_view,
+    }
+    if collision_flag:
+        step_view["gateway_request_collision"] = True
+    return step_view
+
+
+def _build_message_view(m: dict, participant_role_by_id: Dict[str, str]) -> dict:
+    mtype = m.get("ssot__AiAgentInteractionMessageType__c")
+    pid = m.get("ssot__AiAgentSessionParticipantId__c")
+    role = participant_role_by_id.get(pid)
+    if role is None:
+        role = "USER" if mtype == "Input" else "AGENT" if mtype == "Output" else None
+    return {
+        "message_id": m.get("ssot__Id__c"),
+        "type": mtype,
+        "role": role,
+        "participant_id": pid,
+        "text": m.get("ssot__ContentText__c"),
+        "content_type": m.get("ssot__AiAgentInteractionMsgContentType__c"),
+        "modality": m.get("Modality__c"),
+        "ts": m.get("ssot__MessageSentTimestamp__c"),
+    }
+
+
+def _build_interaction_view(interaction: dict, rows: Dict[str, List[dict]],
+                            idx: Indexes, dispatch: PolymorphicSplits,
+                            binding: BindingResults,
+                            build_gw) -> Tuple[dict, BinderCtx]:
+    """Emit one Interaction view plus its BinderCtx.
+
+    Returns (view, binder_ctx). Binder scratch state lives in the `BinderCtx`
+    and is keyed externally by `iid`; it never touches the emitted view, so
+    it can't leak into `dc._session_tree.json`. `build_gw` is the
+    `functools.partial` from `assemble()`.
+    """
+    iid = interaction["ssot__Id__c"]
+    trace_id = _extract_trace_id(interaction)
+
+    steps_sorted = sorted(
+        idx.steps_by_interaction.get(iid, []),
+        key=lambda s: (s.get("ssot__StartTimestamp__c") or "", s.get("ssot__Id__c") or ""))
+    step_views = [_build_step_view(s, idx, dispatch, binding.step_id_to_gw_id, build_gw)
+                  for s in steps_sorted]
+
+    # Step windows consumed only by _ts_window_pass via the parallel BinderCtx.
+    steps_with_ts: List[Tuple[dict, Optional[datetime], Optional[datetime]]] = [
+        (s, _ts(s.get("ssot__StartTimestamp__c")), _ts(s.get("ssot__EndTimestamp__c")))
+        for s in steps_sorted if _ts(s.get("ssot__StartTimestamp__c")) is not None
+    ]
+
+    messages_sorted = sorted(
+        idx.messages_by_interaction.get(iid, []),
+        key=lambda r: (r.get("ssot__MessageSentTimestamp__c") or "",
+                       r.get("ssot__Id__c") or ""))
+    msg_views = [_build_message_view(m, idx.participant_role_by_id)
+                 for m in messages_sorted]
+
+    view = {
+        "id": iid,
+        "type": interaction.get("ssot__AiAgentInteractionType__c"),
+        "topic": _clean(interaction.get("ssot__TopicApiName__c")),
+        "trace_id": trace_id,
+        "start_ts": interaction.get("ssot__StartTimestamp__c"),
+        "end_ts": interaction.get("ssot__EndTimestamp__c"),
+        "messages": msg_views,
+        "telemetry_spans": [s for s in rows.get("telemetry_spans", [])
+                            if s.get("ssot__TelemetryTrace__c") == trace_id],
+        "steps": step_views,
+        "timestamp_bound_gateway_calls": [],  # appended by _ts_window_pass
+        "tag_associations": dispatch.tag_assoc_by_interaction.get(iid, []),
+    }
+    binder_ctx = BinderCtx(
+        start_ts=_ts(interaction.get("ssot__StartTimestamp__c")),
+        end_ts=_ts(interaction.get("ssot__EndTimestamp__c")),
+        steps_with_ts=steps_with_ts,
+        reserved_step_ids=binding.declared_steps_with_gw,
+    )
+    return view, binder_ctx
+
+
+def _ts_window_pass(interactions_view: List[dict],
+                    binders: Dict[str, BinderCtx],
+                    idx: Indexes,
+                    binding: BindingResults,
+                    build_gw) -> Tuple[List[dict], dict]:
+    """Place every chain-orphan GW via timestamp-window, or into unbound[].
+
+    Reads per-interaction binder state from the parallel `binders` dict keyed
+    by `iv["id"]` — never from the view itself. Mutates `interactions_view`
+    in place only to append to `timestamp_bound_gateway_calls[]` (an emission
+    field, pre-initialized to `[]` in `_build_interaction_view`).
+
+    Returns (unbound_gw_calls, gw_binding_counts).
+    """
+    unbound: List[dict] = []
+    counts = {
+        "declared": len(binding.declared_gw_ids),
+        "timestamp_window": 0,
+        "unbound": 0,
+        "declared_collisions": binding.declared_collisions,
+    }
+    for gw_id, gw_req in idx.gw_req_by_id.items():
+        if gw_id in binding.declared_gw_ids:
+            continue
+        placed = False
+        for iv in interactions_view:
+            bctx = binders[iv["id"]]
+            placement, bound_step_id = _bind_ts_window(
+                gw_req,
+                bctx.steps_with_ts,
+                (bctx.start_ts, bctx.end_ts),
+                bctx.reserved_step_ids,
+            )
+            if placement in ("step", "interaction"):
+                iv["timestamp_bound_gateway_calls"].append(
+                    build_gw(gw_req, "timestamp_window", bound_step_id=bound_step_id))
+                counts["timestamp_window"] += 1
+                placed = True
+                break
+        if not placed:
+            unbound.append(build_gw(gw_req, "unbound"))
+            counts["unbound"] += 1
+
+    # Defense in depth: if anyone reintroduces the binder-cache-on-view
+    # pattern in a future edit, this catches it before the tree ever writes.
+    assert not any(k.startswith("_") for iv in interactions_view for k in iv), \
+        "binder scratch state leaked into interaction view — do not stash on the view dict"
+
+    return unbound, counts
+
+
+def _build_moments_view(rows: Dict[str, List[dict]], dispatch: PolymorphicSplits) -> List[dict]:
+    """session.moments[] with interaction_ids[] back-refs derived from MomentInteraction."""
+    by_moment: Dict[str, List[str]] = defaultdict(list)
+    for mi in rows.get("moment_interactions", []):
+        mid = mi.get("ssot__AiAgentMomentId__c")
+        iid = mi.get("ssot__AiAgentInteractionId__c")
+        if mid not in _NOT_SET and iid not in _NOT_SET:
+            by_moment[mid].append(iid)
+
+    moments_sorted = sorted(
+        rows.get("moments", []),
+        key=lambda r: (r.get("ssot__StartTimestamp__c") or "", r.get("ssot__Id__c") or ""))
+    return [
+        {
+            "moment_id": m.get("ssot__Id__c"),
+            "agent_api_name": _clean(m.get("ssot__AiAgentApiName__c")),
+            "agent_version": _clean(m.get("ssot__AiAgentVersionApiName__c")),
+            "request_summary_text": _clean(m.get("ssot__RequestSummaryText__c")),
+            "response_summary_text": _clean(m.get("ssot__ResponseSummaryText__c")),
+            "interaction_ids": sorted(by_moment.get(m.get("ssot__Id__c"), [])),
+            "start_ts": m.get("ssot__StartTimestamp__c"),
+            "end_ts": m.get("ssot__EndTimestamp__c"),
+            "tag_associations": dispatch.tag_assoc_by_moment.get(m.get("ssot__Id__c"), []),
+        }
+        for m in moments_sorted
+    ]
+
+
+def _build_participants_view(rows: Dict[str, List[dict]]) -> List[dict]:
+    return [
+        {
+            "participant_id": p.get("ssot__Id__c"),
+            "role": p.get("ssot__AiAgentSessionParticipantRole__c"),
+            "agent_api_name": _clean(p.get("ssot__AiAgentApiName__c")),
+            "agent_version": _clean(p.get("ssot__AiAgentVersionApiName__c")),
+            "agent_type": _clean(p.get("ssot__AiAgentType__c")),
+        }
+        for p in sorted(
+            rows.get("participants", []),
+            key=lambda r: (r.get("ssot__StartTimestamp__c") or "", r.get("ssot__Id__c") or ""))
+    ]
+
+
+def _build_counts(rows: Dict[str, List[dict]], dispatch: PolymorphicSplits,
+                  binding_counts: dict,
+                  manifest: dict, collisions: List[dict],
+                  parse_warnings: List[str]) -> dict:
+    int_by_type: Dict[str, int] = defaultdict(int)
+    step_by_type: Dict[str, int] = defaultdict(int)
+    for i in rows.get("interactions", []):
+        int_by_type[i.get("ssot__AiAgentInteractionType__c")] += 1
+    for s in rows.get("steps", []):
+        step_by_type[s.get("ssot__AiAgentInteractionStepType__c")] += 1
+
+    return {
+        "interactions_total": len(rows.get("interactions", [])),
+        "interactions_turn": int_by_type.get("TURN", 0),
+        "interactions_session_end": int_by_type.get("SESSION_END", 0),
+        "steps_total": len(rows.get("steps", [])),
+        "steps_by_type": {
+            k: step_by_type.get(k, 0) for k in
+            ("LLM_STEP", "ACTION_STEP", "TOPIC_STEP", "TRUST_GUARDRAILS_STEP", "SESSION_END")
+        },
+        "generations": len(rows.get("generations", [])),
+        "gateway_requests": len(rows.get("gateway_requests", [])),
+        "gateway_responses": len(rows.get("gateway_responses", [])),
+        "gateway_metadata": len(rows.get("gateway_request_metadata", [])),
+        "gateway_llm": len(rows.get("gateway_request_llm", [])),
+        "gateway_records_grounded": sum(len(v) for v in dispatch.gw_records_by_gw_req.values()),
+        "gateway_records_feedback": sum(len(v) for v in dispatch.gw_records_by_feedback.values()),
+        "feedback": len(rows.get("feedback", [])),
+        "audit_chain_1to1_ok": (
+            len(rows.get("gateway_requests", [])) == len(rows.get("gateway_responses", []))
+        ),
+        "gw_binding": binding_counts,
+        "session_shape": manifest.get("session_shape", "unknown"),
+        "pk_collisions": collisions,
+        "parse_warnings": parse_warnings,
+    }
+
+
+def assemble(sid: str) -> Tuple[dict, Path]:
+    """Orchestrate: load → index → dispatch → bind → build views → counts → tree.
+
+    Returns (tree, session_dir). The session_dir is resolved by
+    ``_find_session_dir`` (via breadcrumb or glob) and passed back so
+    the caller can write ``dc._session_tree.json`` next to the inputs
+    without re-scanning the disk.
+    """
+    manifest, rows, parse_warnings, session_dir = _load_all(sid)
+
+    # Short-circuit: session row not found.
+    sessions = rows.get("sessions", [])
+    if not sessions:
+        return _minimal_tree_session_not_found(sid, manifest, parse_warnings), session_dir
+
+    # Short-circuit: STDM Interaction/Step/Message DMOs haven't materialized yet
+    # (gateway_requests present, interactions/steps empty). Render the gateway
+    # chain directly instead of silently emitting an empty tree.
+    if manifest.get("session_shape") == "interactions_not_materialized_yet":
+        return _assemble_gateway_direct(sid, rows, manifest, parse_warnings), session_dir
+
+    collisions: List[dict] = []
+    # Phase 1: independent bags.
+    idx = _build_indexes(rows, collisions)
+    dispatch = _dispatch_polymorphic(rows, idx)
+    catalog = _filter_catalog(rows)
+    # Phase 2: derived bag that depends on idx.
+    binding = _declared_binding_pass(rows, idx)
+
+    # Bind the invariant gw-view args once; call sites supply only the varying ones.
+    build_gw = functools.partial(_build_gw_view, idx=idx, dispatch=dispatch)
+
+    # Build per-Interaction views + parallel binder state (sorted by start_ts).
+    interactions_view: List[dict] = []
+    binders: Dict[str, BinderCtx] = {}
+    for interaction in sorted(
+            rows.get("interactions", []),
+            key=lambda r: (r.get("ssot__StartTimestamp__c") or "",
+                           r.get("ssot__Id__c") or "")):
+        view, bctx = _build_interaction_view(interaction, rows, idx, dispatch, binding, build_gw)
+        interactions_view.append(view)
+        binders[view["id"]] = bctx
+
+    # Timestamp-window fallback; mutates interactions_view only via
+    # timestamp_bound_gateway_calls[].append.
+    unbound_gw_calls, gw_binding_counts = _ts_window_pass(
+        interactions_view, binders, idx, binding, build_gw)
+
+    session_row = sessions[0]
+    session_identity = _build_session_identity(rows, manifest)
+    # `org_id_15` is the canonical 15-char slice used by path helpers.
+    # Prefer the manifest-stamped value (resolved in wave 1a of fetch_dc
+    # from sessions[0].ssot__InternalOrganizationId__c); fall back to
+    # slicing session_identity.org_id (the 18-char form from
+    # gateway_requests) when the manifest is missing the field (older
+    # artifacts predate the manifest stamp).
+    org_id_15 = manifest.get("org_id_15")
+    if not org_id_15 and session_identity.get("org_id"):
+        org_id_15 = session_identity["org_id"][:15]
+    session_identity["org_id_15"] = org_id_15
+
+    # Top-level identity block — this is the canonical location read by the
+    # migration script (`scripts/migrate_data_layout.py`) and by downstream
+    # runtime code. Contains just the 3 segments needed to name the session
+    # dir; richer identity fields live under `session.identity` as before.
+    # Promote richer values from `session_identity` when the manifest carries
+    # placeholders (notably ``agent_version="v0"`` from the MyAgent
+    # fallback in fetch_dc.py:570-597) — without this, the top-level block
+    # diverges from `session.identity` in the same JSON file.
+    top_identity = _reconcile_top_identity(manifest, session_identity, org_id_15)
+
+    return {
+        "identity": top_identity,
+        "session": {
+            "id": sid,
+            "_schema_version": 1,
+            "org": {
+                "alias": manifest.get("org_alias"),
+                "instance_url": manifest.get("instance_url"),
+            },
+            "identity": session_identity,
+            "start_ts": session_row.get("ssot__StartTimestamp__c"),
+            "end_ts": session_row.get("ssot__EndTimestamp__c"),
+            "end_type": _resolve_end_type(session_row, rows),
+            "channel": _harvest_str(session_row.get("ssot__AiAgentChannelType__c")),
+            "participants": _build_participants_view(rows),
+            "moments": _build_moments_view(rows, dispatch),
+            "interactions": interactions_view,
+            "session_tag_associations": dispatch.tag_assoc_session,
+            "unbound_gateway_calls": unbound_gw_calls,
+            "counts": _build_counts(rows, dispatch, gw_binding_counts,
+                                    manifest, collisions, parse_warnings),
+        },
+        "catalog": {
+            "agents_observed": catalog.agents_observed,
+            "tag_definitions": catalog.tag_definitions,
+            "tag_definition_associations": catalog.tag_definition_associations,
+            "tags": catalog.tags,
+        },
+        "_doc": (
+            "Assembled from "
+            "DATA_ROOT/<org>/<agent>__<ver>/<sid>/dc.*.json. "
+            "See dc._session_manifest.json for per-query counts and empty reasons. "
+            "Contract: references/dc_pipeline_contract.md."
+        ),
+    }, session_dir
+
+
+def _build_generation_view(gen: dict,
+                           quality_by_parent: Dict[str, List[dict]],
+                           categories_by_generation: Dict[str, List[dict]],
+                           categories_by_quality: Dict[str, List[dict]],
+                           feedback_by_gen: Dict[str, List[dict]],
+                           feedback_details_by_parent: Dict[str, List[dict]],
+                           gw_records_by_feedback: Dict[str, List[dict]]) -> dict:
+    gen_id = gen["generationId__c"]
+    # Quality rows with their TOXICITY sub-categories nested.
+    quality_rows = []
+    for q in quality_by_parent.get(gen_id, []):
+        q_view = dict(q)
+        q_view["_toxicity_subcategories"] = categories_by_quality.get(q.get("id__c"), [])
+        quality_rows.append(q_view)
+
+    # Feedback rows with details + feedback-attachment records nested.
+    feedback_rows = []
+    for fb in feedback_by_gen.get(gen_id, []):
+        fid = fb.get("feedbackId__c")
+        feedback_rows.append({
+            "feedback_id": fid,
+            "feedback": fb.get("feedback__c"),
+            "action": fb.get("action__c"),
+            "details": feedback_details_by_parent.get(fid, []),
+            "records": gw_records_by_feedback.get(fid, []),
+        })
+
+    return {
+        "generation_id": gen_id,
+        "response_id": _clean(gen.get("generationResponseId__c")),
+        "response_text": gen.get("responseText__c"),
+        "masked_response_text": gen.get("maskedResponseText__c"),
+        "response_parameters": gen.get("responseParameters__c"),
+        "feature": _clean(gen.get("feature__c")),
+        "quality": quality_rows,
+        "categories": categories_by_generation.get(gen_id, []),
+        "feedback": feedback_rows,
+    }
+
+
+_STDM_LAG_NOTE = (
+    "Interaction/Step/Message DMOs materialize on a separate cadence from "
+    "Gateway DMOs. For fresh sessions this view reflects the gateway chain "
+    "directly. Re-run in 24–72 hours for the full hierarchical trace."
+)
+
+
+def _assemble_gateway_direct(sid: str, rows: Dict[str, List[dict]],
+                              manifest: dict,
+                              parse_warnings: List[str]) -> dict:
+    """Build a gateway-chain-only tree for sessions whose STDM hierarchy hasn't materialized.
+
+    Mirrors ``_minimal_tree_session_not_found`` in shape, but populates a
+    ``session.gateway_chain[]`` harvested directly from ``gateway_requests``
+    joined to ``gateway_request_tags`` / ``gateway_request_metadata`` /
+    ``gateway_responses``. ``session.interactions`` is an explicit empty list
+    so consumers that walk it simply no-op.
+
+    The sentinel ``_source = "gateway_direct"`` is consumed by
+    ``render_dc._render_gateway_direct``.
+    """
+    sessions = rows.get("sessions", [])
+    session_row = sessions[0] if sessions else {}
+
+    # Reuse the canonical identity harvester — same tag-alias fallbacks,
+    # same normalization — and apply the same org_id_15 fallback as the
+    # happy path so the top-level identity block is consistent across shapes.
+    session_identity = _build_session_identity(rows, manifest)
+    org_id_15 = manifest.get("org_id_15")
+    if not org_id_15 and session_identity.get("org_id"):
+        org_id_15 = session_identity["org_id"][:15]
+    session_identity["org_id_15"] = org_id_15
+
+    # Same placeholder-promotion policy as the happy path — see
+    # `_reconcile_top_identity` for why we don't trust the manifest blindly.
+    top_identity = _reconcile_top_identity(manifest, session_identity, org_id_15)
+
+    # Group the child DMOs by parent once so the per-request loop stays O(n).
+    tags_by_req: Dict[str, List[dict]] = _groupby(
+        rows.get("gateway_request_tags", []), "parent__c")
+    md_by_req: Dict[str, List[dict]] = _groupby(
+        rows.get("gateway_request_metadata", []), "parent__c")
+    resp_by_req: Dict[str, List[dict]] = _groupby(
+        rows.get("gateway_responses", []), "generationRequestId__c")
+
+    # Deterministic order: sort by (timestamp__c, gatewayRequestId__c) so
+    # repeat runs on the same inputs produce byte-identical output.
+    gw_sorted = sorted(
+        rows.get("gateway_requests", []),
+        key=lambda r: (r.get("timestamp__c") or "",
+                       r.get("gatewayRequestId__c") or ""),
+    )
+
+    gateway_chain: List[dict] = []
+    for gw in gw_sorted:
+        gw_id = gw.get("gatewayRequestId__c")
+        # sf__Id (platform row id) isn't harvested by fetch_dc; the logical
+        # PK is gatewayRequestId__c. Keep both keys on the view so readers
+        # can lift either without re-joining.
+        sf_id = gw.get("sf__Id")
+
+        # timestamp: prefer the columns named in the change-request
+        # (requestTimeStamp__c, createdAt__c), then fall back to the
+        # documented column (timestamp__c in references/dc_dmo_fields.md).
+        timestamp = (
+            _clean(gw.get("requestTimeStamp__c"))
+            or _clean(gw.get("createdAt__c"))
+            or _clean(gw.get("timestamp__c"))
+        )
+
+        # Tag-driven fields. Use _harvest_str for html-unescape + quote-strip —
+        # same normalizer _build_session_identity uses on tag values.
+        tag_first: Dict[str, Optional[str]] = {}
+        for t in sorted(
+                tags_by_req.get(gw_id, []),
+                key=lambda r: (r.get("tag__c") or "",
+                               r.get("tagValue__c") or "")):
+            k = t.get("tag__c")
+            if not k or k in tag_first:
+                continue
+            tag_first[k] = _harvest_str(t.get("tagValue__c"))
+
+        # Prompt-template name: prefer the direct column on the request;
+        # fall back to the tag alias used by older agent builds.
+        prompt_template_dev_name = (
+            _clean(gw.get("promptTemplateDevName__c"))
+            or tag_first.get("prompt_template_dev_name")
+        )
+        # `feature` likewise prefers the typed column, falls back to tag.
+        feature = _clean(gw.get("feature__c")) or tag_first.get("feature")
+
+        # Response side — take the first by response timestamp. 1:1 invariant
+        # holds on every live session we've observed, but defend against the
+        # in-flight-call edge case by sorting deterministically.
+        responses_sorted = sorted(
+            resp_by_req.get(gw_id, []),
+            key=lambda r: (r.get("timestamp__c") or "",
+                           r.get("generationResponseId__c") or ""),
+        )
+        response_view: Optional[dict] = None
+        if responses_sorted:
+            resp = responses_sorted[0]
+            response_view = {
+                "timestamp": _clean(resp.get("timestamp__c")),
+                "finish_reason": _parse_finish_reason_params(resp.get("parameters__c")),
+            }
+
+        gateway_chain.append({
+            "gateway_request_id": gw_id,
+            "sf_id": sf_id,
+            "timestamp": timestamp,
+            "model": _clean(gw.get("model__c")),
+            "provider": _clean(gw.get("provider__c")),
+            "prompt_template_dev_name": prompt_template_dev_name,
+            "feature": feature,
+            "prompt_tokens": gw.get("promptTokens__c"),
+            "completion_tokens": gw.get("completionTokens__c"),
+            "total_tokens": gw.get("totalTokens__c"),
+            # Raw prompt is authoritative on disk (dc.gateway_requests.json);
+            # the 64 KB display cap lives in the render layer, not here.
+            "prompt_text": gw.get("prompt__c"),
+            "metadata": md_by_req.get(gw_id, []),
+            "tags": tags_by_req.get(gw_id, []),
+            "response": response_view,
+        })
+
+    return {
+        "identity": top_identity,
+        "_source": "gateway_direct",
+        "session": {
+            "id": sid,
+            "_schema_version": 1,
+            "org": {
+                "alias": manifest.get("org_alias"),
+                "instance_url": manifest.get("instance_url"),
+            },
+            "identity": session_identity,
+            "start_ts": session_row.get("ssot__StartTimestamp__c"),
+            "end_ts": session_row.get("ssot__EndTimestamp__c"),
+            "end_type": _resolve_end_type(session_row, rows),
+            "channel": _harvest_str(session_row.get("ssot__AiAgentChannelType__c")),
+            "participants": _build_participants_view(rows),
+            # Explicit empty list — downstream consumers walk this and must
+            # no-op safely when STDM hasn't materialized yet.
+            "interactions": [],
+            "gateway_chain": gateway_chain,
+            "_stdm_lag_note": _STDM_LAG_NOTE,
+            "counts": {
+                "session_shape": manifest.get("session_shape",
+                                              "interactions_not_materialized_yet"),
+                "gateway_requests": len(rows.get("gateway_requests", [])),
+                "gateway_responses": len(rows.get("gateway_responses", [])),
+                "gateway_metadata": len(rows.get("gateway_request_metadata", [])),
+                "gateway_tags": len(rows.get("gateway_request_tags", [])),
+                "interactions_total": 0,
+                "steps_total": 0,
+                "parse_warnings": parse_warnings,
+            },
+        },
+        "_doc": (
+            f"Session {sid}: STDM Interaction/Step/Message DMOs have not "
+            "materialized yet (they lag Gateway DMOs by hours to days). "
+            "Tree carries the gateway chain harvested directly from "
+            "GenAIGatewayRequest + related audit DMOs. Re-run fetch_dc.py "
+            "in 24–72h once the STDM hierarchy has caught up for the full "
+            "hierarchical trace."
+        ),
+    }
+
+
+def _parse_finish_reason_params(parameters: Optional[str]) -> Optional[str]:
+    """Lift finish_reason out of GatewayResponse.parameters__c.
+
+    The field arrives HTML-escaped and the finish_reason value itself is
+    often wrapped in escaped quotes (e.g. `\\"stop\\"`). Mirrors
+    ``render_dc._parse_finish_reason`` but against the gateway-response
+    parameters column rather than Generation.responseParameters__c.
+    """
+    if not parameters:
+        return None
+    try:
+        decoded = html.unescape(parameters)
+        parsed = json.loads(decoded)
+    except (ValueError, TypeError):
+        return None
+    raw = parsed.get("finish_reason") if isinstance(parsed, dict) else None
+    if not isinstance(raw, str):
+        return None
+    return raw.replace("\\", "").strip('"').strip() or None
+
+
+def _minimal_tree_session_not_found(sid: str, manifest: dict,
+                                     parse_warnings: List[str]) -> dict:
+    # Note: deliberately does NOT include `session.identity` — harvest
+    # sources (gateway_requests, gateway_request_tags, sessions[0],
+    # participants) are all empty on this path. Renderer's minimal-tree
+    # branch must handle absent identity. DOES include _schema_version so
+    # the renderer's version check doesn't warn on every not-found session.
+    #
+    # Top-level `identity` still carries the manifest-stamped (org, agent,
+    # version) when available — the session dir already exists under that
+    # identity or the manifest couldn't have been read. Migration code
+    # and breadcrumb readers depend on this block being present on EVERY
+    # tree, not just full-populated ones.
+    return {
+        "identity": {
+            "org_id_15": manifest.get("org_id_15"),
+            "agent_api_name": manifest.get("agent_api_name"),
+            "agent_version": manifest.get("agent_version"),
+        },
+        "session": {
+            "id": sid,
+            "_schema_version": 1,
+            "org": {
+                "alias": manifest.get("org_alias"),
+                "instance_url": manifest.get("instance_url"),
+            },
+            "counts": {
+                "session_shape": manifest.get("session_shape", "session_not_found"),
+                "parse_warnings": parse_warnings,
+            },
+        },
+        "_doc": (
+            f"Session {sid} did not resolve in Data Cloud "
+            "(sessions.json returned 0 rows). Check the session id, or wait for "
+            "STDM materialization. No interactions, catalog, or audit rows available."
+        ),
+    }
+
+
+# ---- public entry points --------------------------------------------------
+
+def main_for_session(sid: str) -> int:
+    """Called by fetch_dc.py's auto-run hook and by `--session` CLI.
+
+    Writes ``dc._session_tree.json`` into the session dir located by
+    ``_find_session_dir`` (via breadcrumb / glob) — the caller does not
+    need to know ``(org, agent, version)`` to invoke the assembler.
+    """
+    tree, session_dir = assemble(sid)
+    tree_path = session_dir / "dc._session_tree.json"
+    tree_path.write_text(json.dumps(tree, indent=2, sort_keys=True, default=str) + "\n")
+    print(f"assemble_dc: wrote {tree_path}", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="assemble_dc.py",
+        description="Assemble dc._session_tree.json for one session.",
+    )
+    ap.add_argument("--session", required=True,
+                    help="AI-agent session UUID or MessagingSession id (0Mw...). "
+                         "Messaging ids are resolved from disk "
+                         "(DATA_ROOT/*/dc.sessions.json); run fetch_dc.py first "
+                         "if the session hasn't been fetched yet.")
+    args = ap.parse_args()
+    from resolve_session import resolve_disk_or_live
+    sid = resolve_disk_or_live(args.session)
+    return main_for_session(sid)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-d360/scripts/config.py
+++ b/skills/investigating-agentforce-d360/scripts/config.py
@@ -1,0 +1,45 @@
+"""Shared constants for investigating-agentforce-d360.
+
+Values that don't vary per environment or user live here. If a value
+needs to be overridable at runtime in the future, swap this module for
+a loader — callers won't notice.
+
+Path layout::
+
+    ~/.claude/data/investigating-agentforce-d360/
+    └── <org_id_15>/
+        └── <agent_api_name>__<agent_version>/
+            └── <session_id>/                          ← session artifacts
+
+``DATA_ROOT`` is re-exported from the canonical helper in
+``scripts/_shared/paths.py`` (sibling module, inlined at the skill
+boundary). All session-dir composition MUST go through
+``paths.session_dir(...)`` — never compose ``DATA_ROOT / <sid>``
+directly, because that bypasses the 4-segment regex validation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Data Cloud Query API — the instance_url prefix is resolved at runtime
+# via `sf org display --target-org <alias> --json` (Claude does that,
+# not python). Python only owns the path.
+DC_API_PATH = "/services/data/v66.0/ssot/query"
+
+
+# -----------------------------------------------------------------------------
+# Shared path helpers — sibling _shared/ package
+# -----------------------------------------------------------------------------
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from _shared import paths  # type: ignore  # noqa: E402,F401 — re-export
+from _shared import sql    # type: ignore  # noqa: E402,F401 — re-export
+
+# One persistent tree per session. Writes land directly here — no
+# ephemeral /tmp staging. Re-running the same session id finds prior
+# results, which later enables per-artifact caching.
+DATA_ROOT = paths.DATA_ROOT

--- a/skills/investigating-agentforce-d360/scripts/dc.py
+++ b/skills/investigating-agentforce-d360/scripts/dc.py
@@ -1,0 +1,188 @@
+"""Data Cloud queries for investigating-agentforce-d360.
+
+Two responsibilities:
+
+1. **Templates.** `load_sql(name, **params)` reads `assets/dc/*.sql` and
+   substitutes `{{PLACEHOLDER}}` values. `parse(response)` turns a DC
+   query response into a list of row dicts. Neither knows specific
+   column names — those live in the .sql files.
+
+2. **Transport.** `resolve_org(alias)` shells out to `sf org display`
+   for the instance URL + access token. `post(sql, instance_url, token)`
+   POSTs the SQL to the Data Cloud Query API and returns parsed rows.
+   Errors route through `DCQueryError` with the full response body + SQL
+   context so callers can surface a useful message.
+
+Persistence lives in `storage.save`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from config import DC_API_PATH
+
+SQL_DIR = Path(__file__).parent.parent / "assets" / "dc"
+
+
+class DCQueryError(RuntimeError):
+    """Data Cloud query failed. Carries full response body + SQL context."""
+
+
+# ---- templates -------------------------------------------------------------
+
+def load_sql(name: str, **params: str) -> str:
+    """Read assets/dc/<name>.sql and substitute {{PARAM}} placeholders.
+
+    Add a new query by dropping a `.sql` file into `assets/dc/` — no
+    python edits needed. Callers pass whichever placeholders that
+    template defines.
+    """
+    sql = (SQL_DIR / f"{name}.sql").read_text()
+    for key, value in params.items():
+        sql = sql.replace(f"{{{{{key}}}}}", value)
+    return sql.strip()
+
+
+def parse(response: dict | None) -> list[dict]:
+    """Data Cloud response → list of row dicts. No field knowledge.
+
+    Callers pick whatever columns they need by ssot__* name. Empty list
+    means "no response" or "zero rows" — callers decide whether that's
+    a partial state worth flagging.
+    """
+    if not response:
+        return []
+    return response.get("data") or []
+
+
+# ---- transport -------------------------------------------------------------
+
+_REDACTION_MARKER_FRAGMENT = "show-access-token"
+"""Substring identifying the sf CLI v2 redaction placeholder. The full
+literal is `"[REDACTED] Use 'sf org auth show-access-token' to view"`,
+but we match on the embedded subcommand name because the surrounding
+wording has shifted across sf CLI builds while the subcommand has been
+stable since forcedotcom/cli#3560 landed."""
+
+
+def _run_sf_json(argv: list[str], env: dict | None = None) -> dict:
+    """Shell out + parse JSON. SystemExits on FileNotFoundError /
+    CalledProcessError so callers get a clean message instead of a stack."""
+    try:
+        r = subprocess.run(
+            argv, capture_output=True, text=True, check=True, env=env,
+        )
+    except FileNotFoundError:
+        raise SystemExit("sf CLI not found on PATH — install Salesforce CLI first")
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"{' '.join(argv[:4])}... failed:\n{e.stderr.strip() or e.stdout.strip()}"
+        )
+    return json.loads(r.stdout)
+
+
+def resolve_org(alias: str) -> tuple[str, str]:
+    """Resolve instanceUrl + accessToken for the sf org alias.
+
+    Two-path strategy per forcedotcom/cli#3560 (effective 2026-05-27):
+
+      1. **Primary** — `sf org display --json --verbose` for instanceUrl,
+         then `sf org auth show-access-token --json --no-prompt` for the
+         access token. This is the upstream long-term path; the
+         `SF_TEMP_SHOW_SECRETS=true` workaround is decommissioned in
+         summer 2026.
+      2. **Fallback** — if `sf org auth show-access-token` is unknown
+         (older sf CLI) OR returns an empty/redacted value, fall back
+         to the accessToken from the org_display call which uses
+         `SF_TEMP_SHOW_SECRETS=true` env var to bypass the redaction.
+
+    `--verbose` is required on the org_display call: without it, sf CLI
+    v2 omits `accessToken` from the JSON entirely (so the fallback
+    path needs both `--verbose` and the env var to work).
+
+    Raises SystemExit on CLI failure — this is the one thing every
+    downstream operation depends on, so a clean early exit is friendlier
+    than a stack trace.
+    """
+    # Step 1: org_display gives us instanceUrl always; accessToken is
+    # the legacy fallback path (redacted unless SF_TEMP_SHOW_SECRETS=true).
+    env = {**os.environ, "SF_TEMP_SHOW_SECRETS": "true"}
+    display = _run_sf_json(
+        ["sf", "org", "display", "--target-org", alias, "--json", "--verbose"],
+        env=env,
+    )["result"]
+    instance_url = display.get("instanceUrl") or ""
+    if not instance_url:
+        raise SystemExit(
+            f"sf org display returned no instanceUrl for alias {alias!r}"
+        )
+
+    # Step 2: prefer the dedicated command. Older sf CLI versions emit
+    # "is not a sf command" with returncode 0 (warning, not error), so
+    # we detect by parsing JSON shape. If the command is unknown the
+    # output isn't JSON; we let the json parse error trigger the fallback.
+    access_token = ""
+    try:
+        token_payload = _run_sf_json(
+            ["sf", "org", "auth", "show-access-token",
+             "--target-org", alias, "--json", "--no-prompt"],
+        )
+    except (SystemExit, json.JSONDecodeError):
+        # Unknown command on older sf CLI → JSON parse fails OR
+        # CalledProcessError → SystemExit; either way, fall through.
+        pass
+    else:
+        token_result = token_payload.get("result") or {}
+        access_token = token_result.get("accessToken") or ""
+
+    # Fallback: if the dedicated command didn't yield a usable token,
+    # try the legacy SF_TEMP_SHOW_SECRETS path via the org_display
+    # payload we already have.
+    if not access_token or _REDACTION_MARKER_FRAGMENT in access_token:
+        legacy = display.get("accessToken") or ""
+        if legacy and _REDACTION_MARKER_FRAGMENT not in legacy:
+            access_token = legacy
+
+    if not access_token or _REDACTION_MARKER_FRAGMENT in access_token:
+        raise SystemExit(
+            f"could not retrieve a usable access token for alias {alias!r} "
+            f"via sf org auth show-access-token (primary) or sf org display "
+            f"(fallback). Ensure sf CLI is logged in for this org."
+        )
+
+    return instance_url, access_token
+
+
+def post(sql: str, instance_url: str, token: str, query_name: str = "") -> list[dict]:
+    """POST SQL to Data Cloud Query API, return parsed rows.
+
+    `query_name` is a human label used only for error messages — pass
+    the template name (e.g. "sessions") so DCQueryError identifies
+    which query failed.
+    """
+    req = urllib.request.Request(
+        f"{instance_url}{DC_API_PATH}",
+        data=json.dumps({"sql": sql}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode(errors="replace")
+        raise DCQueryError(
+            f"query={query_name or '?'} http={e.code}\n"
+            f"--- response ({len(err_body)} bytes) ---\n{err_body}\n"
+            f"--- sql (first 400 chars) ---\n{sql[:400]}"
+        ) from None
+    return parse(body)

--- a/skills/investigating-agentforce-d360/scripts/discover_sessions.py
+++ b/skills/investigating-agentforce-d360/scripts/discover_sessions.py
@@ -1,0 +1,550 @@
+"""Session discovery for investigating-agentforce-d360 — Data Cloud only.
+
+Lets the user find candidate sessions when they don't have a session id.
+Output is a numbered picker table to stdout; the skill agent asks the user
+to pick one, then falls through to the existing fetch_dc.py pipeline with
+the chosen UUID. Writes no artifacts.
+
+DC-only by design (no OTel path).
+
+## CLI
+
+    python3 scripts/discover_sessions.py --org <alias> [options]
+
+Options (all optional except --org):
+  --since <expr>    "last 2 hours" | "last 10" | "today" | "yesterday"
+                    | "YYYY-MM-DD" | "YYYY-MM-DD to YYYY-MM-DD"
+                    | explicit UTC/TZ datetime (RFC 3339). Default: last 24 hours.
+  --agent <name>    Agent API name (e.g. MyAgent). Adds participant JOIN.
+  --channel <type>  Builder | Messaging | Voice. "Messaging" maps to
+                    "SCRT2 - EmbeddedMessaging" in SQL.
+  --outcome <type>  USER_ENDED | ESCALATED | TRANSFERRED | TIMEOUT | NOT_SET
+  --grep <pattern>  Substring in conversation text (user input + agent output).
+                    Adds interaction + message JOINs. Case-insensitive by
+                    default (LOWER on both sides); pass --grep-case-sensitive
+                    for exact match. `%` and `_` are escaped so they match
+                    the literal char.
+  --grep-case-sensitive
+                    Opt-in: make --grep case-sensitive (rare; default is
+                    case-insensitive because users almost always type the
+                    quote in whatever case they remember it).
+  --tz <IANA>       Override auto-detected local tz (e.g. America/Los_Angeles).
+                    Only affects calendar-day resolution (today/yesterday/
+                    bare-date/date-range); `last N` windows are anchored to
+                    UTC regardless. The chosen tz is echoed in zero-row
+                    output so the user can sanity-check boundaries.
+  --limit <N>       Max sessions. Default 20.
+
+Exit codes:
+  0 — ≥1 session found
+  2 — zero sessions (picker prints composed SQL so user can widen)
+  other — DC query or arg-parse error
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from dc import DCQueryError, load_sql, post, resolve_org
+from _shared.sql import _escape_sql_literal
+
+
+# ---- channel alias ---------------------------------------------------------
+
+# Source-skill convention: users type "Messaging" but DC stores the full
+# SCRT2 string. Other channels pass through as-is (Builder, Voice).
+_CHANNEL_ALIAS = {
+    "Messaging": "SCRT2 - EmbeddedMessaging",
+}
+
+
+# ---- escaping --------------------------------------------------------------
+#
+# `_escape_sql_literal` is imported from `_shared.sql` (single source of
+# truth per its module docstring). Do NOT re-declare locally — divergence
+# would break the documented contract that every DC-SQL caller shares one
+# escape strategy.
+
+_LIKE_ESCAPE = "!"  # ASCII, doesn't collide with SQL syntax, no quoting ambiguity
+
+def _escape_like_pattern(s: str) -> str:
+    """Escape SQL LIKE wildcards (`%`, `_`) and the escape char itself
+    (`!`) so `--grep "100%_off"` matches the literal text, not "100
+    anything-underscore-off". Quote-doubling still happens on top of this
+    via _escape_sql_literal. Used with the `ESCAPE '!'` clause in the
+    composed SQL.
+
+    Backslash was avoided because `ESCAPE '\\'` in source reduces to a
+    bare backslash on the wire, which some SQL parsers read as an
+    unterminated string literal (\\' → escaped quote).
+    """
+    return (
+        s.replace(_LIKE_ESCAPE, _LIKE_ESCAPE * 2)
+        .replace("%", f"{_LIKE_ESCAPE}%")
+        .replace("_", f"{_LIKE_ESCAPE}_")
+    )
+
+
+# ---- time parsing ----------------------------------------------------------
+
+@dataclass(frozen=True)
+class TimeRange:
+    """Half-open UTC range [start, end). `expr` is the original user input
+    so the picker header can echo back what was searched."""
+    start_utc: datetime
+    end_utc: datetime
+    expr: str
+    tz_name: str  # IANA or "UTC"
+
+    def iso(self, dt: datetime) -> str:
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _autodetect_tz() -> str:
+    """IANA tz from /etc/localtime symlink (macOS / most Linux). Falls
+    back to the TZ env var, then UTC."""
+    link = Path("/etc/localtime")
+    try:
+        if link.is_symlink():
+            target = os.readlink(link)
+            # Typically .../zoneinfo/America/Los_Angeles
+            if "zoneinfo/" in target:
+                return target.split("zoneinfo/", 1)[1]
+    except OSError:
+        pass
+    return os.environ.get("TZ") or "UTC"
+
+
+_RX_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+_RX_DATE_RANGE = re.compile(r"^(\d{4}-\d{2}-\d{2})\s+to\s+(\d{4}-\d{2}-\d{2})$")  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+_RX_LAST_N = re.compile(  # @rule-suppress starter-sec-002 — re.compile, not eval/exec
+    r"^last\s+(\d+)(?:\s+(hour|hours|day|days|minute|minutes))?$",
+    re.IGNORECASE,
+)
+
+
+def parse_time_expr(expr: Optional[str], tz_name: str) -> TimeRange:
+    """Parse one of the supported time expressions into a UTC half-open
+    range. Default (None) is "last 24 hours" so every query has a sane
+    time predicate — DC scans over the whole DMO without one are slow."""
+    tz_name = tz_name or _autodetect_tz()
+    try:
+        local_tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        raise SystemExit(f"discover_sessions: unknown IANA timezone {tz_name!r}")
+
+    now_utc = datetime.now(timezone.utc)
+
+    if expr is None:
+        return TimeRange(
+            start_utc=now_utc - timedelta(hours=24),
+            end_utc=now_utc,
+            expr="last 24 hours (default)",
+            tz_name=tz_name,
+        )
+
+    s = expr.strip()
+    sl = s.lower()
+
+    # "last N" / "last N hours" / "last N days" / "last N minutes"
+    m = _RX_LAST_N.match(sl)
+    if m:
+        n = int(m.group(1))
+        unit = (m.group(2) or "hours").lower()
+        if unit in ("hour", "hours"):
+            delta = timedelta(hours=n)
+        elif unit in ("day", "days"):
+            delta = timedelta(days=n)
+        elif unit in ("minute", "minutes"):
+            delta = timedelta(minutes=n)
+        else:
+            raise SystemExit(f"discover_sessions: unsupported time unit {unit!r}")
+        return TimeRange(
+            start_utc=now_utc - delta,
+            end_utc=now_utc,
+            expr=s,
+            tz_name=tz_name,
+        )
+
+    # "today" / "yesterday" — calendar day in local tz
+    if sl in ("today", "yesterday"):
+        local_now = datetime.now(local_tz)
+        offset_days = 0 if sl == "today" else 1
+        start_local = local_now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=offset_days)
+        end_local = start_local + timedelta(days=1)
+        return TimeRange(
+            start_utc=start_local.astimezone(timezone.utc),
+            end_utc=end_local.astimezone(timezone.utc),
+            expr=s,
+            tz_name=tz_name,
+        )
+
+    # "YYYY-MM-DD to YYYY-MM-DD" — inclusive range in local tz
+    m = _RX_DATE_RANGE.match(s)
+    if m:
+        start_d, end_d = m.group(1), m.group(2)
+        start_local = datetime.strptime(start_d, "%Y-%m-%d").replace(tzinfo=local_tz)
+        end_local = datetime.strptime(end_d, "%Y-%m-%d").replace(tzinfo=local_tz) + timedelta(days=1)
+        return TimeRange(
+            start_utc=start_local.astimezone(timezone.utc),
+            end_utc=end_local.astimezone(timezone.utc),
+            expr=s,
+            tz_name=tz_name,
+        )
+
+    # Bare "YYYY-MM-DD"
+    if _RX_DATE.match(s):
+        start_local = datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=local_tz)
+        end_local = start_local + timedelta(days=1)
+        return TimeRange(
+            start_utc=start_local.astimezone(timezone.utc),
+            end_utc=end_local.astimezone(timezone.utc),
+            expr=s,
+            tz_name=tz_name,
+        )
+
+    # Try RFC 3339 single datetime — caller probably meant "since this time"
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=local_tz)
+        return TimeRange(
+            start_utc=dt.astimezone(timezone.utc),
+            end_utc=now_utc,
+            expr=f"since {s}",
+            tz_name=tz_name,
+        )
+    except ValueError:
+        pass
+
+    raise SystemExit(
+        f"discover_sessions: cannot parse --since {s!r}. "
+        f"Try: `last 2 hours`, `today`, `yesterday`, `2026-04-22`, "
+        f"`2026-04-22 to 2026-04-25`, or an ISO datetime."
+    )
+
+
+# ---- SQL composition -------------------------------------------------------
+
+def compose_sql(
+    *,
+    tr: TimeRange,
+    agent: Optional[str],
+    channel: Optional[str],
+    outcome: Optional[str],
+    grep: Optional[str],
+    grep_case_sensitive: bool = False,
+    limit: int,
+) -> str:
+    """Build the discovery SQL. Conditional JOINs + WHERE ANDs are
+    composed from `tr` + flag args; the SQL skeleton lives at
+    `assets/dc/discover_sessions.sql`."""
+    joins: list[str] = []
+    wheres: list[str] = [
+        f"s.ssot__StartTimestamp__c >= '{tr.iso(tr.start_utc)}'",
+        f"s.ssot__StartTimestamp__c < '{tr.iso(tr.end_utc)}'",
+    ]
+
+    if agent:
+        joins.append(
+            "JOIN ssot__AiAgentSessionParticipant__dlm p "
+            "ON s.ssot__Id__c = p.ssot__AiAgentSessionId__c"
+        )
+        wheres.append(f"p.ssot__AiAgentApiName__c = '{_escape_sql_literal(agent)}'")
+
+    if grep:
+        joins.append(
+            "JOIN ssot__AiAgentInteraction__dlm i "
+            "ON s.ssot__Id__c = i.ssot__AiAgentSessionId__c"
+        )
+        joins.append(
+            "JOIN ssot__AiAgentInteractionMessage__dlm m "
+            "ON i.ssot__Id__c = m.ssot__AiAgentInteractionId__c"
+        )
+        # LIKE wildcards (%, _) and the escape char (!) are neutralized so
+        # `--grep "100%_off"` matches the literal substring. Quote-doubling
+        # is layered on top via _escape_sql_literal. The `ESCAPE '!'` clause
+        # tells SQL the escape char is `!`.
+        pat = _escape_sql_literal(_escape_like_pattern(grep))
+        if grep_case_sensitive:
+            wheres.append(
+                f"m.ssot__ContentText__c LIKE '%{pat}%' ESCAPE '{_LIKE_ESCAPE}'"
+            )
+        else:
+            # Lowercase both sides so the predicate is case-insensitive.
+            # Default behaviour — users almost always type the quoted
+            # phrase in whatever case they remember, not the case the
+            # agent rendered it in.
+            wheres.append(
+                f"LOWER(m.ssot__ContentText__c) LIKE LOWER('%{pat}%') "
+                f"ESCAPE '{_LIKE_ESCAPE}'"
+            )
+
+    if channel:
+        ch = _CHANNEL_ALIAS.get(channel, channel)
+        wheres.append(f"s.ssot__AiAgentChannelType__c = '{_escape_sql_literal(ch)}'")
+
+    if outcome:
+        wheres.append(f"s.ssot__AiAgentSessionEndType__c = '{_escape_sql_literal(outcome)}'")
+
+    # DISTINCT when JOINs are present — a session can JOIN multiple
+    # participants / messages and explode rows.
+    columns = (
+        "s.ssot__Id__c, s.ssot__StartTimestamp__c, s.ssot__EndTimestamp__c, "
+        "s.ssot__AiAgentChannelType__c, s.ssot__AiAgentSessionEndType__c"
+    )
+    select_list = f"DISTINCT {columns}" if joins else columns
+
+    return load_sql(
+        "discover_sessions",
+        SELECT_LIST=select_list,
+        JOINS="\n".join(joins),
+        WHERE_CLAUSE=" AND ".join(wheres),
+        LIMIT=str(limit),
+    )
+
+
+# ---- agent-name enrichment -------------------------------------------------
+
+_NAME_NOT_SET = {"", "NOT_SET", None}
+
+
+def fetch_agent_names(
+    session_ids: list[str], *, instance_url: str, token: str
+) -> dict[str, str]:
+    """One follow-up query to grab agent names for discovered sessions.
+    The discovery query itself drops agent name from the projection
+    because adding it to SELECT forces a participant JOIN on every query
+    (including the no-filter case) and DC penalizes that.
+
+    Returns {session_uuid: agent_api_name}. Missing sessions → not in dict.
+
+    No role filter on the SQL. Some agent shapes (e.g. MyAgent) leave
+    AGENT-role rows with ``ssot__AiAgentApiName__c = 'NOT_SET'`` while USER-
+    role rows correctly carry the agent's api_name. Filtering to ``role =
+    'AGENT'`` would either return no row (picker shows '—' for a session
+    that clearly has an agent) or return the literal ``'NOT_SET'`` (picker
+    misleads the operator). Dropping the role filter and de-duplicating in
+    Python with the dominant-agent rule (``sorted(...)[0]``) recovers both
+    cases. Mirrors the fallback in ``fetch_dc._resolve_identity``.
+    """
+    if not session_ids:
+        return {}
+    quoted = ", ".join(f"'{_escape_sql_literal(sid)}'" for sid in session_ids)
+    sql = (
+        "SELECT ssot__AiAgentSessionId__c, ssot__AiAgentApiName__c "
+        "FROM ssot__AiAgentSessionParticipant__dlm "
+        f"WHERE ssot__AiAgentSessionId__c IN ({quoted})"
+    )
+    try:
+        rows = post(sql, instance_url, token, "discover_sessions_agent_names")
+    except DCQueryError:
+        return {}  # non-fatal — picker shows "—" for agent
+    # Group all api_names per session, drop NOT_SET sentinels, dominant-agent
+    # pick (lexicographic first) to match the rule used in fetch_dc and the
+    # migration script. Sessions where every participant row is NOT_SET fall
+    # out of the result entirely — the picker will show '—', which is more
+    # honest than displaying the literal 'NOT_SET'.
+    by_sid: dict[str, set[str]] = {}
+    for row in rows:
+        sid = row.get("ssot__AiAgentSessionId__c")
+        name = row.get("ssot__AiAgentApiName__c")
+        if not sid or name in _NAME_NOT_SET:
+            continue
+        by_sid.setdefault(sid, set()).add(name)
+    return {sid: sorted(names)[0] for sid, names in by_sid.items() if names}
+
+
+# ---- rendering -------------------------------------------------------------
+
+def _fmt_duration(start_iso: Optional[str], end_iso: Optional[str]) -> str:
+    """Human-readable duration (e.g. "1m 12s", "28s") from two ISO timestamps.
+    Returns "—" if start_iso is missing or unparseable. When end_iso is
+    None but start_iso parses, computes elapsed-from-now and appends "+"
+    to signal the session is still open (or end timestamp hasn't
+    materialized in DC yet)."""
+    if not start_iso:
+        return "—"
+    try:
+        start = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return "—"
+    ongoing = False
+    if not end_iso:
+        end = datetime.now(timezone.utc)
+        ongoing = True
+    else:
+        try:
+            end = datetime.fromisoformat(end_iso.replace("Z", "+00:00"))
+        except ValueError:
+            return "—"
+    seconds = int((end - start).total_seconds())
+    if seconds < 0:
+        return "—"
+    suffix = "+" if ongoing else ""
+    if seconds < 60:
+        return f"{seconds}s{suffix}"
+    m, s = divmod(seconds, 60)
+    if m < 60:
+        return (f"{m}m {s}s" if s else f"{m}m") + suffix
+    h, m = divmod(m, 60)
+    return f"{h}h {m}m{suffix}"
+
+
+def _fmt_channel(raw: Optional[str]) -> str:
+    """Compact channel label for the picker."""
+    if not raw:
+        return "—"
+    # Reverse the Messaging alias for readability.
+    if raw == "SCRT2 - EmbeddedMessaging":
+        return "Messaging"
+    # Custom channel labels arrive HTML-encoded from DC (e.g. "E &amp; O").
+    return html.unescape(raw)
+
+
+def _fmt_start(iso: Optional[str]) -> str:
+    if not iso:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return iso
+    return dt.strftime("%Y-%m-%d %H:%M:%SZ")
+
+
+def render_picker(
+    *,
+    rows: list[dict],
+    agent_by_sid: dict[str, str],
+    org: str,
+    tr: TimeRange,
+    filters: dict[str, Optional[str]],
+    composed_sql: str,
+) -> str:
+    """Markdown picker. Returned as a string so the caller prints once
+    (single subprocess write on stdout)."""
+    filter_bits = [f"{tr.expr}"]
+    for k, v in filters.items():
+        if v:
+            filter_bits.append(f"{k}={v}")
+    header_filters = " · ".join(filter_bits)
+
+    if not rows:
+        # Echo the composed SQL so the user can widen the query.
+        return (
+            f"No sessions matched in **{org}** ({header_filters}).\n\n"
+            f"Range searched (UTC): `{tr.iso(tr.start_utc)}` → `{tr.iso(tr.end_utc)}`\n"
+            f"Local tz: `{tr.tz_name}`\n\n"
+            f"Composed SQL:\n```sql\n{composed_sql}\n```\n"
+            f"Try widening: larger `--since`, drop `--channel`/`--outcome`, or broaden `--grep`."
+        )
+
+    lines = [
+        f"Found **{len(rows)}** session{'s' if len(rows) != 1 else ''} in "
+        f"**{org}** ({header_filters}):",
+        "",
+        "| # | UUID | Start (UTC) | Agent | Channel | Duration | Outcome |",
+        "|---|------|-------------|-------|---------|----------|---------|",
+    ]
+    for i, row in enumerate(rows, start=1):
+        uuid = row.get("ssot__Id__c") or "—"
+        agent = agent_by_sid.get(uuid, "—")
+        lines.append(
+            f"| {i} | `{uuid}` | {_fmt_start(row.get('ssot__StartTimestamp__c'))} "
+            f"| {agent} | {_fmt_channel(row.get('ssot__AiAgentChannelType__c'))} "
+            f"| {_fmt_duration(row.get('ssot__StartTimestamp__c'), row.get('ssot__EndTimestamp__c'))} "
+            f"| {row.get('ssot__AiAgentSessionEndType__c') or '—'} |"
+        )
+    lines.append("")
+    lines.append(f"Pick a number (1–{len(rows)}) to trace, or paste a UUID.")
+    return "\n".join(lines)
+
+
+# ---- CLI -------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Find candidate Agentforce sessions via Data Cloud. "
+                    "Prints a numbered picker; no artifacts written.",
+    )
+    ap.add_argument("--org", required=True, help="sf CLI org alias (the one you configured via `sf org login`)")
+    ap.add_argument("--since", help='time range: "last 2 hours" | "today" | "yesterday" | '
+                                    '"YYYY-MM-DD" | "YYYY-MM-DD to YYYY-MM-DD" | ISO datetime. '
+                                    'Default: last 24 hours.')
+    ap.add_argument("--agent", help="Agent API name (exact match)")
+    ap.add_argument("--channel", help="Builder | Messaging | Voice (or full STDM string)")
+    ap.add_argument("--outcome", help="USER_ENDED | ESCALATED | TRANSFERRED | TIMEOUT | NOT_SET")
+    ap.add_argument(
+        "--grep",
+        help="substring in conversation text (user + agent); "
+             "case-insensitive by default — pass --grep-case-sensitive for exact match",
+    )
+    ap.add_argument(
+        "--grep-case-sensitive",
+        action="store_true",
+        default=False,
+        help="opt-in: make --grep case-sensitive (rare; default is case-insensitive)",
+    )
+    ap.add_argument("--tz", help="IANA timezone override for calendar-day resolution")
+    ap.add_argument("--limit", type=int, default=20, help="max sessions (default 20)")
+    args = ap.parse_args()
+
+    if args.limit < 1:
+        raise SystemExit("discover_sessions: --limit must be >= 1")
+
+    tr = parse_time_expr(args.since, args.tz or "")
+    sql = compose_sql(
+        tr=tr,
+        agent=args.agent,
+        channel=args.channel,
+        outcome=args.outcome,
+        grep=args.grep,
+        grep_case_sensitive=args.grep_case_sensitive,
+        limit=args.limit,
+    )
+
+    instance_url, token = resolve_org(args.org)
+    try:
+        rows = post(sql, instance_url, token, "discover_sessions")
+    except DCQueryError as e:
+        print(f"discover_sessions: DC query failed.\n{e}", file=sys.stderr)
+        return 1
+
+    agent_by_sid: dict[str, str] = {}
+    if rows:
+        sids = [r["ssot__Id__c"] for r in rows if r.get("ssot__Id__c")]
+        agent_by_sid = fetch_agent_names(sids, instance_url=instance_url, token=token)
+
+    filters = {
+        "agent": args.agent,
+        "channel": args.channel,
+        "outcome": args.outcome,
+        "grep": args.grep,
+        # Only surface the case-sensitive note when --grep is in play AND
+        # the user opted into exact match — the default (insensitive) is
+        # the boring path and shouldn't clutter the picker header.
+        "grep_case_sensitive": "yes" if (args.grep and args.grep_case_sensitive) else None,
+    }
+    print(render_picker(
+        rows=rows,
+        agent_by_sid=agent_by_sid,
+        org=args.org,
+        tr=tr,
+        filters=filters,
+        composed_sql=sql,
+    ))
+    return 0 if rows else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/investigating-agentforce-d360/scripts/fetch_dc.py
+++ b/skills/investigating-agentforce-d360/scripts/fetch_dc.py
@@ -1,0 +1,1041 @@
+"""Fetch all 24 Data Cloud artifacts for one Agentforce session.
+
+Given a session UUID and an `sf` org alias, this CLI drives the waterfall
+of DC queries defined in `assets/dc/*.sql`, lands each result under the
+nested layout:
+
+    DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/<sid>/dc.<name>.json
+
+…via `storage.save`, and emits a `dc._session_manifest.json` summarizing
+counts, timings, and empty-by-design reasons.
+
+Design contract:
+  - SQL loaded via `dc.load_sql(name, **params)` only — no inline concat.
+  - Responses parsed via `dc.parse(response)` — no inline dict digging.
+  - Persistence via `storage.save(data, org, agent, ver, sid, "dc", name)`
+    — no direct writes. Every on-disk path is validated by
+    ``paths.session_dir`` before it's touched.
+  - Identity is resolved BEFORE the first write. The sessions + participants
+    queries run first so (org_id_15, agent_api_name, agent_version) can be
+    derived; those three segments name the session dir.
+  - Every output file is written exactly once; empty artifacts go through
+    `_fetch_empty(name, reason)` so the manifest records why.
+  - Rerunning the same session overwrites prior artifacts.
+
+Invocation:
+    python3 scripts/fetch_dc.py --session <uuid> --org <alias> [--verbose]
+
+After the waterfall finishes, the fetcher chains two downstream steps:
+  1. assemble_dc.main_for_session → dc._session_tree.json
+     (skip with --no-assemble).
+  2. render_dc.main_for_session → dc._session_summary.md
+     (skip with --no-render). Runs against the on-disk tree from step 1
+     or a prior run.
+
+## DC-access preflight
+
+Before the waterfall starts, we run a single cheap probe:
+
+    SELECT Id FROM ssot__AIAgentSession__dlm WHERE ssot__Id__c = '<esc_sid>' LIMIT 1
+
+If the probe fails (401/403, no org alias, resolve_org failure), we raise
+``DcAccessDenied`` and the top-level ``main()`` branches on
+``sys.stdin.isatty()``:
+
+  - Interactive (tty): print a 2-option menu, read one line from stdin.
+    (1) retry with a different --org  (2) cancel.
+  - Headless (no tty): emit a single-line JSON preamble to stdout and
+    ``exit(10)`` immediately. Orchestrators (subagents, CI, ``claude -p``)
+    see ``exit(10)`` as the stable contract for "DC access denied".
+
+``exit(10)`` is the stable contract between this skill and any orchestrator
+wrapper — a non-zero exit code that is distinct from generic errors.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import DATA_ROOT, paths, sql as _sql_mod
+from dc import SQL_DIR, DCQueryError, load_sql, post, resolve_org
+from storage import save
+
+
+# ---- preflight / exit contracts -------------------------------------------
+
+# Exit code reserved for "DC access denied".
+# Orchestrators grep for this specifically. See module docstring for the full
+# contract; do not reuse for other failure modes.
+EXIT_DC_ACCESS_DENIED = 10
+
+
+class DcAccessDenied(RuntimeError):
+    """DC probe failed in a way that tells us DC is unusable for this session.
+
+    Carries both a short machine-readable ``reason`` (for the JSON preamble
+    payload — e.g. ``"401"``, ``"no_org"``, ``"resolve_org_failed"``) and a
+    longer human-readable ``detail`` (surfaced in the interactive prompt).
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}")
+
+
+def preflight_dc_access(
+    session_id: str,
+    org_alias: str,
+) -> tuple[str, str]:
+    """Probe DC for this session. Returns (instance_url, token) on success.
+
+    Runs the cheapest possible DC query — a single ``LIMIT 1`` against
+    ``ssot__AIAgentSession__dlm`` — to establish that:
+      - ``sf`` CLI can resolve the org alias to an instance URL + token.
+      - DC accepts the token (no 401/403).
+      - The session id is well-formed SOQL (no literal injection).
+
+    Raises ``DcAccessDenied`` on failure. The ``session_id`` is escaped
+    via ``sql._escape_sql_literal`` before being interpolated, matching
+    the Batch-C defense for ``_session_row_live``. The probe does NOT
+    require the session to exist — a zero-row response is success
+    (proves DC is reachable and auth'd).
+    """
+    # Stage 1: resolve org alias → instance_url + token. Any failure here
+    # is classified as "no_org" / "resolve_org_failed" — we never got far
+    # enough to hit DC.
+    try:
+        instance_url, token = resolve_org(org_alias)
+    except SystemExit as e:
+        raise DcAccessDenied("no_org", str(e)) from e
+
+    # Stage 2: issue the probe. Reuse ``sessions`` template with a narrow
+    # WHERE clause + LIMIT 1. The escape hardens against injection at the
+    # literal interpolation point.
+    esc_sid = _sql_mod._escape_sql_literal(session_id)
+    probe_sql = (
+        f"SELECT ssot__Id__c FROM ssot__AIAgentSession__dlm "
+        f"WHERE ssot__Id__c = '{esc_sid}' LIMIT 1"
+    )
+    try:
+        post(probe_sql, instance_url, token, "preflight")
+    except DCQueryError as e:
+        msg = str(e)
+        # Classify based on the HTTP code in the error message. The error
+        # body carries ``http=<code>`` right at the start per dc.post().
+        if "http=401" in msg:
+            raise DcAccessDenied("401", msg) from e
+        if "http=403" in msg:
+            raise DcAccessDenied("403", msg) from e
+        raise DcAccessDenied("dc_probe_failed", msg) from e
+    return instance_url, token
+
+
+def _emit_dc_access_denied_preamble(
+    reason: str,
+    detail: str,
+) -> None:
+    """Headless fallback: emit the machine-readable preamble to stdout.
+
+    Single-line JSON per the Batch-D plan. Followed by ``exit(EXIT_DC_ACCESS_DENIED)``
+    by the caller. Kept separate so tests can drive it without spawning a
+    subprocess.
+    """
+    payload = {
+        "status":  "DC_ACCESS_DENIED",
+        "reason":  reason,
+        "detail":  detail,
+        "options": [
+            {"code": "1", "action": "retry", "arg": "--org <alias>"},
+            {"code": "2", "action": "cancel"},
+        ],
+    }
+    print(json.dumps(payload))
+
+
+def _handle_dc_access_denied(
+    exc: DcAccessDenied,
+    *,
+    session_id: str,
+    is_tty: bool,
+) -> int:
+    """Branch on tty presence and return an exit code.
+
+    Interactive: print the 2-option menu; read one line from stdin.
+      - ``1`` → signal caller to retry (returns ``EXIT_DC_ACCESS_DENIED``;
+        outer ``main()`` may re-prompt for alias in a bounded loop — for
+        now we surface the exit code and let the user re-invoke).
+      - ``2`` → return 0 (user cancelled; graceful exit).
+
+    Headless: emit JSON preamble + ``EXIT_DC_ACCESS_DENIED`` immediately.
+    """
+    if not is_tty:
+        _emit_dc_access_denied_preamble(exc.reason, exc.detail)
+        return EXIT_DC_ACCESS_DENIED
+
+    _log(
+        f"\nThis skill requires Data Cloud access, which failed: "
+        f"{exc.detail}\nYour options:\n"
+        f"  (1) Retry with a different org alias (pass --org <alias>)\n"
+        f"  (2) Cancel\nPick one: "
+    )
+    try:
+        choice = sys.stdin.readline().strip()
+    except (KeyboardInterrupt, EOFError):
+        return 0
+    if choice == "1":
+        _log("Re-invoke with: python3 fetch_dc.py --session "
+             f"{session_id} --org <new-alias>")
+        return EXIT_DC_ACCESS_DENIED
+    # Any other response is treated as cancel.
+    return 0
+
+
+# ---- constants -------------------------------------------------------------
+
+_INTERNAL_TRACE_RE = re.compile(r'"internalTraceId":"([a-f0-9]+)"')  # @rule-suppress starter-sec-002 — re.compile, not exec/eval
+_NOT_SET = {"", "NOT_SET", None}
+# Mirrors _shared/fs_guard.API_NAME_RE. Duplicated locally as a pre-flight
+# gate so the cross-role fallback's adopted api_name string satisfies the
+# path-builder's regex before we hand it to paths.session_dir(). Without
+# this, paths.session_dir would reject the path with an opaque
+# ValidationError after the fallback claimed success — operator confusion.
+# Anchored \A...\Z + `.fullmatch()` (not ^...$ + .match) so trailing
+# newlines don't slip through; matches the security pattern in fs_guard.
+_API_NAME_RE = re.compile(r"\A[A-Za-z0-9_]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not exec/eval
+# Mirrors _shared/fs_guard.AGENT_VERSION_RE. Used by the cross-role
+# fallback so we never adopt a malformed version string into a session-dir
+# path.
+_VERSION_RE = re.compile(r"\Av[0-9]+\Z")  # @rule-suppress starter-sec-002 — re.compile, not exec/eval
+
+# All 24 .sql templates — checked for existence at startup.
+_TEMPLATES = (
+    "sessions", "interactions", "messages", "moments", "participants",
+    "tag_associations", "gateway_requests",
+    "steps", "moment_interactions",
+    "telemetry_spans", "generations", "app_generation",
+    "gateway_request_tags", "gateway_responses", "gateway_records",
+    "gateway_request_metadata", "gateway_request_llm",
+    "feedback",
+    "content_quality", "content_category", "feedback_details",
+    "tag_definitions", "tag_definition_associations", "tags",
+)
+
+
+# ---- small helpers ---------------------------------------------------------
+
+def _in_list(ids: list[str]) -> str:
+    """SQL `IN (…)` fragment. Dedupes, drops NOT_SET/empty, preserves order."""
+    seen: dict[str, None] = {}
+    for i in ids:
+        if i and i not in _NOT_SET and i not in seen:
+            seen[i] = None
+    return "(" + ",".join(f"'{i}'" for i in seen) + ")"
+
+
+def _extract_trace_ids(interactions: list[dict]) -> list[str]:
+    """Pull runtime trace_ids from interaction rows.
+
+    `ssot__TelemetryTraceId__c` is often empty — the real trace_id lives
+    HTML-escaped inside `ssot__AttributeText__c` as `"internalTraceId":"…"`.
+    See references/dc_dmo_fields.md for the full gotcha.
+    """
+    out: list[str] = []
+    for r in interactions:
+        tid = r.get("ssot__TelemetryTraceId__c") or ""
+        if tid and tid not in _NOT_SET:
+            out.append(tid)
+            continue
+        attr = html.unescape(r.get("ssot__AttributeText__c") or "")
+        m = _INTERNAL_TRACE_RE.search(attr)
+        if m:
+            out.append(m.group(1))
+    # dedupe, preserve order
+    return list(dict.fromkeys(out))
+
+
+def _preflight_templates() -> None:
+    """Refuse to start if any .sql template is missing."""
+    missing = [n for n in _TEMPLATES if not (SQL_DIR / f"{n}.sql").is_file()]
+    if missing:
+        raise SystemExit(
+            f"missing SQL templates in {SQL_DIR}: {', '.join(missing)}"
+        )
+
+
+# ---- fetch helpers (single entry point for disk writes + manifest) --------
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _fetch(
+    ctx: dict,
+    wave: int,
+    name: str,
+    where: str,
+    order_by: str = "",
+    *,
+    join_path: str | None = None,
+) -> list[dict]:
+    """Run a live query, save result, append manifest entry, return rows."""
+    sql = load_sql(name, WHERE_CLAUSE=where, ORDER_BY=order_by)
+    if ctx["verbose"]:
+        _log(f"    SQL[{name}]:\n{sql}\n")
+    t0 = time.monotonic()
+    try:
+        rows = post(sql, ctx["instance_url"], ctx["token"], name)
+    except DCQueryError as e:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        _log(f"  dc.{name:<30} ERROR ({elapsed_ms}ms)")
+        entry = {
+            "name": name, "wave": wave, "rows": 0,
+            "elapsed_ms": elapsed_ms, "status": "error",
+            "_unavailable_reason": str(e).splitlines()[0],
+        }
+        ctx["queries"].append(entry)
+        return []
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    # Only persist when there's data. Zero-row / error / skipped outcomes
+    # are recorded in the manifest (status + _unavailable_reason); a
+    # matching dc.<name>.json would be an empty `[]` file adding noise to
+    # the per-session directory. assemble_dc._load tolerates missing
+    # files by returning [].
+    if rows:
+        save(
+            rows,
+            ctx["org_id_15"],
+            ctx["agent_api_name"],
+            ctx["agent_version"],
+            ctx["session_id"],
+            "dc",
+            name,
+        )
+    entry = {
+        "name": name, "wave": wave, "rows": len(rows),
+        "elapsed_ms": elapsed_ms,
+        "status": "ok" if rows else "empty",
+    }
+    if join_path:
+        entry["join_path"] = join_path
+    if not rows:
+        entry["_unavailable_reason"] = (
+            f"query returned zero rows for where={where[:120]}"
+        )
+    ctx["queries"].append(entry)
+    _log(f"  dc.{name:<30} rows={len(rows):<5} ({elapsed_ms}ms)")
+    return rows
+
+
+def _fetch_empty(ctx: dict, wave: int, name: str, reason: str) -> None:
+    """Record a skipped query in the manifest — no HTTP call, no artifact file."""
+    ctx["queries"].append({
+        "name": name, "wave": wave, "rows": 0,
+        "elapsed_ms": 0, "status": "skipped",
+        "_unavailable_reason": reason,
+    })
+    _log(f"  dc.{name:<30} SKIPPED ({reason})")
+
+
+# ---- main entry point -----------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="fetch_dc.py",
+        description="Fetch all 24 DC artifacts for one Agentforce session.",
+    )
+    ap.add_argument("--session", required=True,
+                    help="AI-agent session UUID, OR a Salesforce MessagingSession id "
+                         "(0Mw... prefix). Messaging ids are resolved to the UUID "
+                         "via a one-row DC lookup before the waterfall starts.")
+    ap.add_argument("--org", required=True, help="sf org alias")
+    ap.add_argument("--verbose", action="store_true", help="dump each SQL before POST")
+    ap.add_argument("--no-assemble", action="store_true",
+                    help="skip tree assembly after fetch")
+    ap.add_argument("--no-render", action="store_true",
+                    help="skip summary markdown rendering")
+    args = ap.parse_args()
+
+    _preflight_templates()
+
+    # Accept either a UUID or a MessagingSession id (0Mw...). The resolver
+    # passes UUIDs through unchanged; on messaging ids it tries disk first
+    # (any prior fetch left dc.sessions.json behind under DATA_ROOT), and
+    # falls back to a live one-row DC lookup only if disk misses. This keeps
+    # fetch_dc consistent with every other entry point and avoids a
+    # round-trip when re-invoking against an already-fetched session.
+    # On multi-match or zero-match the resolver exits with a diagnostic.
+    from resolve_session import is_messaging_id, resolve_disk_or_live
+    input_id = args.session
+    session_id = resolve_disk_or_live(input_id, org=args.org)
+    if is_messaging_id(input_id):
+        _log(f"resolved messaging id {input_id} → AiAgentSession {session_id}")
+
+    # Preflight — one cheap probe before the waterfall starts.
+    # Fails fast with DcAccessDenied on 401/403/no-org. The outer try
+    # block routes the exception through _handle_dc_access_denied, which
+    # emits either an interactive prompt or a JSON preamble depending on
+    # tty presence, then exits with EXIT_DC_ACCESS_DENIED (10).
+    try:
+        instance_url, token = preflight_dc_access(session_id, args.org)
+    except DcAccessDenied as exc:
+        return _handle_dc_access_denied(
+            exc,
+            session_id=session_id,
+            is_tty=sys.stdin.isatty(),
+        )
+    _log(f"org:     {instance_url}")
+    _log(f"session: {session_id}\n")
+
+    ctx = {
+        "session_id": session_id,
+        "org_alias": args.org,
+        "instance_url": instance_url,
+        "token": token,
+        "verbose": args.verbose,
+        "queries": [],
+        "started_at": datetime.now(timezone.utc),
+        # Populated by _resolve_identity() before the first storage.save call.
+        "org_id_15": None,
+        "agent_api_name": None,
+        "agent_version": None,
+    }
+
+    _run_waterfall(ctx)
+
+    _write_manifest(ctx)
+
+    if not args.no_assemble:
+        from assemble_dc import main_for_session as _assemble
+        _assemble(args.session)
+
+    if not args.no_render:
+        from render_dc import main_for_session as _render
+        _render(args.session)  # SystemExits if tree is missing
+
+    return 0
+
+
+def _fetch_no_save(
+    ctx: dict, wave: int, name: str, where: str, order_by: str = "",
+) -> list[dict]:
+    """Variant of ``_fetch`` that skips the on-disk write.
+
+    Used for the identity-resolution phase: ``sessions`` and ``participants``
+    run before we know ``(org_id_15, agent_api_name, agent_version)``, which
+    are required to build the target session dir. We stash the rows and
+    write them via ``storage.save`` once identity is resolved.
+
+    Manifest entry is still appended so the final ``dc._session_manifest.json``
+    mirrors every query run.
+    """
+    sql = load_sql(name, WHERE_CLAUSE=where, ORDER_BY=order_by)
+    if ctx["verbose"]:
+        _log(f"    SQL[{name}]:\n{sql}\n")
+    t0 = time.monotonic()
+    try:
+        rows = post(sql, ctx["instance_url"], ctx["token"], name)
+    except DCQueryError as e:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        _log(f"  dc.{name:<30} ERROR ({elapsed_ms}ms)")
+        ctx["queries"].append({
+            "name": name, "wave": wave, "rows": 0,
+            "elapsed_ms": elapsed_ms, "status": "error",
+            "_unavailable_reason": str(e).splitlines()[0],
+        })
+        return []
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    entry = {
+        "name": name, "wave": wave, "rows": len(rows),
+        "elapsed_ms": elapsed_ms,
+        "status": "ok" if rows else "empty",
+    }
+    if not rows:
+        entry["_unavailable_reason"] = (
+            f"query returned zero rows for where={where[:120]}"
+        )
+    ctx["queries"].append(entry)
+    _log(f"  dc.{name:<30} rows={len(rows):<5} ({elapsed_ms}ms)  [deferred save]")
+    return rows
+
+
+def _lookup_org_id_via_sf_cli(org_alias: str) -> str:
+    """Return the 15-char org id from ``sf org display --target-org <alias>``.
+
+    Fallback path for ``_resolve_identity``: the DMO field
+    ``ssot__InternalOrganizationId__c`` is occasionally null on
+    otherwise-well-formed sessions (materialization gap in the SSOT
+    pipeline). Since the authenticated ``sf`` alias already knows the
+    org id, we ask the CLI directly rather than failing the whole run.
+
+    Matches the shell pattern used by ``dc.resolve_org`` — same argv, same
+    JSON shape (``.result.id``). Any non-zero exit, missing binary, or
+    malformed payload propagates to the caller as an exception so the
+    outer ``_resolve_identity`` can raise a unified "both sources failed"
+    diagnostic.
+    """
+    proc = subprocess.run(
+        ["sf", "org", "display", "--target-org", org_alias, "--json"],
+        capture_output=True, text=True, check=True,
+    )
+    payload = json.loads(proc.stdout)
+    org_id = (payload.get("result") or {}).get("id") or ""
+    if len(org_id) < 15:
+        raise ValueError(
+            f"sf org display returned result.id={org_id!r} (len<15)"
+        )
+    return org_id[:15]
+
+
+def _resolve_identity(
+    sessions: list[dict],
+    participants: list[dict],
+    org_alias: str,
+) -> tuple[str, str, str]:
+    """Derive (org_id_15, agent_api_name, agent_version) from wave-1 rows.
+
+    - ``org_id_15`` — ``sessions[0].ssot__InternalOrganizationId__c[:15]``,
+      falling back to ``sf org display --target-org <org_alias>`` when the
+      DMO field is null/empty/shorter-than-15 (a known SSOT materialization
+      gap; the authenticated CLI alias knows the org id regardless).
+    - ``agent_api_name`` / ``agent_version`` — first AGENT participant row
+      (sorted by participant id for determinism) with both fields populated.
+
+    **Dominant-agent policy:** if multiple AGENT participants are present
+    (handoff sessions), the one with the lexicographically first
+    ``agent_api_name`` wins. Matches the ``sorted(agents_observed)[0]``
+    rule used by ``_session_row_live`` and the migration script, so every
+    writer agrees on the session's home dir.
+
+    Raises ``SystemExit`` with a clear diagnostic when any segment cannot
+    be derived. We deliberately do NOT fall back to a catch-all "unknown"
+    agent dir — writing under a synthetic identity would let every
+    ambiguous session pile into the same folder and corrupt the layout
+    invariant the migration script depends on.
+    """
+    if not sessions:
+        raise SystemExit(
+            "fetch_dc: sessions query returned 0 rows; "
+            "cannot resolve org identity — is the session id correct?"
+        )
+    org_id_18 = sessions[0].get("ssot__InternalOrganizationId__c") or ""
+    if org_id_18 and len(org_id_18) >= 15:
+        org_id_15 = org_id_18[:15]
+    else:
+        # DMO field is null/empty/short. The session is otherwise well-formed
+        # — fall back to the authenticated sf alias for the org id.
+        try:
+            org_id_15 = _lookup_org_id_via_sf_cli(org_alias)
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                json.JSONDecodeError, ValueError) as e:
+            raise SystemExit(
+                f"fetch_dc: both DMO field and sf org display failed — "
+                f"sessions[0].ssot__InternalOrganizationId__c={org_id_18!r}, "
+                f"sf org display --target-org {org_alias!r} error: "
+                f"{type(e).__name__}: {e}"
+            )
+        _log(
+            f"  org_id_15 fallback to sf org display: {org_id_15} "
+            f"(DMO field was null)"
+        )
+
+    # Collect every AGENT participant with a non-empty agent_api_name +
+    # agent_version. Sort by (api_name, version) for a stable dominant-
+    # agent pick on handoffs.
+    candidates = sorted(
+        {
+            (
+                p.get("ssot__AiAgentApiName__c") or "",
+                p.get("ssot__AiAgentVersionApiName__c") or "",
+            )
+            for p in participants
+            if p.get("ssot__AiAgentSessionParticipantRole__c") == "AGENT"
+        }
+    )
+    # Drop entries missing either field.
+    candidates = [(n, v) for n, v in candidates if n and v and n not in _NOT_SET and v not in _NOT_SET]
+    if not candidates:
+        # Fallback: some agent shapes (e.g. MyAgent on Messaging)
+        # leave AGENT rows with api_name/version=NOT_SET while USER (or
+        # other-role) participant rows carry both fields. Harvest from
+        # ANY role first so we land on the real (api_name, version) pair
+        # — that's what assemble_dc later reconciles into the tree, so
+        # the dir name and tree.identity will agree out of the gate
+        # rather than dir=__v0/ + tree=__v24/.
+        cross_role = sorted({
+            (
+                p.get("ssot__AiAgentApiName__c") or "",
+                p.get("ssot__AiAgentVersionApiName__c") or "",
+            )
+            for p in participants
+        })
+        cross_role = [
+            (n, v) for n, v in cross_role
+            if n and n not in _NOT_SET
+            and v and v not in _NOT_SET
+            and _API_NAME_RE.fullmatch(n)
+            and _VERSION_RE.fullmatch(v)
+        ]
+        if cross_role:
+            api_name, version = cross_role[0]
+            _log(
+                f"  identity fallback: strict AGENT-row resolution failed; "
+                f"using api_name={api_name!r} version={version!r} from a "
+                f"non-AGENT participant row"
+            )
+            return org_id_15, api_name, version
+        # Last-ditch fallback: api_name from any role, but no version
+        # available anywhere. Stamp version='v0' (placeholder satisfying
+        # ^v[0-9]+$). Without this, the entire DC pipeline is unrunnable
+        # for those sessions even though all the downstream rows exist.
+        # The Builder Previewer shape legitimately lands here — every
+        # version_api_name in DC for that session truly is empty/v0.
+        any_names = sorted({
+            (p.get("ssot__AiAgentApiName__c") or "")
+            for p in participants
+        })
+        any_names = [n for n in any_names if n and n not in _NOT_SET]
+        # Only promote names that satisfy fs_guard's API_NAME_RE — otherwise
+        # paths.session_dir would reject the dir later with an opaque
+        # ValidationError. Cleaner UX is to fall through to the original
+        # SystemExit, which carries actionable diagnostic text.
+        any_names = [n for n in any_names if _API_NAME_RE.fullmatch(n)]
+        if any_names:
+            _log(
+                f"  identity fallback: strict AGENT-row resolution failed; "
+                f"no participant row carries (api_name, version) together; "
+                f"using api_name={any_names[0]!r} from any participant row, "
+                f"version='v0' (placeholder)"
+            )
+            return org_id_15, any_names[0], "v0"
+        raise SystemExit(
+            "fetch_dc: no AGENT participants with agent_api_name + "
+            "agent_version on this session; cannot resolve identity. "
+            "If the session was created recently, STDM materialization "
+            "may not have completed yet — retry in a few minutes. "
+            "Otherwise the session may be malformed."
+        )
+    agent_api_name, agent_version = candidates[0]
+    return org_id_15, agent_api_name, agent_version
+
+
+def _run_waterfall(ctx: dict) -> None:
+    """5-wave forward-only orchestration.
+
+    Wave 1 fetches session-scoped rows directly keyed on the session id.
+    Wave 2 fetches interaction-scoped rows (Steps, MomentInteractions).
+    Wave 3 fans out to Generation (via Step.GenerationId) and to the full
+    Gateway audit chain (via GatewayRequest.sessionId__c harvested in
+    wave 1 — GatewayResponse, Tags, ObjRecord, Metadata, LLM).
+    Wave 4 fetches Generation-scoped child rows (Quality, Category,
+    Feedback children).
+    Wave 5 fetches the agent/tag catalog (not session-keyed).
+
+    Every edge is forward from Session. See `references/dc_dmo_fields.md`
+    for the full join map.
+
+    Wave-1 ordering: ``sessions`` + ``participants`` run first with
+    deferred saves so ``_resolve_identity`` can compute the session's
+    target dir BEFORE any on-disk write. Without this ordering, the
+    first ``storage.save`` call would fail validation (``paths.session_dir``
+    requires the 3 identity segments). Once identity is stamped on
+    ``ctx``, remaining wave-1 queries save through the normal ``_fetch``
+    path.
+    """
+    sid = ctx["session_id"]
+    sid_q = f"'{sid}'"
+
+    # ---- wave 1a: identity resolution (deferred save) --------------------
+    _log("== wave 1a: identity resolution ==")
+    sessions = _fetch_no_save(ctx, 1, "sessions",
+                              f"ssot__Id__c = {sid_q}")
+    participants = _fetch_no_save(ctx, 1, "participants",
+                                  f"ssot__AiAgentSessionId__c = {sid_q}")
+    (
+        ctx["org_id_15"],
+        ctx["agent_api_name"],
+        ctx["agent_version"],
+    ) = _resolve_identity(sessions, participants, ctx["org_alias"])
+    _log(
+        f"  identity: org={ctx['org_id_15']}  "
+        f"agent={ctx['agent_api_name']}  version={ctx['agent_version']}"
+    )
+
+    # Flush deferred writes now that identity is known. Empty results
+    # stay unwritten (same contract as ``_fetch``).
+    if sessions:
+        save(
+            sessions, ctx["org_id_15"], ctx["agent_api_name"],
+            ctx["agent_version"], sid, "dc", "sessions",
+        )
+    if participants:
+        save(
+            participants, ctx["org_id_15"], ctx["agent_api_name"],
+            ctx["agent_version"], sid, "dc", "participants",
+        )
+
+    # ---- wave 1b: remaining session-scoped (5 queries) -------------------
+    _log("\n== wave 1b: session-scoped ==")
+    interactions = _fetch(ctx, 1, "interactions",
+                          f"ssot__AiAgentSessionId__c = {sid_q}",
+                          "ORDER BY ssot__StartTimestamp__c")
+    messages = _fetch(ctx, 1, "messages",
+                      f"ssot__AiAgentSessionId__c = {sid_q}",
+                      "ORDER BY ssot__MessageSentTimestamp__c")
+    moments = _fetch(ctx, 1, "moments",
+                     f"ssot__AiAgentSessionId__c = {sid_q}",
+                     "ORDER BY ssot__StartTimestamp__c")
+    _fetch(ctx, 1, "tag_associations",
+           f"ssot__AiAgentSessionId__c = {sid_q}")
+    # sessionId__c is stored as a literal quoted string ('"<uuid>"'); raw-UUID
+    # exact match returns 0 rows. LIKE handles both '"<uuid>"' and any future
+    # variant cleanly. See references/dc_dmo_fields.md.
+    gw_requests = _fetch(ctx, 1, "gateway_requests",
+                         f"sessionId__c LIKE '%{sid}%'",
+                         "ORDER BY timestamp__c")
+
+    # Harvest IDs from wave 1 for downstream waves
+    interaction_ids = [r.get("ssot__Id__c") for r in interactions]
+    # Agent name harvest: moments DMO is sparse — many short or
+    # abandoned-before-tagging sessions never write a moment row, leaving
+    # agent_api_names empty even though the agent identity was already
+    # resolved upstream. Fall through to participants (always populated
+    # for any session with ≥1 turn) and finally to ctx.agent_api_name
+    # (resolved during identity wave 1a from BotDefinition).
+    _harvested = {
+        r["ssot__AiAgentApiName__c"]
+        for r in moments
+        if r.get("ssot__AiAgentApiName__c") and r["ssot__AiAgentApiName__c"] not in _NOT_SET
+    }
+    _harvested |= {
+        r["ssot__AiAgentApiName__c"]
+        for r in participants
+        if r.get("ssot__AiAgentApiName__c") and r["ssot__AiAgentApiName__c"] not in _NOT_SET
+    }
+    if not _harvested and ctx.get("agent_api_name"):
+        _harvested = {ctx["agent_api_name"]}
+    agent_api_names = sorted(_harvested)
+    gw_req_ids = [r.get("gatewayRequestId__c") for r in gw_requests]
+    trace_ids = _extract_trace_ids(interactions)
+    _log(f"  harvested: {len(interaction_ids)} interactions, "
+         f"{len(moments)} moments, trace_ids={len(trace_ids)}, "
+         f"gw_req_ids={len(gw_req_ids)}, agents={agent_api_names}")
+
+    # ---- wave 2: interaction/moment-scoped (2 queries) --------------------
+    _log("\n== wave 2: interaction/moment-scoped ==")
+    interaction_in = _in_list(interaction_ids)
+    if interaction_in != "()":
+        steps = _fetch(ctx, 2, "steps",
+                       f"ssot__AiAgentInteractionId__c IN {interaction_in}",
+                       "ORDER BY ssot__StartTimestamp__c")
+        _fetch(ctx, 2, "moment_interactions",
+               f"ssot__AiAgentInteractionId__c IN {interaction_in}")
+    else:
+        steps = []
+        _fetch_empty(ctx, 2, "steps",
+                     "no interactions for session")
+        _fetch_empty(ctx, 2, "moment_interactions",
+                     "no interactions for session")
+
+    # Harvest generation IDs from steps for forward fetch of GenAIGeneration.
+    # (Step.ssot__GenAiGatewayResponseId__c / ssot__GenAiGatewayRequestId__c are
+    # NOT harvested — those would be backward chains. Gateway audit rows are
+    # fetched forward from the session via GatewayRequest.sessionId__c in wave 1.)
+    step_gen_ids = [s.get("ssot__GenerationId__c") for s in steps]
+    _log(f"  harvested: generation_ids={len([x for x in step_gen_ids if x and x not in _NOT_SET])}")
+
+    # ---- wave 3: trace/generation/gateway fanout (6 queries) --------------
+    _log("\n== wave 3: trace/generation/gateway fanout ==")
+
+    # telemetry_spans — on trace_ids from interactions
+    trace_in = _in_list(trace_ids)
+    if trace_in != "()":
+        _fetch(ctx, 3, "telemetry_spans",
+               f"ssot__TelemetryTrace__c IN {trace_in}",
+               "ORDER BY ssot__StartDateTime__c")
+    else:
+        _fetch_empty(ctx, 3, "telemetry_spans",
+                     "no trace_ids extractable from interactions "
+                     "(TelemetryTraceId__c empty and no internalTraceId in AttributeText__c)")
+
+    # generations — canonical path: steps.ssot__GenerationId__c
+    gen_in = _in_list(step_gen_ids)
+    if gen_in != "()":
+        generations = _fetch(ctx, 3, "generations",
+                             f"generationId__c IN {gen_in}",
+                             "ORDER BY timestamp__c",
+                             join_path="steps.ssot__GenerationId__c")
+        # app_generation — same join key as generations (sibling DMO)
+        _fetch(ctx, 3, "app_generation",
+               f"generationId__c IN {gen_in}",
+               "ORDER BY timestamp__c",
+               join_path="steps.ssot__GenerationId__c")
+    else:
+        generations = []
+        _fetch_empty(ctx, 3, "generations",
+                     "no step.ssot__GenerationId__c values on this session "
+                     "(all steps had NOT_SET or steps table was empty)")
+        _fetch_empty(ctx, 3, "app_generation",
+                     "no step.ssot__GenerationId__c values on this session "
+                     "(all steps had NOT_SET or steps table was empty)")
+
+    # --- Gateway audit chain (forward-only from session) ------------------
+    # All audit rows flow forward from Session via GatewayRequest.sessionId__c
+    # (harvested in wave 1). Every child table is keyed on the authoritative
+    # gw_req_ids from that wave-1 fetch:
+    #
+    #   GenAIGatewayResponse       generationRequestId__c IN {gw_req_ids}
+    #   GenAIGatewayRequestTag     parent__c              IN {gw_req_ids}
+    #   GenAIGtwyObjRecord         parent__c              IN {gw_req_ids}
+    #   GenAIGtwyRequestMetadata   parent__c              IN {gw_req_ids}
+    #   GenAIGtwyRequestLLM        parent__c              IN {gw_req_ids}
+    #
+    # No Step->Response->Request chain. Step's GenAiGatewayRequestId__c and
+    # GenAiGatewayResponseId__c FKs exist but we don't harvest them: they
+    # only cover LLM_STEP-owned calls and miss nested features like
+    # PromptTemplateGenerationsInvocable. The session-direct fetch in wave 1
+    # is the authoritative set.
+    gw_req_in = _in_list(gw_req_ids)
+    if gw_req_in != "()":
+        _fetch(ctx, 3, "gateway_responses",
+               f"generationRequestId__c IN {gw_req_in}",
+               "ORDER BY timestamp__c",
+               join_path="gateway_requests.gatewayRequestId__c")
+        _fetch(ctx, 3, "gateway_request_tags",
+               f"parent__c IN {gw_req_in}")
+        _fetch(ctx, 3, "gateway_records",
+               f"parent__c IN {gw_req_in}")
+        _fetch(ctx, 3, "gateway_request_metadata",
+               f"parent__c IN {gw_req_in}")
+        _fetch(ctx, 3, "gateway_request_llm",
+               f"parent__c IN {gw_req_in}")
+    else:
+        gw_empty_reason = (
+            "no gateway_requests matched GatewayRequest.sessionId__c LIKE "
+            "'%<sid>%' in wave 1 — Trust Layer gateway logging may be "
+            "disabled for this org, or the session produced no LLM calls"
+        )
+        for n in ("gateway_responses", "gateway_request_tags", "gateway_records",
+                  "gateway_request_metadata", "gateway_request_llm"):
+            _fetch_empty(ctx, 3, n, gw_empty_reason)
+
+    # feedback — keyed by generationId (no session col on GenAIFeedback)
+    gen_ids_for_feedback = [r.get("generationId__c") for r in generations]
+    feedback_in = _in_list(gen_ids_for_feedback)
+    if feedback_in != "()":
+        feedback = _fetch(ctx, 3, "feedback",
+                          f"generationId__c IN {feedback_in}")
+    else:
+        feedback = []
+        _fetch_empty(ctx, 3, "feedback",
+                     "no generation_ids available (generations wave was empty)")
+
+    # ---- wave 4: generation/feedback-dependent (3 queries) ----------------
+    _log("\n== wave 4: generation/feedback-dependent ==")
+    gen_only_in = _in_list(gen_ids_for_feedback)
+    if gen_only_in != "()":
+        quality = _fetch(ctx, 4, "content_quality",
+                         f"parent__c IN {gen_only_in}")
+    else:
+        quality = []
+        _fetch_empty(ctx, 4, "content_quality",
+                     "no generation_ids (parent__c IN cannot be empty)")
+
+    # content_category — parent is (generation_ids ∪ quality.id__c)
+    quality_ids = [r.get("id__c") or r.get("ssot__Id__c") for r in quality]
+    category_parent_ids = gen_ids_for_feedback + quality_ids
+    category_in = _in_list(category_parent_ids)
+    if category_in != "()":
+        _fetch(ctx, 4, "content_category",
+               f"parent__c IN {category_in}")
+    else:
+        _fetch_empty(ctx, 4, "content_category",
+                     "no generation_ids or quality_ids to parent to")
+
+    # feedback_details — parent is feedback row id.
+    # GenAIFeedback__dlm PK is `feedbackId__c` (no ssot__ prefix, verified via describe);
+    # the old harvest used ssot__Id__c which doesn't exist on this DMO.
+    feedback_ids = [r.get("feedbackId__c") for r in feedback]
+    feedback_ids_in = _in_list(feedback_ids)
+    if feedback_ids_in != "()":
+        _fetch(ctx, 4, "feedback_details",
+               f"parent__c IN {feedback_ids_in}")
+    else:
+        _fetch_empty(ctx, 4, "feedback_details",
+                     "no feedback rows for this session "
+                     "(no user thumbs-up/down on any generation)")
+
+    # ---- wave 5: tag catalog (agent-scoped) -------------------------------
+    _log("\n== wave 5: tag catalog ==")
+    # Live orgs use 'Available' (not Help-doc's 'Active'). If that returns
+    # zero rows, retry unfiltered — some orgs have a different enum value or
+    # the definitions predate the Status field. See references/dc_dmo_fields.md.
+    tag_defs = _fetch(ctx, 5, "tag_definitions",
+                      "ssot__Status__c = 'Available'")
+    if not tag_defs:
+        _log("  (tag_definitions Status='Available' empty — retrying unfiltered)")
+        # Pop the empty entry so _fetch can append a fresh one for the retry.
+        # The retry overwrites the same on-disk artifact (last run wins).
+        ctx["queries"].pop()
+        tag_defs = _fetch(ctx, 5, "tag_definitions",
+                          "ssot__Id__c IS NOT NULL")
+        # Tag the retry in the manifest for traceability.
+        ctx["queries"][-1]["notes"] = (
+            "retried unfiltered after Status='Available' returned 0 rows"
+        )
+        if not tag_defs:
+            ctx["queries"][-1]["_unavailable_reason"] = (
+                "tag_definitions truly empty on this org"
+            )
+
+    agent_in = _in_list(agent_api_names)
+    if agent_in != "()":
+        _fetch(ctx, 5, "tag_definition_associations",
+               f"ssot__AiAgentApiName__c IN {agent_in}")
+    else:
+        _fetch_empty(ctx, 5, "tag_definition_associations",
+                     "no agent api names observed in moments")
+
+    def_ids = [r.get("ssot__Id__c") for r in tag_defs]
+    def_in = _in_list(def_ids)
+    if def_in != "()":
+        _fetch(ctx, 5, "tags",
+               f"ssot__AiAgentTagDefinitionId__c IN {def_in}")
+    else:
+        _fetch_empty(ctx, 5, "tags",
+                     "no tag_definition ids (tag_definitions was empty)")
+
+    # Tally steps by type for the session_shape classifier.
+    steps_by_type = {
+        "LLM_STEP": 0, "ACTION_STEP": 0, "TOPIC_STEP": 0,
+        "TRUST_GUARDRAILS_STEP": 0, "SESSION_END": 0,
+    }
+    for s in steps:
+        t = s.get("ssot__AiAgentInteractionStepType__c")
+        if t in steps_by_type:
+            steps_by_type[t] += 1
+
+    # Stash harvested-id counts for the manifest
+    steps_with_gen = sum(1 for g in step_gen_ids if g and g not in _NOT_SET)
+    ctx["harvested_ids"] = {
+        "sessions": len(sessions),
+        "messages": len(messages),
+        "interactions": len(interaction_ids),
+        "moments": len(moments),
+        "steps_total": len(steps),
+        "steps_by_type": steps_by_type,
+        "steps_with_generation_id": steps_with_gen,
+        "trace_ids_from_interactions": len(trace_ids),
+        "gateway_request_ids": len(gw_req_ids),
+        "generation_ids": sum(
+            1 for g in gen_ids_for_feedback if g and g not in _NOT_SET
+        ),
+        "agents_observed": agent_api_names,
+    }
+
+    # Classify session shape. 5-value enum; rules evaluated top-to-bottom, first-match-wins.
+    # See references/dc_dmo_fields.md for rationale.
+    ctx["session_shape"] = _classify_session_shape(
+        sessions_count=len(sessions),
+        steps_total=len(steps),
+        llm_step_count=steps_by_type["LLM_STEP"],
+        steps_with_generation_id=steps_with_gen,
+        gw_req_count=len(gw_req_ids),
+    )
+
+
+def _classify_session_shape(*, sessions_count, steps_total, llm_step_count,
+                            steps_with_generation_id, gw_req_count):
+    """6-value session-shape diagnostic. First match wins.
+
+    Rules (top-to-bottom):
+    - session_not_found                       — sessions.json returned 0 rows
+    - interactions_not_materialized_yet       — gw_reqs > 0 AND steps == 0. Gateway DMOs
+                                                materialize within minutes; STDM Interaction
+                                                / Step / Message DMOs can take hours to days.
+                                                Detected BEFORE abandoned_before_llm because
+                                                gw_req_count > 0 is a stronger positive signal
+                                                than steps_total > 0 (and the two rules'
+                                                inputs are disjoint on this path — steps == 0
+                                                here, gw_reqs == 0 for abandoned).
+    - abandoned_before_llm                    — steps > 0, LLM_STEP == 0, gw_reqs == 0
+    - gateway_requests_dropped_by_stdm        — LLM_STEP > 0
+                                                AND gw_reqs == 0 AND steps_with_generation_id == 0.
+                                                STDM dropped not just gateway_requests but also
+                                                generations (the join chain Step→Generation
+                                                is broken). Frequently observed on Atlas-routed
+                                                sessions; visible in Splunk LLMGatewayUsageEventWriter
+                                                even when DC has zero rows.
+    - planner_ran_no_gateway_logs             — LLM_STEP > 0 AND steps_with_generation_id > 0
+                                                AND gw_reqs == 0 (the extra guard prevents a
+                                                broken generations-IN-clause from being
+                                                misclassified here). Generations wrote to DC,
+                                                gateway_requests did not — narrower defect than
+                                                gateway_requests_dropped_by_stdm.
+    - complete                                — everything else (the "normal" bucket,
+                                                including partial chain-orphan sessions)
+
+    See references/dc_dmo_fields.md for rationale.
+    """
+    if sessions_count == 0:
+        return "session_not_found"
+    if gw_req_count > 0 and steps_total == 0:
+        return "interactions_not_materialized_yet"
+    if steps_total > 0 and llm_step_count == 0 and gw_req_count == 0:
+        return "abandoned_before_llm"
+    # When LLM_STEPs ran but neither gateway_requests nor generations
+    # wrote, the STDM exporter dropped both. Distinct from
+    # planner_ran_no_gateway_logs (which still has generation rows).
+    if (llm_step_count > 0 and steps_with_generation_id == 0
+            and gw_req_count == 0):
+        return "gateway_requests_dropped_by_stdm"
+    if (llm_step_count > 0 and steps_with_generation_id > 0
+            and gw_req_count == 0):
+        return "planner_ran_no_gateway_logs"
+    return "complete"
+
+
+def _write_manifest(ctx: dict) -> None:
+    """Emit dc._session_manifest.json next to the 24 artifacts."""
+    finished = datetime.now(timezone.utc)
+    elapsed_ms = int((finished - ctx["started_at"]).total_seconds() * 1000)
+    manifest = {
+        "_doc": "Per-query summary of this DC fetch run.",
+        "session_id": ctx["session_id"],
+        "org_alias": ctx["org_alias"],
+        "instance_url": ctx["instance_url"],
+        # Identity resolved in wave 1a, before any on-disk write. Stamped
+        # here so downstream readers can recover (org, agent, version)
+        # without re-parsing the tree.
+        "org_id_15": ctx.get("org_id_15"),
+        "agent_api_name": ctx.get("agent_api_name"),
+        "agent_version": ctx.get("agent_version"),
+        "session_shape": ctx.get("session_shape", "unknown"),
+        "started_at_utc": ctx["started_at"].isoformat().replace("+00:00", "Z"),
+        "finished_at_utc": finished.isoformat().replace("+00:00", "Z"),
+        "elapsed_ms": elapsed_ms,
+        "queries": ctx["queries"],
+        "harvested_ids": ctx.get("harvested_ids", {}),
+    }
+    target = paths.session_dir(
+        ctx["org_id_15"],
+        ctx["agent_api_name"],
+        ctx["agent_version"],
+        ctx["session_id"],
+    ) / "dc._session_manifest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(manifest, indent=2, default=str) + "\n")
+    _log(f"\nmanifest: {target}  ({elapsed_ms}ms total)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-d360/scripts/render_dc.py
+++ b/skills/investigating-agentforce-d360/scripts/render_dc.py
@@ -1,0 +1,1746 @@
+"""Render dc._session_summary.md from dc._session_tree.json + dc._session_manifest.json.
+
+Given `DATA_ROOT/<sid>/dc._session_tree.json` (produced by `scripts/assemble_dc.py`)
+this module emits a human-readable `dc._session_summary.md`. Pure tree reader —
+no raw DMO fetches, no joins. The `session.identity` sub-object on the tree
+(added by the assembler) supplies all identity fields; everything else
+(counts, trees, catalog) comes from the tree itself.
+
+Output has 8 `##` sections:
+
+  1. Session identity      — org/agent/bot/planner/session-start/end/duration
+  2. ID reference          — full UUIDs for every ellipsized id in the tree
+  3. Transcript            — narrative USER/AGENT text per TURN
+  4. Complete hierarchical trace — tree with `+start + dur = +end` math
+  5. Per-turn summary      — one row per interaction
+  6. Session counts        — engineer-facing totals
+  7. Empties diagnostics   — DMOs that returned 0 rows + reason
+  8. Catalog (session-filtered)
+
+Contract:
+  - Pure in-memory compute over already-produced artifacts.
+  - Reads DATA_ROOT/<sid>/dc._session_tree.json and dc._session_manifest.json.
+  - UUIDs in the tree are truncated to first 8 chars + `…`; full forms
+    live in the ID reference block.
+  - Session-not-found trees render only Session identity + a note.
+  - Tree schema version check: refuses incompatible versions, warns on
+    missing version (backward compat).
+
+Invocation:
+    python3 scripts/render_dc.py --session <sid>
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import DATA_ROOT, paths
+
+
+# ---- schema ---------------------------------------------------------------
+
+_SUPPORTED_SCHEMA_VERSION = 1
+
+
+# ---- timestamp / string helpers -------------------------------------------
+
+def _parse_iso(s: Optional[str]) -> Optional[datetime]:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _fmt_offset(ts_iso: Optional[str], start_dt: Optional[datetime]) -> str:
+    """Return '+12.345s' or '—' if timestamp is missing."""
+    ts = _parse_iso(ts_iso)
+    if ts is None or start_dt is None:
+        return "—"
+    return f"+{(ts - start_dt).total_seconds():.3f}s"
+
+
+def _fmt_duration_ms(start_iso: Optional[str], end_iso: Optional[str]) -> str:
+    s = _parse_iso(start_iso)
+    e = _parse_iso(end_iso)
+    if s is None or e is None:
+        return "—"
+    return f"{int((e - s).total_seconds() * 1000)}ms"
+
+
+def _decode(s: Optional[str]) -> str:
+    if not s:
+        return ""
+    return html.unescape(s).replace("\n", " ").strip()
+
+
+def _truncate(s: Optional[str], n: int = 80) -> str:
+    if not s:
+        return "—"
+    s = _decode(s)
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _short(uid: Optional[str], keep: int = 8) -> str:
+    """Truncate a UUID to `keep` chars + ellipsis. Full form lives in ID reference."""
+    if not uid:
+        return "—"
+    return uid[:keep] + "…" if len(uid) > keep else uid
+
+
+def _fmt_total_duration(start_iso: Optional[str], end_iso: Optional[str]) -> Optional[str]:
+    s = _parse_iso(start_iso)
+    e = _parse_iso(end_iso)
+    if s is None or e is None:
+        return None
+    total_secs = (e - s).total_seconds()
+    if total_secs >= 3600:
+        h = int(total_secs // 3600)
+        m = int((total_secs % 3600) // 60)
+        return f"{h}h {m}m {total_secs % 60:.3f}s"
+    if total_secs >= 60:
+        m = int(total_secs // 60)
+        return f"{m}m {total_secs % 60:.3f}s"
+    return f"{total_secs:.3f}s"
+
+
+# ---- session-end derivation ----------------------------------------------
+
+def _derive_session_end(sess: dict) -> tuple[Optional[str], Optional[str]]:
+    """Return (effective_end_iso, source_label).
+
+    Contract §3.5 derivation:
+      1. If `session.end_ts` is non-null → return it as-is (caller adds
+         "✓ materialized" suffix).
+      2. Else prefer a SESSION_END interaction's `start_ts`
+         (label: "from SESSION_END interaction").
+      3. Else fall back to the last TURN interaction's `end_ts`
+         (or `start_ts` if end is null) (label: "session still open (last TURN)").
+      4. Else `(None, None)`.
+    """
+    end_iso = sess.get("end_ts")
+    if end_iso:
+        return end_iso, None  # no derivation needed
+    interactions = sess.get("interactions") or []
+    # Prefer SESSION_END start_ts.
+    for iv in interactions:
+        if iv.get("type") == "SESSION_END" and iv.get("start_ts"):
+            return iv["start_ts"], "from SESSION_END interaction"
+    # Fall back to the last TURN (by interaction order; tree is already sorted).
+    last_turn = None
+    for iv in interactions:
+        if iv.get("type") == "TURN":
+            last_turn = iv
+    if last_turn is not None:
+        fallback = last_turn.get("end_ts") or last_turn.get("start_ts")
+        if fallback:
+            return fallback, "session still open (last TURN)"
+    return None, None
+
+
+# ---- section builders -----------------------------------------------------
+
+# Channel-mode value → human cell. Annotated so the reader can tell at
+# a glance why we believe the mode is
+# what it is — `ssot__AiAgentChannelType__c` is identical for MIAW
+# production and Builder Previewer, which makes it useless without the
+# annotation.
+_MODE_HINTS: dict[str, str] = {
+    "production_messaging": "production_messaging  ←  inferred from RelatedMessagingSessionId",
+    "builder_previewer":    "builder_previewer  ←  inferred from VariableText__c bootstrap keys",
+    "voice":                "voice  ←  inferred from RelatedVoiceCallId",
+    "unknown":              "unknown  ←  no signals (headless API, etc.)",
+}
+
+
+def _fmt_mode_cell(mode_value: str) -> str:
+    """Format the `mode` field with a short why-this-value annotation."""
+    return _MODE_HINTS.get(mode_value, mode_value)
+
+
+# Channel values that flag a production messaging session. `VariableText__c`
+# is expected to be NOT_SET on these — the bootstrap variables ride the
+# messaging session record, not the AI session. Any other channel
+# (E & O headless API, Builder Previewer, voice, unknown/integration)
+# can also legitimately produce NOT_SET, but for a different reason
+# (no bootstrap variables were attached at session start) — and we
+# must not mislabel those as "production messaging path".
+_MESSAGING_CHANNELS = frozenset({
+    "SCRT2 - EmbeddedMessaging",
+    "Messaging",
+})
+
+
+def _section_session_bootstrap(identity: dict, channel: Optional[str] = None) -> List[str]:
+    """Render the `bootstrap_variables` block parsed from VariableText__c.
+
+    Three states (all rendered as a small subtable so they don't clutter
+    the main identity table):
+      - None / NOT_SET → "no bootstrap variables for this session"
+                         (with a messaging-path addendum only when the
+                         session's `channel` is actually a messaging
+                         channel — see `_MESSAGING_CHANNELS`).
+      - parse error    → "_parse_error" with the raw prefix
+      - populated      → key/value pairs sorted, plus a "Builder Previewer
+                         indicators" tally derived from the same key set
+                         used in `_derive_mode`.
+
+    Empty section returned when bootstrap_variables is missing entirely
+    (older artifacts predate the bootstrap-variables harvest).
+    """
+    if "bootstrap_variables" not in identity:
+        return []  # older artifact: no bootstrap_variables harvested
+
+    bootstrap = identity.get("bootstrap_variables")
+    lines: List[str] = ["## Session bootstrap", ""]
+
+    if bootstrap is None:
+        if channel in _MESSAGING_CHANNELS:
+            lines.append(
+                "`ssot__VariableText__c` is `NOT_SET` — no bootstrap variables "
+                "(production messaging path; messaging sessions don't carry VariableText)."
+            )
+        else:
+            lines.append(
+                "`ssot__VariableText__c` is `NOT_SET` — no bootstrap variables for this session."
+            )
+        lines.append("")
+        return lines
+
+    if isinstance(bootstrap, dict) and bootstrap.get("_parse_error"):
+        raw = bootstrap.get("_raw") or ""
+        lines.append("`ssot__VariableText__c` failed to parse as JSON:")
+        lines.append("")
+        lines.append("```")
+        lines.append(raw)
+        lines.append("```")
+        lines.append("")
+        return lines
+
+    # Populated case.
+    indicator_keys = {
+        "__resolved_locale__",
+        "__locale_instruction__",
+        "__supports_result_display__",
+        "__show_tool_results_invoked__",
+    }
+    present_indicators = sorted(set(bootstrap) & indicator_keys)
+    indicator_cell = (
+        "yes  ·  " + ", ".join(present_indicators)
+        if present_indicators else "no"
+    )
+
+    lines.append("| Key | Value |")
+    lines.append("|---|---|")
+    for key in sorted(bootstrap):
+        value = bootstrap[key]
+        # Render lists / dicts compactly; keep strings/numbers/bools as-is.
+        if isinstance(value, (list, dict)):
+            value_repr = json.dumps(value)
+        else:
+            value_repr = str(value)
+        # Pipe character would break the markdown table — escape.
+        value_repr = value_repr.replace("|", "\\|")
+        lines.append(f"| {key} | {value_repr} |")
+    lines.append(f"| **Builder Previewer indicators** | {indicator_cell} |")
+    lines.append("")
+    return lines
+
+
+def _compose_agent_cell(identity: dict) -> Optional[str]:
+    """Build the human Agent cell from identity fields; drop None components."""
+    parts: List[str] = []
+    api_name = identity.get("agent_api_name")
+    version = identity.get("agent_version")
+    if api_name and version:
+        parts.append(f"{api_name} {version}")
+    elif api_name:
+        parts.append(api_name)
+    elif version:
+        parts.append(version)
+    label = identity.get("agent_label")
+    if label:
+        parts.append(f"— {label}" if parts else label)
+    atype = identity.get("agent_type")
+    if atype:
+        parts.append(f"({atype})")
+    return " ".join(parts) if parts else None
+
+
+def _fmt_session_end_cell(effective_end_iso: Optional[str],
+                          end_source: Optional[str],
+                          raw_end_iso: Optional[str]) -> Optional[str]:
+    """Compose the identity-table value for `Session end`.
+
+    - Materialized end (`raw_end_iso` truthy)           → "<iso> ✓ materialized"
+    - Derived end   (end_source truthy)                 → "<iso> (<source label>)"
+    - Neither                                           → None (row is dropped)
+    """
+    if effective_end_iso is None:
+        return None
+    if raw_end_iso:
+        return f"{effective_end_iso} ✓ materialized"
+    if end_source:
+        return f"{effective_end_iso} ({end_source})"
+    return effective_end_iso
+
+
+def _section_session_identity(sess: dict, effective_end_iso: Optional[str],
+                              end_source: Optional[str]) -> List[str]:
+    identity = sess.get("identity") or {}
+    org = sess.get("org") or {}
+
+    # `mode` is "production_messaging" / "builder_previewer" / "voice" /
+    # "unknown" — derived in assemble_dc from RelatedMessagingSessionId +
+    # RelatedVoiceCallId + bootstrap_variables because
+    # ssot__AiAgentChannelType__c is identical for MIAW production and
+    # Builder Previewer.
+    mode_value = identity.get("mode")
+    mode_cell = _fmt_mode_cell(mode_value) if mode_value else None
+
+    rows_out = [
+        ("Session id", sess.get("id")),
+        ("Org id", identity.get("org_id")),
+        ("Org alias", org.get("alias")),
+        ("Instance URL", org.get("instance_url")),
+        ("Channel", sess.get("channel")),
+        ("Mode", mode_cell),
+        ("App type", identity.get("app_type")),
+        ("Agent", _compose_agent_cell(identity)),
+        ("Bot id", identity.get("bot_id")),
+        ("Bot name", identity.get("bot_name")),
+        ("Bot version id", identity.get("bot_version_id")),
+        ("Planner id", identity.get("planner_id")),
+        ("Planner name", identity.get("planner_name")),
+        ("Planner type", identity.get("planner_type")),
+        ("Configured model", identity.get("configured_model")),
+        ("Platform user id", identity.get("platform_user_id")),
+        ("Messaging session id", identity.get("messaging_session_id")),
+        ("Messaging end-user id", identity.get("messaging_end_user_id")),
+        ("Voice call id", identity.get("voice_call_id")),
+        ("Individual id", identity.get("individual_id")),
+        ("Session start", sess.get("start_ts")),
+        (
+            "Session end",
+            _fmt_session_end_cell(effective_end_iso, end_source, sess.get("end_ts")),
+        ),
+        ("End type", sess.get("end_type")),
+        ("Total duration", _fmt_total_duration(sess.get("start_ts"), effective_end_iso)),
+    ]
+    lines: List[str] = ["## Session identity", "", "| Field | Value |", "|---|---|"]
+    for label, value in rows_out:
+        if value is None or value == "" or value == "—":
+            continue
+        lines.append(f"| {label} | {value} |")
+    lines.append("")
+    return lines
+
+
+def _section_id_reference(sess: dict) -> List[str]:
+    """Full-UUID lookup for every id the tree truncates."""
+    lines: List[str] = [
+        "## ID reference",
+        "",
+        "The tree truncates UUIDs to the first 8 chars + `…`. Look up the full "
+        "form here. Ordered by type → first occurrence.",
+        "",
+        "```",
+        f"session        = {sess.get('id')}",
+        "",
+    ]
+    # Interactions
+    lines.append("interactions:")
+    for iv in sess.get("interactions", []):
+        lines.append(
+            f"  {iv.get('id')}   type={iv.get('type') or '?'}   "
+            f"trace={iv.get('trace_id') or '—'}"
+        )
+    lines.append("")
+    # Participants
+    lines.append("participants:")
+    for p in sess.get("participants", []):
+        lines.append(
+            f"  {p.get('participant_id') or '—'}   role={p.get('role') or '—'}   "
+            f"agent={p.get('agent_api_name') or '—'}   version={p.get('agent_version') or '—'}   "
+            f"type={p.get('agent_type') or '—'}"
+        )
+    lines.append("")
+
+    # Steps, generations, gateway_requests, messages harvested from the tree.
+    all_steps: List[tuple] = []
+    all_gens: List[tuple] = []
+    all_gws: List[tuple] = []
+    all_msgs: List[tuple] = []
+    for iv in sess.get("interactions", []):
+        for m in iv.get("messages", []):
+            if m.get("message_id"):
+                all_msgs.append((m["message_id"], m.get("role") or m.get("type") or "?"))
+        for st in iv.get("steps", []):
+            if st.get("id"):
+                all_steps.append((st["id"], st.get("type") or "?", st.get("name") or "—"))
+            gen = st.get("generation")
+            if gen and gen.get("generation_id"):
+                all_gens.append((
+                    gen["generation_id"],
+                    gen.get("response_id") or "—",
+                    gen.get("feature") or "—",
+                ))
+            gw = st.get("gateway_request")
+            if gw and gw.get("gateway_request_id"):
+                all_gws.append((
+                    gw["gateway_request_id"], "declared",
+                    gw.get("feature") or "—", gw.get("model") or "—",
+                ))
+        for tb in iv.get("timestamp_bound_gateway_calls", []):
+            if tb.get("gateway_request_id"):
+                all_gws.append((
+                    tb["gateway_request_id"], "timestamp_window",
+                    tb.get("feature") or "—", tb.get("model") or "—",
+                ))
+    for g in sess.get("unbound_gateway_calls", []):
+        if g.get("gateway_request_id"):
+            all_gws.append((
+                g["gateway_request_id"], "unbound",
+                g.get("feature") or "—", g.get("model") or "—",
+            ))
+
+    if all_steps:
+        lines.append("steps:")
+        for sid_, stype, sname in all_steps:
+            lines.append(f"  {sid_}   type={stype}   name={sname}")
+        lines.append("")
+    if all_gens:
+        lines.append("generations:")
+        for gid, rid, feat in all_gens:
+            lines.append(f"  {gid}   response_id={rid}   feature={feat}")
+        lines.append("")
+    if all_gws:
+        lines.append("gateway_requests:")
+        for gwid, bm, feat, model in all_gws:
+            lines.append(f"  {gwid}   binding={bm}   feature={feat}   model={model}")
+        lines.append("")
+    if all_msgs:
+        lines.append("messages:")
+        for mid, role in all_msgs:
+            lines.append(f"  {mid}   role={role}")
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _section_transcript(sess: dict, start_dt: Optional[datetime]) -> List[str]:
+    turns = [iv for iv in sess.get("interactions", []) if iv.get("type") == "TURN"]
+    if not turns:
+        return []
+    lines: List[str] = ["## Transcript", ""]
+    for iv in turns:
+        start_off = _fmt_offset(iv.get("start_ts"), start_dt)
+        dur = _fmt_duration_ms(iv.get("start_ts"), iv.get("end_ts"))
+        lines.append(f"**Interaction {_short(iv.get('id'))}** · {start_off} · {dur}")
+        for m in iv.get("messages", []):
+            role = m.get("role") or m.get("type") or "?"
+            lines.append(f"> **{role}:** {_decode(m.get('text') or '')}")
+        lines.append("")
+    return lines
+
+
+def _section_hierarchical_trace(sess: dict, start_dt: Optional[datetime],
+                                effective_end_iso: Optional[str],
+                                end_source: Optional[str]) -> List[str]:
+    lines: List[str] = [
+        "## Complete hierarchical trace",
+        "",
+        "Notation: `+Xs` = offset in seconds from session start. "
+        "UUIDs are truncated to 8 chars + `…` for readability; "
+        "full forms are in the **ID reference** block above.",
+        "",
+        "```",
+    ]
+
+    # Session header
+    lines.append(f"SESSION {_short(sess.get('id'))}")
+    start_iso = sess.get("start_ts")
+    if start_iso:
+        lines.append(f"│   Start +0.000s ({start_iso})")
+
+    end_iso_raw = sess.get("end_ts")
+    end_type = sess.get("end_type") or None
+    outcome_s = end_type or "—"
+    if not end_type and not end_iso_raw:
+        outcome_s = "—  (session end not yet materialized in STDM)"
+    display_end = end_iso_raw or effective_end_iso
+    if display_end:
+        label_suffix = f"  [{end_source}]" if end_source else ""
+        lines.append(
+            f"│   End   {_fmt_offset(display_end, start_dt)} ({display_end}){label_suffix}  "
+            f"outcome={outcome_s}"
+        )
+    else:
+        lines.append(f"│   End   — (session still open)  outcome={outcome_s}")
+    lines.append("│")
+
+    interactions = sess.get("interactions", [])
+    for iv_idx, iv in enumerate(interactions):
+        is_last_iv = iv_idx == len(interactions) - 1
+        iv_branch = "└──" if is_last_iv else "├──"
+        iv_cont = "    " if is_last_iv else "│   "
+
+        iv_start_off = _fmt_offset(iv.get("start_ts"), start_dt)
+        iv_end_off = _fmt_offset(iv.get("end_ts"), start_dt)
+        iv_dur = _fmt_duration_ms(iv.get("start_ts"), iv.get("end_ts"))
+        iv_type = iv.get("type") or "?"
+        lines.append(
+            f"{iv_branch} {iv_type}  {_short(iv.get('id'))}  "
+            f"{iv_start_off} + {iv_dur} = {iv_end_off}"
+        )
+
+        topic = iv.get("topic")
+        if topic:
+            lines.append(f"{iv_cont}├── TOPIC: {topic}")
+
+        for m in iv.get("messages", []):
+            role = m.get("role") or m.get("type") or "?"
+            m_off = _fmt_offset(m.get("ts"), start_dt) if m.get("ts") else "—"
+            lines.append(f"{iv_cont}├── {role} message  {_short(m.get('message_id'))}  ts={m_off}")
+            lines.append(f"{iv_cont}│   └── text: \"{_truncate(m.get('text'), 100)}\"")
+
+        steps = iv.get("steps", [])
+        tsbound = iv.get("timestamp_bound_gateway_calls", [])
+        tsb_by_step: Dict[str, List[dict]] = {}
+        tsb_interaction_level: List[dict] = []
+        for tb in tsbound:
+            bsid = tb.get("bound_to_step_id")
+            if bsid:
+                tsb_by_step.setdefault(bsid, []).append(tb)
+            else:
+                tsb_interaction_level.append(tb)
+
+        remaining_groups: List[str] = []
+        if steps:
+            remaining_groups.append("steps")
+        if tsb_interaction_level:
+            remaining_groups.append("ts_il")
+
+        for grp_idx, grp in enumerate(remaining_groups):
+            grp_is_last = grp_idx == len(remaining_groups) - 1
+            grp_branch = "└──" if grp_is_last else "├──"
+            grp_cont = "    " if grp_is_last else "│   "
+            if grp == "steps":
+                lines.append(f"{iv_cont}{grp_branch} STEPS:")
+                for st_idx, st in enumerate(steps):
+                    lines.extend(_render_step(
+                        st, st_idx, len(steps), iv_cont, grp_cont,
+                        start_dt, tsb_by_step,
+                    ))
+            else:  # grp == "ts_il"
+                lines.append(f"{iv_cont}{grp_branch} INTERACTION-LEVEL TIMESTAMP-BOUND GATEWAY CALLS:")
+                for tb_idx, tb in enumerate(tsb_interaction_level):
+                    tb_is_last = tb_idx == len(tsb_interaction_level) - 1
+                    tb_branch = "└──" if tb_is_last else "├──"
+                    lines.append(
+                        f"{iv_cont}{grp_cont}{tb_branch} "
+                        f"gateway_request [timestamp_window, interaction-level]  "
+                        f"{_short(tb.get('gateway_request_id'))}  "
+                        f"feature={tb.get('feature') or '—'}  "
+                        f"model={tb.get('model') or '—'}"
+                    )
+
+        if not is_last_iv:
+            lines.append("│")
+
+    # Unbound gateway calls (session root level)
+    ub = sess.get("unbound_gateway_calls", [])
+    if ub:
+        lines.append("")
+        lines.append(
+            f"UNBOUND GATEWAY CALLS ({len(ub)}) — neither declared chain "
+            "nor timestamp window matched"
+        )
+        for i, g in enumerate(ub):
+            branch = "└──" if i == len(ub) - 1 else "├──"
+            lines.append(
+                f"{branch} {_short(g.get('gateway_request_id'))}  "
+                f"feature={g.get('feature') or '—'}  model={g.get('model') or '—'}"
+            )
+
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _render_step(st: dict, st_idx: int, n_steps: int,
+                 iv_cont: str, grp_cont: str,
+                 start_dt: Optional[datetime],
+                 tsb_by_step: Dict[str, List[dict]]) -> List[str]:
+    """Render one step + its nested generation / gateway_request / ts-bound GWs."""
+    st_is_last = st_idx == n_steps - 1
+    st_branch = "└──" if st_is_last else "├──"
+    st_cont = "    " if st_is_last else "│   "
+    st_start_off = _fmt_offset(st.get("start_ts"), start_dt)
+    st_end_off = _fmt_offset(st.get("end_ts"), start_dt)
+    st_dur = _fmt_duration_ms(st.get("start_ts"), st.get("end_ts"))
+
+    # Show the bound LLM model alongside the step name when known.
+    # `model_name` is mirrored from the bound gateway_request by
+    # assemble_dc; None when the declared chain didn't reach or when STDM
+    # dropped writes (the `gateway_requests_dropped_by_stdm` shape).
+    name_cell = st.get("name") or "—"
+    model_name = st.get("model_name")
+    if model_name:
+        name_cell = f"{name_cell} · {model_name}"
+
+    lines = [
+        f"{iv_cont}{grp_cont}{st_branch} {st.get('type') or '?'}  {_short(st.get('id'))}  "
+        f"name={name_cell}  {st_start_off} + {st_dur} = {st_end_off}"
+    ]
+
+    # Step children: error, generation (+ trust signals), gateway_request, collision, bound GWs.
+    step_kids: List[tuple] = []
+    if st.get("error_text"):
+        step_kids.append(("error", None))
+    gen = st.get("generation")
+    if gen:
+        step_kids.append(("gen", gen))
+    gw = st.get("gateway_request")
+    if gw:
+        step_kids.append(("gw", gw))
+    if st.get("gateway_request_collision"):
+        step_kids.append(("collision", None))
+    for tb in tsb_by_step.get(st.get("id", ""), []):
+        step_kids.append(("tsb", tb))
+
+    prefix = f"{iv_cont}{grp_cont}{st_cont}"
+    for k_idx, (ktype, kval) in enumerate(step_kids):
+        k_is_last = k_idx == len(step_kids) - 1
+        k_branch = "└──" if k_is_last else "├──"
+        k_cont = "    " if k_is_last else "│   "
+
+        if ktype == "error":
+            lines.append(f"{prefix}{k_branch} ERROR: {st['error_text']}")
+        elif ktype == "collision":
+            lines.append(
+                f"{prefix}{k_branch} ⚠ gateway_request_collision: "
+                "earlier step claimed the declared GW"
+            )
+        elif ktype == "gen":
+            lines.extend(_render_generation(kval, prefix, k_branch, k_cont,
+                                           step_name=st.get("name")))
+        elif ktype == "gw":
+            lines.extend(_render_gw_declared(kval, prefix, k_branch, k_cont))
+        elif ktype == "tsb":
+            tb = kval
+            lines.append(
+                f"{prefix}{k_branch} gateway_request [timestamp_window]  "
+                f"{_short(tb.get('gateway_request_id'))}  "
+                f"feature={tb.get('feature') or '—'}  "
+                f"model={tb.get('model') or '—'}"
+            )
+    return lines
+
+
+_ROLE_LABELS = {
+    "ReactTopicPrompt":                 "topic-classification output",
+    "ReactInitialPrompt":               "ReAct planner step",
+    "ReactValidationPrompt":            "ReAct validator",
+    "ReactFormatSurfaceResponsePrompt": "response formatter",
+}
+
+
+def _role_label_for(step_name: Optional[str]) -> Optional[str]:
+    if not step_name:
+        return None
+    for key, label in _ROLE_LABELS.items():
+        if key in step_name:
+            return label
+    return None
+
+
+def _parse_finish_reason(response_parameters: Optional[str]) -> Optional[str]:
+    """Pull finish_reason out of the HTML-escaped JSON in responseParameters__c.
+    Shape: `{&quot;finish_reason&quot;:&quot;&#92;&quot;stop&#92;&quot;&quot;,...}`."""
+    if not response_parameters:
+        return None
+    try:
+        decoded = html.unescape(response_parameters)
+        parsed = json.loads(decoded)
+    except (ValueError, TypeError):
+        return None
+    raw = parsed.get("finish_reason") if isinstance(parsed, dict) else None
+    if not isinstance(raw, str):
+        return None
+    # value often comes wrapped in escaped quotes: `\"stop\"` → `stop`
+    return raw.replace("\\", "").strip('"').strip()
+
+
+def _decoded_line(response_text: Optional[str]) -> str:
+    """Render `decoded:` content. Detect tool-call JSON and summarize.
+    responseText__c is HTML-escaped (&quot; etc.) in the wire format — unescape
+    before trying to parse as JSON."""
+    if not response_text:
+        return "—"
+    candidate = html.unescape(response_text).strip()
+    if candidate.startswith("{") and '"toolInvocations"' in candidate:
+        try:
+            obj = json.loads(candidate)
+            tools = obj.get("toolInvocations") or []
+            content = (obj.get("content") or "").strip()
+            if tools:
+                first = tools[0].get("function") or {}
+                name = first.get("name") or "?"
+                args_raw = first.get("arguments") or ""
+                arg_summary = ""
+                try:
+                    args_obj = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+                    if isinstance(args_obj, dict) and args_obj:
+                        k, v = next(iter(args_obj.items()))
+                        v_str = str(v)
+                        if len(v_str) > 60:
+                            v_str = v_str[:57] + "…"
+                        arg_summary = f'{k}="{v_str}"'
+                except (ValueError, TypeError):
+                    pass
+                prefix = "no user text" if not content else f'"{_truncate(content, 60)}"'
+                n = len(tools)
+                call_word = "tool call" if n == 1 else "tool calls"
+                return f"{prefix}; {n} {call_word} → {name}({arg_summary})"
+        except (ValueError, TypeError):
+            pass
+    return f'"{_truncate(response_text, 140)}"'
+
+
+def _float_or_none(v) -> Optional[float]:
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _trust_line(g: dict) -> str:
+    """Summarize trust signals. TOXICITY sub-categories (parented on the
+    quality row) carry a dedicated `safety_score` category in the 0-1 range
+    (1.0 = clean). Non-`safety_score` sub-categories are the 8 hazard axes
+    (profanity, hate, violence, …); report the max of those when a detection
+    fires so the reader sees which axis tripped.
+    Non-TOXICITY detectors (InstructionAdherence, etc.) are parented directly
+    on the generation and render as textual verdicts."""
+    quality = g.get("quality") or []
+    cats = g.get("categories") or []
+    if not quality and not cats:
+        return "—  (no quality/category rows)"
+    parts: List[str] = []
+    for q in quality:
+        subs = q.get("_toxicity_subcategories") or []
+        detected = str(q.get("isToxicityDetected__c", "")).lower() == "true"
+        safety: Optional[float] = None
+        hazard_subs: List[tuple] = []
+        for s in subs:
+            if (s.get("detectorType__c") or "").upper() != "TOXICITY":
+                continue
+            name = s.get("category__c") or ""
+            val = _float_or_none(s.get("value__c"))
+            if val is None:
+                continue
+            if name == "safety_score":
+                safety = val
+            else:
+                hazard_subs.append((name, val))
+        status = "detected" if detected else "clean"
+        safety_str = f"{safety:.2f}" if safety is not None else "—"
+        if not detected and hazard_subs and all(v == 0 for _, v in hazard_subs):
+            detail = f" — all {len(hazard_subs)} sub-categories 0.00"
+        elif hazard_subs:
+            top_name, top_val = max(hazard_subs, key=lambda kv: kv[1])
+            detail = f" — max {top_name}={top_val:.2f}"
+        else:
+            detail = ""
+        parts.append(f"TOXICITY safety_score={safety_str} ({status}{detail})")
+    # Non-TOXICITY detectors (generation-direct).
+    for c in cats:
+        dtype = (c.get("detectorType__c") or "?").strip()
+        if dtype.upper() == "TOXICITY":
+            continue
+        val = c.get("value__c")
+        parts.append(f"{dtype}: {_truncate(val, 80)}")
+    return "; ".join(parts) if parts else "—"
+
+
+def _render_generation(g: dict, prefix: str, k_branch: str, k_cont: str,
+                       *, step_name: Optional[str] = None) -> List[str]:
+    """Generation node: 3 fixed children (decoded / finish_reason+masked / trust).
+    Header is naked (id only); `response_id` and `feature` live in the ID reference
+    block / on the sibling gateway_request line."""
+    lines = [
+        f"{prefix}{k_branch} generation  {_short(g.get('generation_id'))}"
+    ]
+    role = _role_label_for(step_name)
+    decoded = _decoded_line(g.get("response_text"))
+    if role:
+        decoded_line = f"decoded: {decoded}  ({role})"
+    else:
+        decoded_line = f"decoded: {decoded}"
+    masked = g.get("masked_response_text")
+    masked_disp = _truncate(masked, 60) if masked else "—"
+    finish_reason = _parse_finish_reason(g.get("response_parameters")) or "—"
+    gprefix = f"{prefix}{k_cont}"
+    lines.append(f"{gprefix}├── {decoded_line}")
+    lines.append(f"{gprefix}├── finish_reason={finish_reason}  masked={masked_disp}")
+    lines.append(f"{gprefix}└── trust: {_trust_line(g)}")
+    return lines
+
+
+def _render_gw_declared(g: dict, prefix: str, k_branch: str, k_cont: str) -> List[str]:
+    tokens = (
+        f"prompt={int(g.get('prompt_tokens') or 0)}  "
+        f"completion={int(g.get('completion_tokens') or 0)}  "
+        f"total={int(g.get('total_tokens') or 0)}"
+    )
+    tags = g.get("tags") or []
+    md = g.get("metadata") or []
+    recs = g.get("records") or []
+    llm = g.get("llm") or []
+    audit_line = (
+        f"audit: tags={len(tags)}  metadata={len(md)}  records={len(recs)}  llm={len(llm)}"
+        if (tags or md or recs or llm)
+        else "audit: (none)"
+    )
+    return [
+        f"{prefix}{k_branch} gateway_request [declared]  "
+        f"{_short(g.get('gateway_request_id'))}  "
+        f"feature={g.get('feature') or '—'}  "
+        f"model={g.get('model') or '—'}  "
+        f"provider={g.get('provider') or '—'}",
+        f"{prefix}{k_cont}├── tokens: {tokens}",
+        f"{prefix}{k_cont}└── {audit_line}",
+    ]
+
+
+def _section_per_turn_summary(sess: dict, start_dt: Optional[datetime]) -> List[str]:
+    lines: List[str] = [
+        "## Per-turn summary",
+        "",
+        "| Interaction | Type | Start offset | Duration | Steps | "
+        "GW declared | GW ts_window | USER → AGENT |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for iv in sess.get("interactions", []):
+        iv_type = iv.get("type") or "?"
+        start_off = _fmt_offset(iv.get("start_ts"), start_dt)
+        dur = _fmt_duration_ms(iv.get("start_ts"), iv.get("end_ts"))
+        step_count = len(iv.get("steps", []))
+        declared_gws = sum(
+            1 for st in iv.get("steps", [])
+            if st.get("gateway_request")
+            and st["gateway_request"].get("binding_method") == "declared"
+        )
+        tsw_gws = len(iv.get("timestamp_bound_gateway_calls", []))
+        user_msg = next((m for m in iv.get("messages", []) if m.get("role") == "USER"), None)
+        agent_msg = next((m for m in iv.get("messages", []) if m.get("role") == "AGENT"), None)
+        ut = _truncate(user_msg.get("text") if user_msg else None, 40)
+        at = _truncate(agent_msg.get("text") if agent_msg else None, 40)
+        lines.append(
+            f"| `{_short(iv.get('id'))}` | {iv_type} | {start_off} | {dur} | "
+            f"{step_count} | {declared_gws} | {tsw_gws} | {ut} → {at} |"
+        )
+    lines.append("")
+    return lines
+
+
+# ---- visual analysis (mermaid) -------------------------------------------
+
+# Chars that break mermaid label parsing when bare; quote-wrap the string
+# when any of these show up. Underscore+digit tokens in topic strings are
+# legal inside mermaid node labels — only syntax-significant chars need
+# escaping here.
+_MERMAID_LABEL_SPECIALS = set(',()<>:"#')
+
+
+def _escape_mermaid_label(s: str) -> str:
+    if not s:
+        return '""'
+    if any(ch in _MERMAID_LABEL_SPECIALS for ch in s):
+        return '"' + s.replace('"', '\\"') + '"'
+    return s
+
+
+def _sequence_msg(s: str) -> str:
+    """Sanitize free-form text for the right-hand side of a sequenceDiagram
+    arrow. Mermaid parses `A->>B: <text>` up to newline — the text itself is
+    unquoted, so wrapping in `"..."` (as node-label escape does) renders the
+    quotes literally. We just strip newlines and escape the one char that
+    ends the message field (semicolon is the statement terminator)."""
+    if not s:
+        return "—"
+    return s.replace("\n", " ").replace(";", ",").strip()
+
+
+def _flowchart_edge_label(s: str) -> str:
+    """Sanitize free-form text for a flowchart edge label `A -->|label| B`.
+    The delimiter is the pipe itself, so a literal `|` in the label shatters
+    the parser. Square brackets also clash with node-shape syntax. Strip/
+    substitute these; other specials (commas, colons, parens) are fine
+    inside quoted labels, which `_escape_mermaid_label` handles."""
+    if not s:
+        return ""
+    cleaned = s.replace("|", "/").replace("[", "(").replace("]", ")")
+    return _escape_mermaid_label(cleaned)
+
+
+def _step_display_name(st: dict) -> str:
+    """Short, mermaid-safe row label for a step.
+
+    - Strip `AiCopilot__` prefix on LLM prompts.
+    - For ACTION_STEP names shaped `Topic_xxx.AGNT_Action_yyy`, keep the
+      action-name portion after the last `.` so the row reads as the
+      invoked action, not the topic.
+    """
+    name = st.get("name") or st.get("type") or "?"
+    if name.startswith("AiCopilot__"):
+        name = name[len("AiCopilot__"):]
+    if st.get("type") == "ACTION_STEP" and "." in name:
+        name = name.rsplit(".", 1)[-1]
+    # Gantt task names cannot contain colons (task syntax is `label : id, start, dur`).
+    return name.replace(":", "·")
+
+
+def _iter_turns(sess: dict) -> List[dict]:
+    return [iv for iv in sess.get("interactions", []) if iv.get("type") == "TURN"]
+
+
+def _mermaid_gantt(
+    sess: dict,
+    start_dt: Optional[datetime],
+    llm_calls: Optional[List[dict]] = None,
+) -> List[str]:
+    """Gantt chart — wall-clock timeline.
+
+    Rows per turn (ACTION steps tagged :crit). When `llm_calls` is
+    non-empty, a trailing "LLM calls" section renders per-call rows
+    tagged by region-class (:active = cross_region, :done = same-
+    region, plain = unknown). Mermaid's built-in 3-class palette is
+    enough signal for v1; full per-region color would need a classDef
+    block (deferred — see plan OOS-2.A).
+
+    Kill-criterion: <3 total rows after dropping zero-duration steps
+    AND no LLM-call rows → return []. If the step set is thin but the
+    call set is non-empty, we still render (the call rows are the
+    whole point of the overlay).
+    """
+    if start_dt is None:
+        return []
+    rows: List[tuple] = []  # (section_label, row_label, start_ms, end_ms, is_action)
+    turns = _iter_turns(sess)
+    for iv in sess.get("interactions", []):
+        if iv.get("type") != "TURN":
+            continue
+        topic = iv.get("topic") or "(no topic)"
+        section = f"Turn {turns.index(iv) + 1} ({topic})"
+        for st in iv.get("steps", []):
+            if st.get("type") == "SESSION_END":
+                continue
+            s_dt = _parse_iso(st.get("start_ts"))
+            e_dt = _parse_iso(st.get("end_ts"))
+            if s_dt is None or e_dt is None:
+                continue
+            s_ms = int((s_dt - start_dt).total_seconds() * 1000)
+            e_ms = int((e_dt - start_dt).total_seconds() * 1000)
+            if e_ms <= s_ms:
+                continue  # skip zero-duration (e.g. TOPIC_STEP markers)
+            rows.append((section, _step_display_name(st), s_ms, e_ms,
+                         st.get("type") == "ACTION_STEP"))
+
+    # LLM-call rows — one per gateway call, derived from _llm_calls.json.
+    # Rendered in a trailing section so they don't interleave with step
+    # rows (mermaid sections don't sort across boundaries).
+    call_rows: List[tuple] = []  # (row_label, start_ms, end_ms, class_tag)
+    for call in (llm_calls or []):
+        t_iso = call.get("_time")
+        dur_ms = call.get("duration_ms")
+        if not t_iso or dur_ms is None:
+            continue
+        t_dt = _parse_iso(t_iso)
+        if t_dt is None:
+            continue
+        s_ms = int((t_dt - start_dt).total_seconds() * 1000)
+        e_ms = s_ms + int(dur_ms)
+        if e_ms <= s_ms:
+            continue
+        # class_tag: cross_region=True → :active (mermaid's yellow),
+        # cross_region=False → :done (grey), unknown/None → no tag
+        # (default blue). Operators can scan for the yellow bars as
+        # the cross-region outliers.
+        cr = call.get("cross_region")
+        if cr is True:
+            class_tag = ":active, "
+        elif cr is False:
+            class_tag = ":done, "
+        else:
+            class_tag = ":"
+        model = call.get("model_name") or "call"
+        region = call.get("routing_decision") or "—"
+        label = _escape_mermaid_label(f"{model} [{region}]")
+        call_rows.append((label, s_ms, e_ms, class_tag))
+
+    if len(rows) < 3 and not call_rows:
+        return []
+
+    # axisFormat: `%M:%S` renders as minutes:seconds via d3. Our offsets
+    # are ms-from-start passed through `dateFormat x` (unix epoch); d3
+    # treats them as Jan 1 1970 timestamps, so for any session under
+    # 1 hour this reads cleanly as m:ss elapsed. `%L` (ms-of-second)
+    # always rendered 000 because ticks land at second boundaries.
+    # The leading `section anchor` + 1ms milestone forces the x-axis to
+    # start at 00:00 — mermaid derives axis min from the smallest task
+    # timestamp, and without the anchor that's the first step's offset
+    # (~5s into a typical session), making the axis misleadingly slide.
+    lines = [
+        "```mermaid",
+        "gantt",
+        "    title Session timeline (m:ss from start)",
+        "    dateFormat x",
+        "    axisFormat %M:%S",
+        "    section Session start",
+        "    t0 :milestone, 0, 0",
+    ]
+    current_section: Optional[str] = None
+    for section, label, s_ms, e_ms, is_action in rows:
+        if section != current_section:
+            lines.append(f"    section {section}")
+            current_section = section
+        # Mermaid gantt task: `<name> :[tag,] <start>, <end>` — single colon,
+        # tag is the first comma-separated field after it. Two colons (the
+        # `:crit:` shape) is a parse error.
+        prefix = ":crit, " if is_action else ":"
+        lines.append(f"    {label} {prefix}{s_ms}, {e_ms}")
+    if call_rows:
+        lines.append("    section LLM calls")
+        for label, s_ms, e_ms, class_tag in call_rows:
+            lines.append(f"    {label} {class_tag}{s_ms}, {e_ms}")
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _action_short_name(st: dict) -> str:
+    name = st.get("name") or ""
+    if "." in name:
+        name = name.rsplit(".", 1)[-1]
+    return name or "action"
+
+
+def _mermaid_sequence_per_turn(iv: dict, start_dt: Optional[datetime],
+                               turn_no: int) -> List[str]:
+    steps = iv.get("steps", [])
+    has_error = any(st.get("error_text") for st in steps)
+    action_steps = [st for st in steps if st.get("type") == "ACTION_STEP"]
+    if not has_error and len(action_steps) < 2:
+        return []
+
+    topic = iv.get("topic") or "(no topic)"
+    heading = f"### Turn {turn_no} ({topic}) — control flow"
+    lines: List[str] = [heading, "", "```mermaid", "sequenceDiagram"]
+
+    # Participants: U, P, L are always present; actions get A1, A2, …
+    lines.append("    participant U as USER")
+    lines.append("    participant P as Planner")
+    lines.append("    participant L as LLM Gateway")
+    action_alias: Dict[str, str] = {}  # step id → alias
+    for i, st in enumerate(action_steps, start=1):
+        alias = f"A{i}"
+        action_alias[st.get("id") or f"_a{i}"] = alias
+        label = _escape_mermaid_label(_action_short_name(st))
+        lines.append(f"    participant {alias} as {label}")
+
+    # User → Planner (utterance).
+    user_msg = next((m for m in iv.get("messages", []) if m.get("role") == "USER"), None)
+    user_text = _truncate(user_msg.get("text") if user_msg else None, 40)
+    if user_msg:
+        lines.append(f"    U->>P: {_sequence_msg(user_text)}")
+
+    # Walk steps in order. LLM → L, ACTION → A<n>, errors → Note over.
+    for st in steps:
+        stype = st.get("type")
+        if stype == "LLM_STEP":
+            label = _step_display_name(st)
+            gw = st.get("gateway_request") or {}
+            model = gw.get("model")
+            suffix = f" ({model})" if model else ""
+            lines.append(f"    P->>L: {_sequence_msg(label + suffix)}")
+            dur = _fmt_duration_ms(st.get("start_ts"), st.get("end_ts"))
+            if st.get("error_text"):
+                lines.append(f"    Note over L: ERROR in {dur}")
+            else:
+                lines.append(f"    L-->>P: ok ({dur})")
+        elif stype == "ACTION_STEP":
+            alias = action_alias.get(st.get("id") or "", "A?")
+            dur = _fmt_duration_ms(st.get("start_ts"), st.get("end_ts"))
+            lines.append(f"    P->>{alias}: invoke")
+            lines.append(f"    {alias}-->>P: result ({dur})")
+
+    # Agent reply (if any).
+    agent_msg = next((m for m in iv.get("messages", []) if m.get("role") == "AGENT"), None)
+    if agent_msg:
+        agent_text = _truncate(agent_msg.get("text"), 40)
+        lines.append(f"    P-->>U: {_sequence_msg(agent_text)}")
+
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _mermaid_topic_flowchart(sess: dict) -> List[str]:
+    turns = _iter_turns(sess)
+    if not turns:
+        return []
+    # Order-preserving unique topics.
+    topic_ids: Dict[str, str] = {}
+    for iv in turns:
+        t = iv.get("topic") or "(no topic)"
+        if t not in topic_ids:
+            topic_ids[t] = f"T{len(topic_ids) + 1}"
+    if len(topic_ids) == len(turns):
+        return []  # linear — no repeats, skip
+
+    lines: List[str] = ["```mermaid", "flowchart LR"]
+    # Node declarations.
+    for topic, node_id in topic_ids.items():
+        lines.append(f"    {node_id}[{_escape_mermaid_label(topic)}]")
+
+    # Edges: one per turn transition, labelled by the user utterance that
+    # drove into that turn. The first turn has no predecessor so we just
+    # declare the node; edges start from turn 2.
+    prev_topic = turns[0].get("topic") or "(no topic)"
+    for iv in turns[1:]:
+        cur_topic = iv.get("topic") or "(no topic)"
+        user_msg = next((m for m in iv.get("messages", []) if m.get("role") == "USER"), None)
+        utter = _truncate(user_msg.get("text") if user_msg else None, 30)
+        src = topic_ids[prev_topic]
+        dst = topic_ids[cur_topic]
+        label = _flowchart_edge_label(utter) if utter and utter != "—" else ""
+        arrow = f"    {src} -->|{label}| {dst}" if label else f"    {src} --> {dst}"
+        lines.append(arrow)
+        prev_topic = cur_topic
+
+    # Error class for topics whose turn ended with an error_text.
+    errored_topic_ids: List[str] = []
+    for iv in turns:
+        if any(st.get("error_text") for st in iv.get("steps", [])):
+            tid = topic_ids[iv.get("topic") or "(no topic)"]
+            if tid not in errored_topic_ids:
+                errored_topic_ids.append(tid)
+    if errored_topic_ids:
+        lines.append(f"    classDef err fill:#fee,stroke:#c00")
+        for tid in errored_topic_ids:
+            lines.append(f"    class {tid} err")
+
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _mermaid_token_pie(sess: dict) -> List[str]:
+    buckets: Dict[str, int] = {}
+    total = 0
+    for iv in sess.get("interactions", []):
+        for st in iv.get("steps", []):
+            gw = st.get("gateway_request") or {}
+            p = int(gw.get("prompt_tokens") or 0)
+            c = int(gw.get("completion_tokens") or 0)
+            tok = p + c
+            if tok <= 0:
+                continue
+            role = _role_label_for(st.get("name")) or "other"
+            buckets[role] = buckets.get(role, 0) + tok
+            total += tok
+    if total < 1000 or not buckets:
+        return []
+
+    lines = [
+        "```mermaid",
+        "pie showData",
+        f"    title Prompt-role token attribution (total = {total:,})",
+    ]
+    # Largest slice first reads better in most renderers.
+    for role, n in sorted(buckets.items(), key=lambda kv: -kv[1]):
+        lines.append(f'    "{role}" : {n}')
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _section_visual_analysis(
+    sess: dict,
+    start_dt: Optional[datetime],
+    llm_calls: Optional[List[dict]] = None,
+) -> List[str]:
+    blocks: List[List[str]] = []
+    gantt = _mermaid_gantt(sess, start_dt, llm_calls=llm_calls)
+    if gantt:
+        blocks.append(gantt)
+    # Per-turn sequence diagrams (at most one per turn; most turns skip).
+    turns = _iter_turns(sess)
+    for idx, iv in enumerate(turns, start=1):
+        seq = _mermaid_sequence_per_turn(iv, start_dt, idx)
+        if seq:
+            blocks.append(seq)
+    flow = _mermaid_topic_flowchart(sess)
+    if flow:
+        blocks.append(flow)
+    pie = _mermaid_token_pie(sess)
+    if pie:
+        blocks.append(pie)
+
+    if not blocks:
+        return []
+    lines: List[str] = ["## Visual analysis", ""]
+    for b in blocks:
+        lines.extend(b)
+    return lines
+
+
+def _section_session_counts(sess: dict) -> List[str]:
+    c = sess.get("counts", {})
+    st_by_type = c.get("steps_by_type", {})
+    gwb = c.get("gw_binding", {})
+    lines: List[str] = [
+        "## Session counts",
+        "",
+        "| metric | value |",
+        "|---|---|",
+        f"| interactions | {c.get('interactions_total', 0)} |",
+        f"| steps | {c.get('steps_total', 0)} |",
+        f"| llm_steps | {st_by_type.get('LLM_STEP', 0)} |",
+        f"| action_steps | {st_by_type.get('ACTION_STEP', 0)} |",
+        f"| gateway_requests | {c.get('gateway_requests', 0)} |",
+        f"| gateway_responses | {c.get('gateway_responses', 0)} |",
+        f"| 1:1 invariant | {'✓' if c.get('audit_chain_1to1_ok') else '✗'} |",
+        f"| gw declared | {gwb.get('declared', 0)} |",
+        f"| gw timestamp_window | {gwb.get('timestamp_window', 0)} |",
+        f"| gw unbound | {gwb.get('unbound', 0)} |",
+    ]
+    if gwb.get("declared_collisions"):
+        lines.append(f"| ⚠ declared_collisions | {gwb['declared_collisions']} |")
+    lines.append("")
+    return lines
+
+
+def _section_empties_diagnostics(manifest: dict) -> List[str]:
+    """Operator-actionable: lift `_unavailable_reason` verbatim from the manifest."""
+    queries = manifest.get("queries", []) if manifest else []
+    empties = [
+        q for q in queries
+        if q.get("rows") == 0 and q.get("_unavailable_reason")
+    ]
+    if not empties:
+        return []
+    lines: List[str] = [
+        "## Empties diagnostics",
+        "",
+        "DMOs that returned zero rows, with the reason lifted verbatim from the manifest:",
+        "",
+        "| DMO | Reason |",
+        "|---|---|",
+    ]
+    for q in empties:
+        name = q.get("name") or "?"
+        # Pipe characters in reason text would break markdown tables.
+        reason = str(q.get("_unavailable_reason") or "").replace("|", "\\|")
+        lines.append(f"| {name} | {reason} |")
+    lines.append("")
+    return lines
+
+
+def _section_catalog(tree: dict) -> List[str]:
+    catalog = tree.get("catalog", {}) or {}
+    agents = ", ".join(catalog.get("agents_observed", []) or []) or "—"
+    return [
+        "## Catalog (session-filtered)",
+        "",
+        f"- TagDefinitions: {len(catalog.get('tag_definitions', []) or [])}",
+        f"- TagDefinitionAssociations: "
+        f"{len(catalog.get('tag_definition_associations', []) or [])} (agents: {agents})",
+        f"- Tags: {len(catalog.get('tags', []) or [])}",
+        "",
+    ]
+
+
+# ---- top-level render + entry points -------------------------------------
+
+def render(
+    tree: dict,
+    manifest: Optional[dict] = None,
+    session_dir: Optional[Path] = None,
+    *,
+    show_prompts: bool = False,
+) -> str:
+    """Produce the summary markdown for a single session.
+
+    Branches on tree shape:
+    - gateway-direct tree (``_source == "gateway_direct"``) → identity +
+      lag banner + gateway-chain table + per-call detail; skips the
+      Interaction-dependent sections.
+    - minimal tree (session-not-found) → short markdown with just identity.
+    - full tree → multi-section summary (see SKILL.md for the full list).
+
+    ``session_dir`` is reserved for callers that want the renderer to look
+    up artifacts beside the tree on disk. The standalone d360 skill produces
+    no runtime-telemetry rollups — DC alone doesn't expose per-turn LLM
+    latency in a useful form — so when ``None`` (the test-friendly default),
+    the gantt simply draws without the LLM-call overlay.
+
+    ``show_prompts`` (opt-in): when True, the full-tree branch appends
+    a "Planner LLM calls" section with full prompt + response text per
+    LLM call. Default False — the section can add hundreds of KB to the
+    summary on multi-turn sessions.
+
+    Refuses incompatible tree schema versions (see `_assert_schema_version`).
+    """
+    _assert_schema_version(tree)
+
+    # Gateway-direct branch — session resolved but STDM hierarchy hasn't
+    # materialized yet. Handled before the has_interactions check because
+    # the gateway-direct tree does set `session.interactions = []`.
+    if tree.get("_source") == "gateway_direct":
+        return _render_gateway_direct(tree, manifest, show_prompts=show_prompts)
+
+    sess = tree.get("session") or {}
+    sid = sess.get("id") or "<unknown>"
+    has_interactions = "interactions" in sess
+
+    # Minimal-tree early return.
+    if not has_interactions:
+        return _render_minimal(sid, sess)
+
+    start_iso = sess.get("start_ts")
+    start_dt = _parse_iso(start_iso)
+    effective_end_iso, end_source = _derive_session_end(sess)
+
+    # The d360 skill produces no runtime-telemetry rollups — DC alone
+    # doesn't expose per-turn LLM latency in a useful form. Visual
+    # analysis falls back to its pre-rollup output.
+    llm_calls: List[dict] = []
+
+    lines: List[str] = [f"# Session {sid}", ""]
+    lines.extend(_section_session_identity(sess, effective_end_iso, end_source))
+    # VariableText__c bootstrap (channel-mode diagnostic).
+    lines.extend(_section_session_bootstrap(
+        sess.get("identity") or {}, channel=sess.get("channel"),
+    ))
+    lines.extend(_section_id_reference(sess))
+    lines.extend(_section_transcript(sess, start_dt))
+    lines.extend(_section_hierarchical_trace(sess, start_dt, effective_end_iso, end_source))
+    lines.extend(_section_per_turn_summary(sess, start_dt))
+    # Opt-in full prompt + response per LLM call. Off by
+    # default — multi-turn sessions can produce hundreds of KB here.
+    lines.extend(_section_planner_llm_calls(sess, show_prompts=show_prompts))
+    lines.extend(_section_visual_analysis(sess, start_dt, llm_calls=llm_calls))
+    lines.extend(_section_session_counts(sess))
+    lines.extend(_section_empties_diagnostics(manifest or {}))
+    lines.extend(_section_catalog(tree))
+    return "\n".join(lines) + "\n"
+
+
+def _render_minimal(sid: str, sess: dict) -> str:
+    """Short markdown for session-not-found minimal trees."""
+    shape = (sess.get("counts") or {}).get("session_shape", "session_not_found")
+    lines = [
+        f"# Session {sid}",
+        "",
+        "## Session identity",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Session id | {sid} |",
+        f"| Session shape | {shape} |",
+        "",
+        "_No interactions resolved in Data Cloud. Check the session id, or wait for "
+        "STDM materialization._",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# Display-only cap on `prompt_text` inside per-call detail. The raw JSON on
+# disk (dc.gateway_requests.json) is authoritative and never truncated — the
+# assembler stores the full prompt, and this slice only applies to markdown.
+_PROMPT_DISPLAY_CAP_BYTES = 65536
+
+
+def _fmt_token_count(value) -> str:
+    """Tolerate ints, stringified ints, and None/''/NOT_SET."""
+    if value in (None, "", "NOT_SET"):
+        return "—"
+    return str(value)
+
+
+def _render_gateway_direct(tree: dict, manifest: Optional[dict],
+                           *, show_prompts: bool = False) -> str:
+    """Render the STDM-hasn't-materialized-yet view.
+
+    Sections:
+      1. Session identity          (reused)
+      2. ID reference              (reused; gracefully handles the empty
+                                    interactions/participants on this path)
+      3. STDM lag banner           (gateway-direct specific)
+      4. Gateway chain table       (gateway-direct specific)
+      5. Per-call detail           (gateway-direct specific)
+      6. Empties diagnostics       (reused; reads manifest, not tree)
+      7. Catalog                   (reused; catalog may be empty on a
+                                    fresh-session gateway-direct tree)
+
+    Skipped: Transcript, Hierarchical trace, Per-turn summary, Session
+    counts — all require Interaction rows that don't exist yet.
+
+    ``show_prompts`` (default False): forwarded to per-call detail so the
+    full prompt block only renders under ``--show-prompts``. The prior
+    behavior unconditionally leaked prompts on this branch, contradicting
+    the documented contract for ``dc._session_summary.md``.
+    """
+    sess = tree.get("session") or {}
+    sid = sess.get("id") or "<unknown>"
+    start_iso = sess.get("start_ts")
+    start_dt = _parse_iso(start_iso)
+    # No derivation needed — sessions.end_ts is the only source on this path.
+    effective_end_iso = sess.get("end_ts")
+
+    lines: List[str] = [f"# Session {sid}", ""]
+    lines.extend(_section_session_identity(sess, effective_end_iso, None))
+    # VariableText__c bootstrap (channel-mode diagnostic).
+    lines.extend(_section_session_bootstrap(
+        sess.get("identity") or {}, channel=sess.get("channel"),
+    ))
+    lines.extend(_section_id_reference(sess))
+    lines.extend(_section_stdm_lag_banner())
+    lines.extend(_section_gateway_chain_table(sess, start_dt))
+    lines.extend(_section_gateway_per_call_detail(sess, show_prompts=show_prompts))
+    lines.extend(_section_empties_diagnostics(manifest or {}))
+    lines.extend(_section_catalog(tree))
+    return "\n".join(lines) + "\n"
+
+
+def _section_stdm_lag_banner() -> List[str]:
+    return [
+        "## STDM materialization lag",
+        "",
+        "> **Note** STDM Interaction/Step/Message DMOs have not yet "
+        "materialized for this session. The view below is the gateway chain "
+        "harvested directly from Gateway DMOs (materialize in minutes). "
+        "Re-run in 24–72h for the full hierarchical trace.",
+        "",
+    ]
+
+
+def _section_gateway_chain_table(sess: dict,
+                                 start_dt: Optional[datetime]) -> List[str]:
+    chain = sess.get("gateway_chain") or []
+    lines: List[str] = [
+        "## Gateway chain",
+        "",
+        "| # | Request ts | Model | Provider | Prompt template | "
+        "Prompt tok | Completion tok | Total tok | Response ts |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for i, call in enumerate(chain, start=1):
+        req_offset = _fmt_offset(call.get("timestamp"), start_dt)
+        resp_offset = _fmt_offset(
+            (call.get("response") or {}).get("timestamp"), start_dt)
+        model = call.get("model") or "—"
+        provider = call.get("provider") or "—"
+        template = call.get("prompt_template_dev_name") or "—"
+        prompt_tok = _fmt_token_count(call.get("prompt_tokens"))
+        completion_tok = _fmt_token_count(call.get("completion_tokens"))
+        total_tok = _fmt_token_count(call.get("total_tokens"))
+        lines.append(
+            f"| {i} | {req_offset} | {model} | {provider} | {template} | "
+            f"{prompt_tok} | {completion_tok} | {total_tok} | {resp_offset} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _pick_fence(text: str) -> str:
+    """Pick a backtick fence long enough to wrap `text` safely.
+
+    CommonMark lets a fenced code block use any run of 3+ backticks; the
+    closing fence must be at least as long as the opening. LLM prompts
+    routinely contain triple-backticks inside tool-use examples, so a
+    hardcoded ``` fence closes early and corrupts the rest of the doc.
+    """
+    if not isinstance(text, str) or not text:
+        return "```"
+    longest = 0
+    run = 0
+    for ch in text:
+        if ch == "`":
+            run += 1
+            if run > longest:
+                longest = run
+        else:
+            run = 0
+    return "`" * max(3, longest + 1)
+
+
+def _capped_payload(text: Optional[str], note_source: str) -> tuple[str, bool, str]:
+    """Cap a payload string at `_PROMPT_DISPLAY_CAP_BYTES` for display.
+
+    Returns ``(body, truncated, source_note)``. Byte-length check so
+    multi-byte chars don't blow through the limit when the renderer emits
+    UTF-8 text. Slicing happens on the encoded form, then decodes with
+    ``errors="ignore"`` so we never split a multi-byte char mid-sequence.
+    `source_note` names the on-disk file with the authoritative full text.
+    """
+    if not isinstance(text, str) or not text:
+        return ("(empty)", False, note_source)
+    encoded = text.encode("utf-8")
+    if len(encoded) <= _PROMPT_DISPLAY_CAP_BYTES:
+        return (text, False, note_source)
+    body = encoded[:_PROMPT_DISPLAY_CAP_BYTES].decode("utf-8", errors="ignore")
+    return (body, True, note_source)
+
+
+def _render_call_detail_block(call: dict, idx: int, *,
+                              show_prompts: bool = False,
+                              show_response_text: bool = False) -> List[str]:
+    """Render one ``#### LLM call N — <short-id>`` block.
+
+    Used by both:
+      - the gateway-direct branch (``_section_gateway_per_call_detail``)
+      - the full-tree opt-in section (``_section_planner_llm_calls``)
+
+    ``call`` shape (subset of fields used here):
+      gateway_request_id, model, provider, prompt_template_dev_name,
+      prompt_tokens, completion_tokens, total_tokens, prompt_text,
+      response (-> finish_reason), response_text (only on full-tree path).
+
+    The prompt and response blocks are independently gated:
+      - ``show_prompts`` controls the **Prompt** block.
+      - ``show_response_text`` controls the **Response** block (full-tree
+        only — gateway-direct chain entries don't carry response_text).
+    Both default off so callers must opt in explicitly. The summary line
+    (model/provider/template/tokens/finish_reason) always renders.
+    """
+    gw_id = call.get("gateway_request_id") or "—"
+    short_id = _short(gw_id)
+    lines = [f"#### LLM call {idx} — {short_id}", ""]
+    finish_reason = (call.get("response") or {}).get("finish_reason") or "—"
+    summary = (
+        f"- model={call.get('model') or '—'}"
+        f"  provider={call.get('provider') or '—'}"
+        f"  template={call.get('prompt_template_dev_name') or '—'}"
+        f"  prompt_tok={_fmt_token_count(call.get('prompt_tokens'))}"
+        f"  completion_tok={_fmt_token_count(call.get('completion_tokens'))}"
+        f"  total_tok={_fmt_token_count(call.get('total_tokens'))}"
+        f"  finish_reason={finish_reason}"
+    )
+    lines.append(summary)
+    lines.append("")
+
+    # Prompt block — gated by show_prompts. Default-off everywhere; the
+    # summary file should never leak full prompt text without an explicit
+    # --show-prompts opt-in (matches the doc contract in SKILL.md).
+    if show_prompts:
+        body, truncated, src = _capped_payload(
+            call.get("prompt_text"), "dc.gateway_requests.json")
+        fence = _pick_fence(body)
+        lines.append("**Prompt** (full input sent to the model):")
+        lines.append(fence)
+        lines.append(body)
+        if truncated:
+            lines.append(f"…[truncated; full prompt in {src}]")
+        lines.append(fence)
+        lines.append("")
+
+    # Response block — only the full-tree path carries response_text;
+    # gateway-direct rows get finish_reason in the header line above and
+    # nothing else (the response DMO doesn't carry text on that path).
+    if show_response_text:
+        body, truncated, src = _capped_payload(
+            call.get("response_text"), "dc.generations.json")
+        # html.unescape so the rendered block reads as plain JSON instead of
+        # &quot;-laden text — matches the existing _decoded_line treatment.
+        if body and body != "(empty)":
+            body = html.unescape(body)
+        fence = _pick_fence(body)
+        lines.append("**Response** (model output, including tool invocations):")
+        lines.append(fence)
+        lines.append(body)
+        if truncated:
+            lines.append(f"…[truncated; full response in {src}]")
+        lines.append(fence)
+        lines.append("")
+
+    return lines
+
+
+def _section_gateway_per_call_detail(sess: dict, *,
+                                     show_prompts: bool = False) -> List[str]:
+    """Per-call detail for the gateway-direct branch.
+
+    ``gateway_chain`` does NOT carry `response_text` (the responses DMO
+    doesn't include it on that path), so the response block is always
+    suppressed. The prompt block is gated by ``show_prompts`` so the
+    default summary doesn't leak full prompt text — matches the
+    documented contract for ``dc._session_summary.md``.
+    """
+    chain = sess.get("gateway_chain") or []
+    lines: List[str] = ["## Per-call detail", ""]
+    for i, call in enumerate(chain, start=1):
+        lines.extend(_render_call_detail_block(
+            call, i, show_prompts=show_prompts, show_response_text=False))
+    return lines
+
+
+def _collect_planner_llm_calls(sess: dict) -> List[dict]:
+    """Walk ``interactions[].steps[]`` and collect call-view dicts.
+
+    Each step that has a ``gateway_request`` (regardless of binding method)
+    contributes one call view. ``response_text`` is sourced from the step's
+    sibling ``generation.response_text`` when present; otherwise the call is
+    still emitted with the prompt + token summary.
+
+    Returned dicts use the same field names as ``gateway_chain`` entries so
+    ``_render_call_detail_block`` can consume both shapes uniformly.
+    """
+    calls: List[dict] = []
+    for iv in sess.get("interactions") or []:
+        for st in iv.get("steps") or []:
+            gw = st.get("gateway_request")
+            if not gw:
+                continue
+            gen = st.get("generation") or {}
+            calls.append({
+                "gateway_request_id": gw.get("gateway_request_id"),
+                "model": gw.get("model"),
+                "provider": gw.get("provider"),
+                "prompt_template_dev_name": gw.get("prompt_template_dev_name"),
+                "prompt_tokens": gw.get("prompt_tokens"),
+                "completion_tokens": gw.get("completion_tokens"),
+                "total_tokens": gw.get("total_tokens"),
+                "prompt_text": gw.get("prompt_text"),
+                "response": gw.get("response"),
+                "response_text": gen.get("response_text"),
+            })
+    return calls
+
+
+def _section_planner_llm_calls(sess: dict, *, show_prompts: bool) -> List[str]:
+    """Opt-in full-tree section showing the input prompt + response
+    for every LLM call in the session's hierarchical trace.
+
+    Off by default — prompts can be 30 KB+ each on multi-turn sessions
+    and would otherwise dominate the summary. Enable with
+    ``render_dc.py --show-prompts``.
+    """
+    if not show_prompts:
+        return []
+    calls = _collect_planner_llm_calls(sess)
+    if not calls:
+        return []
+    lines: List[str] = [
+        "## Planner LLM calls (full prompts + responses)",
+        "",
+        f"_Found {len(calls)} LLM call(s) across the session's hierarchical "
+        f"trace. Prompts are capped at "
+        f"{_PROMPT_DISPLAY_CAP_BYTES // 1024} KB for display; full payloads "
+        f"are on disk in `dc.gateway_requests.json` and "
+        f"`dc.generations.json`._",
+        "",
+    ]
+    for i, call in enumerate(calls, start=1):
+        # show_prompts is True here by section-guard above (early return when
+        # show_prompts is False); pass through explicitly so the helper's new
+        # prompt-gate stays aligned with the section's intent.
+        lines.extend(_render_call_detail_block(
+            call, i, show_prompts=True, show_response_text=True))
+    return lines
+
+
+def _assert_schema_version(tree: dict) -> None:
+    """Refuse unsupported versions; warn on missing version (older assembler)."""
+    version = (tree.get("session") or {}).get("_schema_version")
+    if version is None:
+        print(
+            "render_dc: WARN tree has no _schema_version "
+            "(produced by an older assembler?); rendering anyway",
+            file=sys.stderr,
+        )
+        return
+    if version != _SUPPORTED_SCHEMA_VERSION:
+        raise SystemExit(
+            f"render_dc: unsupported tree _schema_version={version}; "
+            f"expected {_SUPPORTED_SCHEMA_VERSION}"
+        )
+
+
+def main_for_session(sid: str, *, show_prompts: bool = False) -> int:
+    """Read session tree + manifest from the nested session dir; emit summary.md.
+
+    Uses ``assemble_dc._find_session_dir`` to locate the session under
+    ``DATA_ROOT/<org>/<agent>__<ver>/<sid>/`` — follows the ``_sessions/*.link``
+    breadcrumb when present, globs otherwise. No callers need to know the
+    full identity triple upfront.
+
+    ``show_prompts``: pass through to ``render`` to include the
+    opt-in "Planner LLM calls" section.
+    """
+    from assemble_dc import _find_session_dir
+    session_dir = _find_session_dir(sid)
+    tree_path = session_dir / "dc._session_tree.json"
+    if not tree_path.is_file():
+        raise SystemExit(
+            f"render_dc: tree not found at {tree_path}; "
+            f"run `python3 scripts/assemble_dc.py --session {sid}` first"
+        )
+    manifest_path = session_dir / "dc._session_manifest.json"
+    manifest: Optional[dict] = None
+    if manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            print(
+                f"render_dc: WARN could not read manifest: {str(e).splitlines()[0]}",
+                file=sys.stderr,
+            )
+
+    tree = json.loads(tree_path.read_text())
+    _assert_schema_version(tree)
+
+    md_path = session_dir / "dc._session_summary.md"
+    md_path.write_text(render(tree, manifest, session_dir=session_dir,
+                              show_prompts=show_prompts))
+    print(f"render_dc: wrote {md_path}", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="render_dc.py",
+        description="Render dc._session_summary.md from dc._session_tree.json for one session.",
+    )
+    ap.add_argument("--session", required=True,
+                    help="AI-agent session UUID or MessagingSession id (0Mw...). "
+                         "Messaging ids are resolved from disk "
+                         "(DATA_ROOT/*/dc.sessions.json); run fetch_dc.py first "
+                         "if the session hasn't been fetched yet.")
+    ap.add_argument("--show-prompts", action="store_true",
+                    help="Include the opt-in 'Planner LLM calls' section "
+                         "with the full input prompt + response per LLM call. "
+                         "Off by default — multi-turn sessions can produce "
+                         "hundreds of KB here. Per-prompt display is capped "
+                         "at 64 KB; full payloads remain on disk in "
+                         "dc.gateway_requests.json + dc.generations.json.")
+    args = ap.parse_args()
+    from resolve_session import resolve_disk_or_live
+    sid = resolve_disk_or_live(args.session)
+    return main_for_session(sid, show_prompts=args.show_prompts)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/investigating-agentforce-d360/scripts/resolve_session.py
+++ b/skills/investigating-agentforce-d360/scripts/resolve_session.py
@@ -1,0 +1,260 @@
+"""Resolve either an AI-agent session UUID or a Messaging session id (0Mw...)
+to the canonical AI-agent session UUID that the rest of the skill uses.
+
+## Why this exists
+
+`ssot__AIAgentSession__dlm.ssot__RelatedMessagingSessionId__c` stores the
+Service Cloud `MessagingSession.Id` (18-char Salesforce id, prefix `0Mw`).
+Users often only have that messaging id on hand, not the AI-agent session
+UUID (`019dface-0000-7000-8000-000000000002`). This resolver lets every
+entry point in the skill accept either form — it normalises to the UUID,
+and artifacts continue to land under `DATA_ROOT/<uuid>/` as before.
+
+## Many-to-one is real
+
+Live-verified on an internal test org: 7 distinct messaging ids map to
+multiple agent sessions; one id mapped to 5 separate agent sessions.
+"Most recent by start_ts" is NOT a safe default for disambiguation —
+the user could legitimately want any of them. On multi-match we list
+every candidate and exit non-zero; the user re-invokes with the
+specific UUID.
+
+## Two resolution modes
+
+1. **Live** — query DC. Requires `--org`. Used by `fetch_dc.py` at the
+   top of the pipeline (before any artifacts exist on disk).
+2. **Disk-first** — scan `DATA_ROOT/*/dc.sessions.json` for a row whose
+   `ssot__RelatedMessagingSessionId__c` matches. No DC call, no `--org`
+   needed. Used by `assemble_dc.py` and `render_dc.py`. If the session
+   has never been fetched, returns None and the caller errors with a
+   pointer to `fetch_dc.py`.
+
+## CLI
+
+    python3 scripts/resolve_session.py --id <uuid|msg_id> --org <alias>
+
+Prints the resolved UUID to stdout on single-match (or pass-through).
+Non-zero exit with diagnostics on zero-match and multi-match.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import DATA_ROOT
+from dc import load_sql, post, resolve_org
+
+
+# NOT_SET sentinel set. Matches fetch_dc.py:41; keep in sync.
+_NOT_SET = {"", "NOT_SET", None}
+
+
+def is_messaging_id(s: str) -> bool:
+    """Shape check for a Salesforce MessagingSession id. The official key
+    prefix is `0Mw`; the id is 15 or 18 chars. UUIDs are 36 chars with
+    dashes, so they can't accidentally match."""
+    if not s:
+        return False
+    return s.startswith("0Mw") and len(s) in (15, 18)
+
+
+# ---- live resolution (queries Data Cloud) --------------------------------
+
+def _live_lookup(msg_id: str, org: str) -> List[dict]:
+    """Query ssot__AIAgentSession__dlm for rows where RelatedMessagingSessionId
+    matches `msg_id`. Returns raw row dicts (caller decides how to handle
+    N=0, N=1, N>1).
+
+    SQL comes from `assets/dc/messaging_session.sql` — same templating
+    convention as every other DMO query in this skill. The `MSG_ID`
+    placeholder is interpolated as a literal string, but the caller
+    guarantees (via is_messaging_id) that the value is a Salesforce
+    MessagingSession id: exact 15/18 chars, `0Mw` key prefix. No quote,
+    no wildcard, no semicolon can pass that shape check.
+    """
+    if not is_messaging_id(msg_id):
+        raise ValueError(
+            f"_live_lookup: msg_id {msg_id!r} failed is_messaging_id() shape check"
+        )
+    instance_url, token = resolve_org(org)
+    sql = load_sql("messaging_session", MSG_ID=msg_id)
+    return post(sql, instance_url, token, "resolve_session")
+
+
+def _format_multi_match(msg_id: str, rows: List[dict]) -> str:
+    """Human-readable error for the N>1 case. Lists every candidate so
+    the user can pick and re-invoke."""
+    lines = [
+        f"resolve_session: messaging id {msg_id!r} matches {len(rows)} "
+        f"ssot__AIAgentSession__dlm rows — pick one and re-invoke with its UUID:",
+        "",
+    ]
+    for r in rows:
+        uuid = r.get("ssot__Id__c")
+        start = r.get("ssot__StartTimestamp__c") or "—"
+        end = r.get("ssot__EndTimestamp__c") or "—"
+        end_type = r.get("ssot__AiAgentSessionEndType__c") or "—"
+        channel = r.get("ssot__AiAgentChannelType__c") or "—"
+        lines.append(
+            f"  {uuid}  start={start}  end={end}  end_type={end_type}  channel={channel}"
+        )
+    lines.append("")
+    lines.append(
+        f"Example: python3 scripts/fetch_dc.py --session {rows[0].get('ssot__Id__c')} --org <alias>"
+    )
+    return "\n".join(lines)
+
+
+def resolve(sid_or_msg: str, *, org: str) -> str:
+    """Resolve an AI-agent session UUID from either form (live DC query).
+    Exits the process on zero- and multi-match with a diagnostic message.
+    Pass-through for UUID input."""
+    if not is_messaging_id(sid_or_msg):
+        return sid_or_msg  # already a UUID (or unknown form — let caller fail)
+    rows = _live_lookup(sid_or_msg, org)
+    if len(rows) == 0:
+        raise SystemExit(
+            f"resolve_session: no ssot__AIAgentSession__dlm row with "
+            f"RelatedMessagingSessionId={sid_or_msg!r} in org {org!r}"
+        )
+    if len(rows) > 1:
+        raise SystemExit(_format_multi_match(sid_or_msg, rows))
+    return rows[0]["ssot__Id__c"]
+
+
+# ---- disk-first resolution (no DC call) ----------------------------------
+
+def resolve_from_disk(sid_or_msg: str) -> Optional[str]:
+    """For scripts that don't have `--org` wired up. Scans every
+    ``dc.sessions.json`` under ``DATA_ROOT`` for a row whose
+    ``ssot__RelatedMessagingSessionId__c`` matches ``sid_or_msg``. Returns
+    the UUID (from the matching row's ``ssot__Id__c``) or None if not found.
+
+    Layout: the nested scheme is ``DATA_ROOT/<org_id15>/<agent>__<ver>/<uuid>/
+    dc.sessions.json``. Historic flat runs (``DATA_ROOT/<uuid>/...``) are
+    picked up by the same ``rglob`` walk, so this resolver works across
+    both layouts without caller awareness.
+
+    Archive suffix: user-created duplicate dirs named like
+    ``<uuid> - archive 1/`` carry stale copies of the same rows and would
+    otherwise trigger spurious multi-match exits. They are skipped at
+    scan time.
+
+    Pass-through if input is already a UUID; returns input unchanged
+    regardless of disk presence (caller validates with its own load-
+    artifact check).
+    """
+    if not is_messaging_id(sid_or_msg):
+        return sid_or_msg  # UUID — pass through (caller validates disk presence)
+
+    matches: List[str] = []  # uuids
+    if not DATA_ROOT.is_dir():
+        return None
+    # Nested layout is 4-deep (<org>/<agent>/<uuid>/dc.sessions.json), flat
+    # is 2-deep (<uuid>/dc.sessions.json). rglob handles both without a
+    # hard-coded depth.
+    for sessions_p in sorted(DATA_ROOT.rglob("dc.sessions.json")):
+        if not sessions_p.is_file():
+            continue
+        # Skip `<uuid> - archive N/` duplicate dirs — they hold stale copies
+        # of the same rows and would produce spurious multi-match exits.
+        if " - archive" in sessions_p.parent.name:
+            continue
+        try:
+            data = json.loads(sessions_p.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        # `dc.sessions.json` is a list of rows (the skill saves raw DC rows).
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            row_msg = (row.get("ssot__RelatedMessagingSessionId__c") or "").strip()
+            if row_msg in _NOT_SET:
+                continue
+            if row_msg == sid_or_msg:
+                uuid = row.get("ssot__Id__c")
+                if uuid:
+                    matches.append(uuid)
+    if not matches:
+        return None
+    # De-duplicate across multiple dc.sessions.json files that happen to
+    # contain the same row (possible if a user copies artifacts between
+    # agent dirs). Distinct UUIDs remain a multi-match.
+    unique = sorted(set(matches))
+    if len(unique) > 1:
+        raise SystemExit(
+            f"resolve_session: messaging id {sid_or_msg!r} matches {len(unique)} "
+            f"session directories on disk — pick a UUID and re-invoke:\n  "
+            + "\n  ".join(unique)
+        )
+    return unique[0]
+
+
+def resolve_disk_or_live(sid_or_msg: str, org: Optional[str] = None) -> str:
+    """Combined path used by entry points that support both. Tries disk
+    first (cheap); falls back to live DC only if `org` is supplied.
+    Raises with a useful message if disk-miss and no org."""
+    if not is_messaging_id(sid_or_msg):
+        return sid_or_msg  # UUID — no resolution needed
+    disk = resolve_from_disk(sid_or_msg)
+    if disk is not None:
+        return disk
+    if org is None:
+        raise SystemExit(
+            f"resolve_session: cannot resolve messaging id {sid_or_msg!r} from "
+            f"disk (no dc.sessions.json under DATA_ROOT has a matching "
+            f"RelatedMessagingSessionId). Run `python3 scripts/fetch_dc.py "
+            f"--session {sid_or_msg} --org <alias>` first, or re-invoke with "
+            f"the AI-agent session UUID directly."
+        )
+    return resolve(sid_or_msg, org=org)
+
+
+# ---- CLI -----------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Resolve a Salesforce messaging session id (0Mw...) to the "
+                    "AI-agent session UUID the skill uses. Passes UUID input through unchanged."
+    )
+    ap.add_argument("--id", required=True,
+                    help="Either the AI-agent session UUID or the MessagingSession id (0Mw...)")
+    ap.add_argument("--org", help="sf org alias (required for live DC lookup when input is 0Mw...)")
+    ap.add_argument("--disk-only", action="store_true",
+                    help="Only scan DATA_ROOT/*/dc.sessions.json; no DC query")
+    args = ap.parse_args()
+
+    if not is_messaging_id(args.id):
+        print(args.id)
+        return 0
+    if args.disk_only:
+        found = resolve_from_disk(args.id)
+        if found is None:
+            print(f"resolve_session: no local session dir matches {args.id!r}", file=sys.stderr)
+            return 1
+        print(found)
+        return 0
+    if not args.org:
+        # Try disk first as a convenience; only error if that also misses.
+        disk = resolve_from_disk(args.id)
+        if disk is not None:
+            print(disk)
+            return 0
+        print(
+            f"resolve_session: {args.id!r} not found on disk; --org <alias> required "
+            f"for a live DC lookup",
+            file=sys.stderr,
+        )
+        return 2
+    uuid = resolve(args.id, org=args.org)
+    print(uuid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/investigating-agentforce-d360/scripts/storage.py
+++ b/skills/investigating-agentforce-d360/scripts/storage.py
@@ -1,0 +1,92 @@
+"""Shared per-session JSON writer.
+
+Every Data Cloud artifact lands under the nested layout:
+
+    DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/<session_id>/<source>.<name>.json
+
+One save, one shape, one directory convention — imported by every caller.
+
+**Security contract:**
+All four path segments (``org_id_15``, ``agent_api_name``, ``agent_version``,
+``session_id``) flow through ``paths.session_dir(...)``, which validates
+each via fs_guard (regex) before the join. A ``..`` or ``/`` in any
+segment raises ``paths.PathValidationError`` — direct
+``DATA_ROOT / session_id`` composition is unreachable from this module.
+
+Source-prefix convention:
+    Flat directory, prefix filenames with provenance so an `ls` on the
+    per-session dir tells you where each artifact came from:
+
+        dc.sessions.json       — from Data Cloud
+        dc.interactions.json
+
+    Baking the prefix into the API (vs. leaving it to filename discipline)
+    makes it impossible to forget — callers pass ``source`` + ``name``,
+    never a raw filename.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from config import paths
+
+
+def save(
+    data: list[dict] | dict,
+    org_id_15: str,
+    agent_api_name: str,
+    agent_version: str,
+    session_id: str,
+    source: str,
+    name: str,
+) -> Path:
+    """Write JSON under the nested session dir. Returns the target path.
+
+    Signature:
+        save(data, org_id_15, agent_api_name, agent_version, session_id,
+             source, name) -> Path
+
+    ``source`` is the leading filename segment for provenance — callers
+    pass ``"dc"``. ``name`` is the bare artifact name, no extension —
+    ``.json`` is appended.
+
+    Raises ``paths.PathValidationError`` if any of the four identity
+    segments fails validation.
+    """
+    # paths.session_dir() validates org_id_15, agent_api_name, agent_version
+    # (via fs_guard) and session_id (via SESSION_ID_RE.fullmatch). Any bad
+    # input raises PathValidationError before we touch the filesystem.
+    target = paths.session_dir(
+        org_id_15, agent_api_name, agent_version, session_id
+    )
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{source}.{name}.json"
+    path.write_text(json.dumps(data, indent=2, default=str) + "\n")
+    _write_breadcrumb(org_id_15, agent_api_name, agent_version, session_id)
+    return path
+
+
+def _write_breadcrumb(
+    org_id_15: str,
+    agent_api_name: str,
+    agent_version: str,
+    session_id: str,
+) -> None:
+    """Write ``<org>/_sessions/<sid>.link`` pointing at the session dir.
+
+    Plain text, no symlink (Windows-safe). Content is the relative path
+    ``../<agent>__<ver>/<sid>\\n``. Idempotent — overwriting with the
+    same content is a no-op semantically. Silent on failure; breadcrumbs
+    are best-effort (a missing breadcrumb doesn't break the write,
+    only handoff-session discovery).
+    """
+    try:
+        link_dir = paths.DATA_ROOT / org_id_15 / "_sessions"
+        link_dir.mkdir(parents=True, exist_ok=True)
+        link_path = link_dir / f"{session_id}.link"
+        link_path.write_text(
+            f"../{agent_api_name}__{agent_version}/{session_id}\n"
+        )
+    except OSError:
+        pass

--- a/skills/investigating-agentforce-d360/scripts/tests/_bootstrap.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/_bootstrap.py
@@ -1,0 +1,15 @@
+"""Test bootstrap — adds sibling ``scripts/`` to sys.path.
+
+Every ``test_*.py`` in this directory imports this module first
+(as ``from . import _bootstrap``) so the sibling modules
+(`config`, `storage`, `paths`, etc.) resolve.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# scripts/tests/_bootstrap.py → scripts/
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))

--- a/skills/investigating-agentforce-d360/scripts/tests/fixtures/synthetic_session.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/fixtures/synthetic_session.py
@@ -1,0 +1,424 @@
+"""Synthetic session fixture for d360 integration tests.
+
+Provides:
+
+- ``IDS``           a flat namespace of all UUIDs/keys used so tests
+                    can assert against specific values.
+- ``make_rows()``   returns ``{dmo_name: [row, ...]}`` for the 24 DMOs
+                    `assemble_dc` reads. Self-consistent: every
+                    Step.GenerationId references a Generation row, etc.
+- ``make_manifest`` returns the dc._session_manifest.json shape.
+- ``write_to_disk`` materializes the whole fixture under a session dir
+                    so tests that drive the public ``assemble_dc.assemble``
+                    can use ``tmp_path`` + DATA_ROOT redirect without
+                    duplicating layout knowledge.
+
+Shape rules:
+  - Timestamps anchored on 2026-04-22T10:00:00Z; offsets in seconds.
+  - All ssot__Id__c values are 18-char-stable strings (not real Salesforce
+    IDs) — assemble_dc only key-equality-checks them.
+  - HTML escaping applied to AttributeText__c so the trace_id fallback
+    path exercises real code.
+  - parameters__c on gateway_responses uses the &quot;-escaped JSON shape
+    real DC emits.
+"""
+from __future__ import annotations
+
+import html
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+# -----------------------------------------------------------------------------
+# IDs — exposed flat for cross-test assertions
+# -----------------------------------------------------------------------------
+
+
+class _IDs:
+    SID = "019dface-0000-7000-8000-000000000001"
+    """Agent session UUID. Valid UUIDv7 so window decode works."""
+
+    ORG_ID_15 = "00D000000000ABC"
+    ORG_ID_18 = "00D000000000ABCDEF"
+    AGENT_API = "DemoAgent"
+    AGENT_VERSION = "v5"
+    BOT_ID = "0Xx000000000DemoBot"
+
+    # Interactions
+    IXN_START = "ixn-start-001"
+    IXN_TURN = "ixn-turn-002"
+    IXN_END = "ixn-end-003"
+
+    # Steps within the TURN
+    STEP_TOPIC = "step-topic-001"
+    STEP_ACTION = "step-action-002"
+    STEP_GUARDRAIL = "step-guardrail-003"
+
+    # Gateway audit chain — one declared, one timestamp-window-only
+    GW_REQ_DECLARED = "gw-req-declared-001"
+    GW_REQ_WINDOW = "gw-req-window-002"
+    GW_RESP_DECLARED = "gw-resp-declared-001"
+
+    # Generation chain (declared)
+    GEN_DECLARED = "gen-declared-001"
+
+    # Participants
+    PART_AGENT = "part-agent-001"
+    PART_USER = "part-user-002"
+
+    # Trace + window
+    TRACE_ID = "8b820e85aaaaaaaabbbbbbbbcccccccc"
+    SESSION_START = "2026-04-22T10:00:00.000Z"
+    SESSION_END = "2026-04-22T10:01:30.000Z"
+    TURN_START = "2026-04-22T10:00:05.000Z"
+    TURN_END = "2026-04-22T10:01:00.000Z"
+    GW_DECLARED_TS = "2026-04-22T10:00:30.000Z"  # inside step-action window
+    GW_WINDOW_TS = "2026-04-22T10:00:45.000Z"   # inside the TURN window only
+
+
+IDS = _IDs
+
+
+# -----------------------------------------------------------------------------
+# Per-DMO row builders
+# -----------------------------------------------------------------------------
+
+
+def _sessions() -> List[dict]:
+    return [{
+        "ssot__Id__c": IDS.SID,
+        "ssot__InternalOrganizationId__c": IDS.ORG_ID_18,
+        "ssot__StartTimestamp__c": IDS.SESSION_START,
+        "ssot__EndTimestamp__c": IDS.SESSION_END,
+        "ssot__AiAgentChannelType__c": "SCRT2 - EmbeddedMessaging",
+        "ssot__AiAgentSessionEndType__c": "USER_ENDED",
+        "ssot__RelatedMessagingSessionId__c": "0MwTESTMSG12345AAA",
+    }]
+
+
+def _interactions() -> List[dict]:
+    """Three interactions: SESSION_START, TURN, SESSION_END.
+
+    `AttributeText__c` carries the real internalTraceId in HTML-escaped
+    JSON form on the TURN row (matches live DC shape).
+    """
+    # No spaces in separators — production logger emits compact JSON, and
+    # the trace_id regex (`"internalTraceId":"([a-f0-9]+)"`) requires no
+    # whitespace around the colon.
+    raw_attr_text = json.dumps(
+        {"internalTraceId": IDS.TRACE_ID, "label": "react-loop"},
+        separators=(",", ":"),
+    )
+    return [
+        {
+            "ssot__Id__c": IDS.IXN_START,
+            "ssot__AiAgentSessionId__c": IDS.SID,
+            "ssot__AiAgentInteractionType__c": "SESSION_START",
+            "ssot__StartTimestamp__c": IDS.SESSION_START,
+            "ssot__EndTimestamp__c": IDS.SESSION_START,
+            "ssot__TelemetryTraceId__c": "",
+            "ssot__AttributeText__c": "",
+        },
+        {
+            "ssot__Id__c": IDS.IXN_TURN,
+            "ssot__AiAgentSessionId__c": IDS.SID,
+            "ssot__AiAgentInteractionType__c": "TURN",
+            "ssot__StartTimestamp__c": IDS.TURN_START,
+            "ssot__EndTimestamp__c": IDS.TURN_END,
+            "ssot__TelemetryTraceId__c": "",
+            # HTML-escaped JSON triggers the AttributeText fallback path.
+            "ssot__AttributeText__c": html.escape(raw_attr_text, quote=True),
+        },
+        {
+            "ssot__Id__c": IDS.IXN_END,
+            "ssot__AiAgentSessionId__c": IDS.SID,
+            "ssot__AiAgentInteractionType__c": "SESSION_END",
+            "ssot__StartTimestamp__c": IDS.SESSION_END,
+            "ssot__EndTimestamp__c": IDS.SESSION_END,
+            "ssot__TelemetryTraceId__c": "NOT_SET",
+            "ssot__AttributeText__c": "",
+        },
+    ]
+
+
+def _steps() -> List[dict]:
+    """Three steps inside the TURN. Step times nest inside the turn window
+    so the timestamp-window pass binds gateway_requests by containment."""
+    return [
+        {
+            "ssot__Id__c": IDS.STEP_TOPIC,
+            "ssot__AiAgentInteractionId__c": IDS.IXN_TURN,
+            "ssot__AiAgentInteractionStepType__c": "TOPIC_STEP",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:10.000Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:00:20.000Z",
+            "ssot__GenerationId__c": "NOT_SET",
+            "ssot__Name__c": "TopicSelection",
+        },
+        {
+            "ssot__Id__c": IDS.STEP_ACTION,
+            "ssot__AiAgentInteractionId__c": IDS.IXN_TURN,
+            "ssot__AiAgentInteractionStepType__c": "ACTION_STEP",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:25.000Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:00:40.000Z",
+            "ssot__GenerationId__c": IDS.GEN_DECLARED,
+            "ssot__Name__c": "PrimaryAction",
+        },
+        {
+            "ssot__Id__c": IDS.STEP_GUARDRAIL,
+            "ssot__AiAgentInteractionId__c": IDS.IXN_TURN,
+            "ssot__AiAgentInteractionStepType__c": "TRUST_GUARDRAILS_STEP",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:55.000Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:01:00.000Z",
+            "ssot__GenerationId__c": "NOT_SET",
+            "ssot__Name__c": "FinalGuard",
+        },
+    ]
+
+
+def _messages() -> List[dict]:
+    return [
+        {
+            "ssot__Id__c": "msg-001",
+            "ssot__AiAgentInteractionId__c": IDS.IXN_TURN,
+            "ssot__AiAgentInteractionMessageType__c": "USER",
+            "ssot__ContentText__c": "How do I refund my order?",
+            "ssot__StartTimestamp__c": IDS.TURN_START,
+        },
+        {
+            "ssot__Id__c": "msg-002",
+            "ssot__AiAgentInteractionId__c": IDS.IXN_TURN,
+            "ssot__AiAgentInteractionMessageType__c": "AGENT",
+            "ssot__ContentText__c": "I'll help you with the refund process.",
+            "ssot__StartTimestamp__c": IDS.TURN_END,
+        },
+    ]
+
+
+def _participants() -> List[dict]:
+    return [
+        {
+            "ssot__Id__c": IDS.PART_AGENT,
+            "ssot__AiAgentSessionId__c": IDS.SID,
+            "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+            "ssot__AiAgentApiName__c": IDS.AGENT_API,
+            "ssot__AiAgentVersionApiName__c": IDS.AGENT_VERSION,
+        },
+        {
+            "ssot__Id__c": IDS.PART_USER,
+            "ssot__AiAgentSessionId__c": IDS.SID,
+            "ssot__AiAgentSessionParticipantRole__c": "USER",
+            "ssot__AiAgentApiName__c": "",
+            "ssot__AiAgentVersionApiName__c": "",
+        },
+    ]
+
+
+def _gateway_requests() -> List[dict]:
+    """Two gateway requests:
+
+    - GW_REQ_DECLARED: chained from Step → Generation → Response → Request.
+      Timestamp also falls within step-action window so either binding
+      method can resolve it. Declared chain wins.
+
+    - GW_REQ_WINDOW: NOT in the declared chain. Timestamp falls inside
+      the TURN window → exercise timestamp-window fallback.
+    """
+    return [
+        {
+            "gatewayRequestId__c": IDS.GW_REQ_DECLARED,
+            "sf__Id": "sf-" + IDS.GW_REQ_DECLARED,
+            "sessionId__c": f'"{IDS.SID}"',
+            "timestamp__c": IDS.GW_DECLARED_TS,
+            "model__c": "gpt-4o",
+            "provider__c": "openai",
+            "promptTemplateDevName__c": "AiCopilot__ReactInitialPrompt",
+            "feature__c": "plannerservice",
+            "promptTokens__c": 1200,
+            "completionTokens__c": 50,
+            "totalTokens__c": 1250,
+            "prompt__c": "Declared-bound prompt body.",
+        },
+        {
+            "gatewayRequestId__c": IDS.GW_REQ_WINDOW,
+            "sf__Id": "sf-" + IDS.GW_REQ_WINDOW,
+            "sessionId__c": f'"{IDS.SID}"',
+            "timestamp__c": IDS.GW_WINDOW_TS,
+            "model__c": "gpt-4o-mini",
+            "provider__c": "openai",
+            "promptTemplateDevName__c": "AiCopilot__PromptTemplateGenerationsInvocable",
+            "feature__c": "plannerservice",
+            "promptTokens__c": 200,
+            "completionTokens__c": 20,
+            "totalTokens__c": 220,
+            "prompt__c": "Window-bound prompt body.",
+        },
+    ]
+
+
+def _gateway_responses() -> List[dict]:
+    raw = '{"finish_reason":"\\"stop\\""}'
+    escaped = raw.replace('"', "&quot;")
+    return [{
+        "generationResponseId__c": IDS.GW_RESP_DECLARED,
+        "generationRequestId__c": IDS.GW_REQ_DECLARED,
+        "parameters__c": escaped,
+        "timestamp__c": IDS.GW_DECLARED_TS,
+    }]
+
+
+def _generations() -> List[dict]:
+    return [{
+        "generationId__c": IDS.GEN_DECLARED,
+        "generationResponseId__c": IDS.GW_RESP_DECLARED,
+        "responseText__c": "I'll help you with the refund process.",
+        "timestamp__c": IDS.GW_DECLARED_TS,
+    }]
+
+
+def _content_quality() -> List[dict]:
+    return [{
+        "generationId__c": IDS.GEN_DECLARED,
+        "trustScore__c": 0.92,
+        "qualityType__c": "NORMAL",
+    }]
+
+
+def _gateway_records() -> List[dict]:
+    return [{
+        "id__c": "gw-rec-001",
+        "parent__c": IDS.GW_REQ_DECLARED,
+        "sessionId__c": IDS.SID,
+        "recordType__c": "RAG",
+    }]
+
+
+def _gateway_request_tags() -> List[dict]:
+    return [
+        {"id__c": "tag-001", "parent__c": IDS.GW_REQ_DECLARED,
+         "tag__c": "promptTemplateDevName", "tagValue__c": "AiCopilot__ReactInitialPrompt"},
+        {"id__c": "tag-002", "parent__c": IDS.GW_REQ_DECLARED,
+         "tag__c": "feature", "tagValue__c": "plannerservice"},
+    ]
+
+
+# -----------------------------------------------------------------------------
+# Public: rows + manifest
+# -----------------------------------------------------------------------------
+
+
+_ALL_TEMPLATES = (
+    "sessions", "interactions", "messages", "moments", "participants",
+    "tag_associations", "gateway_requests",
+    "steps", "moment_interactions",
+    "telemetry_spans", "generations", "app_generation",
+    "gateway_request_tags", "gateway_responses", "gateway_records",
+    "gateway_request_metadata", "gateway_request_llm",
+    "feedback",
+    "content_quality", "content_category", "feedback_details",
+    "tag_definitions", "tag_definition_associations", "tags",
+)
+
+
+def make_rows() -> Dict[str, List[dict]]:
+    """Return ``{dmo_name: [row, ...]}`` for all 24 DMOs.
+
+    Empty lists for DMOs the synthetic session doesn't exercise — the
+    code under test reads them by ``.get(name, [])`` and tolerates
+    missing entries.
+    """
+    populated = {
+        "sessions": _sessions(),
+        "interactions": _interactions(),
+        "steps": _steps(),
+        "messages": _messages(),
+        "participants": _participants(),
+        "gateway_requests": _gateway_requests(),
+        "gateway_responses": _gateway_responses(),
+        "generations": _generations(),
+        "content_quality": _content_quality(),
+        "gateway_records": _gateway_records(),
+        "gateway_request_tags": _gateway_request_tags(),
+    }
+    rows: Dict[str, List[dict]] = {name: [] for name in _ALL_TEMPLATES}
+    rows.update(populated)
+    return deepcopy(rows)
+
+
+def make_manifest() -> dict:
+    """Manifest shape matching what `fetch_dc.py` writes."""
+    rows = make_rows()
+    queries = [
+        {
+            "name": name,
+            "row_count": len(rows[name]),
+            "elapsed_ms": 50,
+            "where_clause": f"ssot__AiAgentSessionId__c = '{IDS.SID}'",
+        }
+        for name in _ALL_TEMPLATES
+    ]
+    return {
+        "_doc": "Per-query summary of this DC fetch run.",
+        "session_id": IDS.SID,
+        "org_alias": "my-org",
+        "instance_url": "https://example.my.salesforce.com",
+        "org_id_15": IDS.ORG_ID_15,
+        "agent_api_name": IDS.AGENT_API,
+        "agent_version": IDS.AGENT_VERSION,
+        "session_shape": "ok",
+        "started_at_utc": "2026-04-22T10:01:30.000Z",
+        "finished_at_utc": "2026-04-22T10:01:32.000Z",
+        "elapsed_ms": 2000,
+        "queries": queries,
+        "harvested_ids": {
+            "interactions": [IDS.IXN_START, IDS.IXN_TURN, IDS.IXN_END],
+        },
+    }
+
+
+# -----------------------------------------------------------------------------
+# Disk materialization
+# -----------------------------------------------------------------------------
+
+
+def session_dir_for(data_root: Path) -> Path:
+    """Compute the canonical session dir under a tmp DATA_ROOT."""
+    return (
+        data_root
+        / IDS.ORG_ID_15
+        / f"{IDS.AGENT_API}__{IDS.AGENT_VERSION}"
+        / IDS.SID
+    )
+
+
+def write_to_disk(data_root: Path) -> Path:
+    """Materialize the synthetic session under ``<data_root>/<org>/<agent>__<ver>/<sid>/``.
+
+    Writes:
+      - dc._session_manifest.json
+      - dc.<name>.json for every populated DMO
+      - The per-org breadcrumb at <org>/_sessions/<sid>.link
+
+    Returns the session dir absolute path.
+    """
+    sdir = session_dir_for(data_root)
+    sdir.mkdir(parents=True, exist_ok=True)
+
+    # DC manifest + rows
+    (sdir / "dc._session_manifest.json").write_text(
+        json.dumps(make_manifest(), indent=2) + "\n"
+    )
+    rows = make_rows()
+    for name, rs in rows.items():
+        if rs:
+            (sdir / f"dc.{name}.json").write_text(json.dumps(rs, indent=2) + "\n")
+
+    # Breadcrumb so _find_session_dir's primary path resolves
+    link_dir = data_root / IDS.ORG_ID_15 / "_sessions"
+    link_dir.mkdir(parents=True, exist_ok=True)
+    (link_dir / f"{IDS.SID}.link").write_text(
+        f"../{IDS.AGENT_API}__{IDS.AGENT_VERSION}/{IDS.SID}\n"
+    )
+
+    return sdir

--- a/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_bootstrap_and_mode.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_bootstrap_and_mode.py
@@ -1,0 +1,115 @@
+"""Tests for the bootstrap-variable parser + channel-mode deriver in assemble_dc.py.
+
+Coverage:
+  - `_parse_bootstrap_variables`
+      - returns None for missing/NOT_SET/UNSET_VALUE
+      - parses well-formed JSON object
+      - parses HTML-entity-encoded JSON
+      - returns _parse_error dict for malformed JSON
+      - returns _parse_error dict for non-object JSON (array, scalar)
+
+  - `_derive_mode`
+      - voice  → when RelatedVoiceCallId set
+      - production_messaging → when RelatedMessagingSessionId set
+      - builder_previewer → when bootstrap has indicator keys
+      - unknown → when nothing matches
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+from assemble_dc import _parse_bootstrap_variables, _derive_mode  # type: ignore
+
+
+class ParseBootstrapVariablesTests(unittest.TestCase):
+
+    def test_none_input_returns_none(self):
+        self.assertIsNone(_parse_bootstrap_variables(None))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(_parse_bootstrap_variables(""))
+
+    def test_not_set_sentinel_returns_none(self):
+        self.assertIsNone(_parse_bootstrap_variables("NOT_SET"))
+
+    def test_unset_value_sentinel_returns_none(self):
+        self.assertIsNone(_parse_bootstrap_variables("UNSET_VALUE"))
+
+    def test_well_formed_json_object_returns_dict(self):
+        out = _parse_bootstrap_variables('{"__resolved_locale__":"en_US","x":1}')
+        self.assertEqual(out, {"__resolved_locale__": "en_US", "x": 1})
+
+    def test_html_entity_encoded_json_unescaped_then_parsed(self):
+        """Some surfaces emit `&quot;`-encoded JSON. The parser unescapes
+        first, then json.loads."""
+        encoded = "{&quot;__resolved_locale__&quot;:&quot;en_US&quot;}"
+        out = _parse_bootstrap_variables(encoded)
+        self.assertEqual(out, {"__resolved_locale__": "en_US"})
+
+    def test_malformed_json_returns_parse_error_dict(self):
+        out = _parse_bootstrap_variables("{not-valid-json")
+        self.assertIsNotNone(out)
+        self.assertTrue(out.get("_parse_error"))
+        self.assertIn("_raw", out)
+
+    def test_json_array_returns_parse_error_dict(self):
+        """VariableText__c is documented as an object; arrays/scalars are
+        defensive cases that surface as _parse_error rather than crash."""
+        out = _parse_bootstrap_variables('[1, 2, 3]')
+        self.assertTrue(out.get("_parse_error"))
+
+    def test_json_scalar_returns_parse_error_dict(self):
+        out = _parse_bootstrap_variables('"just a string"')
+        self.assertTrue(out.get("_parse_error"))
+
+
+class DeriveModeTests(unittest.TestCase):
+
+    def test_voice_call_id_set_returns_voice(self):
+        out = _derive_mode(
+            messaging_session_id="msg-1",  # ignored when voice present
+            voice_call_id="voice-1",
+            bootstrap_variables=None,
+        )
+        self.assertEqual(out, "voice")
+
+    def test_messaging_session_id_set_returns_production_messaging(self):
+        out = _derive_mode(
+            messaging_session_id="0MwTESTMSG00000",
+            voice_call_id=None,
+            bootstrap_variables=None,
+        )
+        self.assertEqual(out, "production_messaging")
+
+    def test_builder_previewer_keys_in_bootstrap_returns_builder_previewer(self):
+        bootstrap = {"__resolved_locale__": "en_US", "OpenAgent": "x"}
+        out = _derive_mode(
+            messaging_session_id=None,
+            voice_call_id=None,
+            bootstrap_variables=bootstrap,
+        )
+        self.assertEqual(out, "builder_previewer")
+
+    def test_no_signals_returns_unknown(self):
+        out = _derive_mode(
+            messaging_session_id=None,
+            voice_call_id=None,
+            bootstrap_variables={"OpenAgent": "x"},  # no indicator keys
+        )
+        self.assertEqual(out, "unknown")
+
+    def test_voice_takes_priority_over_messaging(self):
+        """Defensive: if both messaging_session_id and voice_call_id are
+        set, voice wins (per priority order documented in the function)."""
+        out = _derive_mode(
+            messaging_session_id="msg-1",
+            voice_call_id="voice-1",
+            bootstrap_variables=None,
+        )
+        self.assertEqual(out, "voice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_gateway_direct.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_gateway_direct.py
@@ -1,0 +1,220 @@
+"""Tests for ``assemble_dc._assemble_gateway_direct``.
+
+Exercises the ``interactions_not_materialized_yet`` path: session row
+resolved, gateway_requests populated, interactions/steps empty. Builds a
+minimal rows-dict fixture and calls the private assembler directly — the
+function is pure over (sid, rows, manifest, parse_warnings), so no disk
+fixtures are needed.
+
+Scope:
+  - ``_source == "gateway_direct"`` sentinel
+  - ``session.interactions == []`` (downstream consumers no-op)
+  - ``session.gateway_chain`` length == fixture's gateway_requests
+  - each gateway_chain entry has a populated ``response.timestamp``
+  - finish_reason is lifted out of the HTML-escaped parameters JSON
+  - model / provider / prompt_template_dev_name / token counts populated
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+from assemble_dc import _assemble_gateway_direct  # type: ignore
+
+
+_SID = "01912345-0000-7000-8000-000000000001"
+
+
+def _gw_request(req_id: str, ts: str, model: str, tokens: tuple) -> dict:
+    """Shape mirrors GenAIGatewayRequest__dlm rows as fetched."""
+    prompt_tok, completion_tok, total_tok = tokens
+    return {
+        "gatewayRequestId__c": req_id,
+        "sf__Id": f"sf-{req_id}",
+        "sessionId__c": f'"{_SID}"',
+        "timestamp__c": ts,
+        "model__c": model,
+        "provider__c": "openai",
+        "promptTemplateDevName__c": "AiCopilot__ReactTopicPrompt",
+        "feature__c": "plannerservice",
+        "promptTokens__c": prompt_tok,
+        "completionTokens__c": completion_tok,
+        "totalTokens__c": total_tok,
+        "prompt__c": f"This is the prompt body for {req_id}.",
+    }
+
+
+def _gw_response(req_id: str, resp_id: str, ts: str, finish: str) -> dict:
+    """Shape mirrors GenAIGatewayResponse__dlm rows as fetched.
+
+    parameters__c is HTML-escaped JSON with the finish_reason value
+    wrapped in escaped quotes — the exact on-wire shape the live fetcher
+    produces. Mirrors the fixture used elsewhere in the test suite.
+    """
+    # Build the raw JSON first, then HTML-escape the quotes the same way
+    # the gateway serializer does.
+    raw = '{"finish_reason":"\\"' + finish + '\\""}'
+    escaped = raw.replace('"', "&quot;")
+    return {
+        "generationResponseId__c": resp_id,
+        "generationRequestId__c": req_id,
+        "parameters__c": escaped,
+        "timestamp__c": ts,
+    }
+
+
+def _tag(req_id: str, key: str, value: str) -> dict:
+    return {
+        "id__c": f"tag-{req_id}-{key}",
+        "parent__c": req_id,
+        "tag__c": key,
+        "tagValue__c": value,
+    }
+
+
+def _md(req_id: str, mtype: str, payload: str) -> dict:
+    return {
+        "id__c": f"md-{req_id}",
+        "parent__c": req_id,
+        "metadataType__c": mtype,
+        "metadata__c": payload,
+    }
+
+
+def _make_rows() -> dict:
+    session_row = {
+        "ssot__Id__c": _SID,
+        "ssot__StartTimestamp__c": "2026-05-03T10:00:00.000Z",
+        "ssot__EndTimestamp__c": None,
+        "ssot__AiAgentChannelType__c": "EmbeddedMessaging",
+        "ssot__AiAgentSessionEndType__c": None,
+    }
+    return {
+        "sessions": [session_row],
+        "participants": [],
+        "messages": [],
+        "moments": [],
+        "interactions": [],
+        "steps": [],
+        "generations": [],
+        "gateway_requests": [
+            _gw_request("gw-1", "2026-05-03T10:00:01.000Z", "gpt-4o", (100, 50, 150)),
+            _gw_request("gw-2", "2026-05-03T10:00:05.000Z", "gpt-4o", (200, 80, 280)),
+            _gw_request("gw-3", "2026-05-03T10:00:10.000Z", "gpt-4o-mini", (50, 30, 80)),
+        ],
+        "gateway_responses": [
+            _gw_response("gw-1", "resp-1", "2026-05-03T10:00:02.500Z", "stop"),
+            _gw_response("gw-2", "resp-2", "2026-05-03T10:00:06.000Z", "tool_calls"),
+            _gw_response("gw-3", "resp-3", "2026-05-03T10:00:11.000Z", "stop"),
+        ],
+        "gateway_request_tags": [
+            _tag("gw-1", "bot_id", "0Xx000000000001"),
+            _tag("gw-2", "feature", "plannerservice"),
+        ],
+        "gateway_request_metadata": [
+            _md("gw-2", "ToolCall", '{"tool":"apex"}'),
+        ],
+        "gateway_request_llm": [],
+        "content_quality": [],
+        "content_category": [],
+        "feedback": [],
+        "feedback_details": [],
+        "gateway_records": [],
+        "tag_associations": [],
+        "tag_definitions": [],
+        "tag_definition_associations": [],
+        "tags": [],
+        "app_generation": [],
+        "telemetry_spans": [],
+        "moment_interactions": [],
+    }
+
+
+def _make_manifest() -> dict:
+    return {
+        "session_id": _SID,
+        "org_alias": "test-org",
+        "instance_url": "https://example.my.salesforce.com",
+        "org_id_15": "00DXX0000000001",
+        "agent_api_name": "My_Agent",
+        "agent_version": "v1",
+        "session_shape": "interactions_not_materialized_yet",
+        "queries": [],
+    }
+
+
+class AssembleGatewayDirectTests(unittest.TestCase):
+
+    def setUp(self):
+        self.rows = _make_rows()
+        self.manifest = _make_manifest()
+        self.tree = _assemble_gateway_direct(
+            _SID, self.rows, self.manifest, parse_warnings=[])
+
+    def test_source_sentinel(self):
+        """The render layer keys off this exact string."""
+        self.assertEqual(self.tree["_source"], "gateway_direct")
+
+    def test_interactions_is_explicit_empty_list(self):
+        """Downstream consumers walk session.interactions — must exist + be empty."""
+        self.assertEqual(self.tree["session"]["interactions"], [])
+
+    def test_gateway_chain_length_matches_input(self):
+        self.assertEqual(len(self.tree["session"]["gateway_chain"]), 3)
+
+    def test_each_chain_entry_has_response_timestamp(self):
+        """Join via generationRequestId__c must populate response.timestamp on each."""
+        for call in self.tree["session"]["gateway_chain"]:
+            with self.subTest(req_id=call.get("gateway_request_id")):
+                self.assertIsNotNone(call.get("response"))
+                self.assertIsNotNone(call["response"].get("timestamp"))
+
+    def test_finish_reason_parsed(self):
+        """HTML-escaped, quote-wrapped finish_reason must decode to bare string."""
+        reasons = [c["response"]["finish_reason"]
+                   for c in self.tree["session"]["gateway_chain"]]
+        self.assertEqual(reasons, ["stop", "tool_calls", "stop"])
+
+    def test_chain_sorted_by_timestamp(self):
+        """Deterministic ordering — required for byte-identical output across runs."""
+        timestamps = [c["timestamp"] for c in self.tree["session"]["gateway_chain"]]
+        self.assertEqual(timestamps, sorted(timestamps))
+
+    def test_model_and_tokens_harvested(self):
+        first = self.tree["session"]["gateway_chain"][0]
+        self.assertEqual(first["model"], "gpt-4o")
+        self.assertEqual(first["provider"], "openai")
+        self.assertEqual(first["prompt_template_dev_name"],
+                         "AiCopilot__ReactTopicPrompt")
+        self.assertEqual(first["prompt_tokens"], 100)
+        self.assertEqual(first["total_tokens"], 150)
+
+    def test_prompt_text_untruncated_on_disk(self):
+        """Assembler stores the full prompt — the 64 KB cap is render-only."""
+        for call in self.tree["session"]["gateway_chain"]:
+            self.assertIn("This is the prompt body for",
+                          call.get("prompt_text") or "")
+
+    def test_identity_block_present(self):
+        """Top-level identity must carry (org_id_15, agent_api_name, agent_version)."""
+        self.assertEqual(self.tree["identity"]["org_id_15"], "00DXX0000000001")
+        self.assertEqual(self.tree["identity"]["agent_api_name"], "My_Agent")
+        self.assertEqual(self.tree["identity"]["agent_version"], "v1")
+
+    def test_stdm_lag_note_on_session(self):
+        note = self.tree["session"].get("_stdm_lag_note") or ""
+        self.assertIn("materialize on a separate cadence", note)
+
+    def test_counts_reflect_input_rows(self):
+        counts = self.tree["session"]["counts"]
+        self.assertEqual(counts["gateway_requests"], 3)
+        self.assertEqual(counts["gateway_responses"], 3)
+        self.assertEqual(counts["interactions_total"], 0)
+        self.assertEqual(counts["steps_total"], 0)
+        self.assertEqual(counts["session_shape"],
+                         "interactions_not_materialized_yet")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_gateway_direct_integration.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_gateway_direct_integration.py
@@ -1,0 +1,158 @@
+"""Integration tests for ``assemble_dc._assemble_gateway_direct``.
+
+Drives the materialization-lag path: session row + gateway_requests
+populated, but interactions / steps absent. Triggered by setting
+``manifest.session_shape = "interactions_not_materialized_yet"``.
+
+Complements ``test_assemble_dc_gateway_direct.py`` which calls the
+private function with a hand-built rows dict; this file drives the
+public ``assemble`` entry point through the disk-load path so manifest
++ rows + path resolution are all exercised.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import (  # type: ignore
+    IDS, write_to_disk, make_manifest,
+)
+
+
+def _materialization_lag_mutator(sdir: Path) -> None:
+    """Make the fixture look like a session whose STDM hierarchy hasn't
+    materialized yet: keep gateway_requests + gateway_responses + tags,
+    but wipe interactions / steps / messages and flip the manifest.
+
+    This is the live-DC failure mode that the gateway-direct path was
+    written to handle.
+    """
+    # Wipe interaction/step/message rows (file with empty list)
+    for name in ("interactions", "steps", "messages"):
+        (sdir / f"dc.{name}.json").write_text("[]")
+    # Update manifest session_shape so assemble's branch fires.
+    manifest = make_manifest()
+    manifest["session_shape"] = "interactions_not_materialized_yet"
+    (sdir / "dc._session_manifest.json").write_text(
+        json.dumps(manifest, indent=2)
+    )
+
+
+class _GatewayDirectHarness:
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        sdir = write_to_disk(self._tmpdir)
+        _materialization_lag_mutator(sdir)
+        self._patch = mock.patch.object(paths, "DATA_ROOT", self._tmpdir)
+        self._patch.start()
+        self.tree, self.sdir = assemble_dc.assemble(IDS.SID)
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+
+# -----------------------------------------------------------------------------
+# Top-level shape on the gateway-direct branch
+# -----------------------------------------------------------------------------
+
+
+class GatewayDirectShapeTests(unittest.TestCase):
+
+    def test_source_marker_set_to_gateway_direct(self):
+        with _GatewayDirectHarness() as h:
+            self.assertEqual(h.tree["_source"], "gateway_direct")
+
+    def test_interactions_is_empty_list(self):
+        with _GatewayDirectHarness() as h:
+            self.assertEqual(h.tree["session"]["interactions"], [])
+
+    def test_gateway_chain_populated_from_gateway_requests(self):
+        with _GatewayDirectHarness() as h:
+            chain = h.tree["session"]["gateway_chain"]
+        # Fixture has 2 gateway_requests; both make it into the chain.
+        self.assertEqual(len(chain), 2)
+        chain_ids = {gw["gateway_request_id"] for gw in chain}
+        self.assertEqual(chain_ids, {IDS.GW_REQ_DECLARED, IDS.GW_REQ_WINDOW})
+
+    def test_chain_sorted_by_timestamp(self):
+        # Earlier gateway request timestamp comes first.
+        with _GatewayDirectHarness() as h:
+            chain = h.tree["session"]["gateway_chain"]
+        timestamps = [gw.get("timestamp") for gw in chain]
+        self.assertEqual(timestamps, sorted(t or "" for t in timestamps))
+
+    def test_each_gateway_chain_entry_has_response(self):
+        # Only the declared request has a response in the fixture; the
+        # window-bound one has response=None. Both shapes are accepted.
+        with _GatewayDirectHarness() as h:
+            chain = h.tree["session"]["gateway_chain"]
+        declared = next(gw for gw in chain
+                        if gw["gateway_request_id"] == IDS.GW_REQ_DECLARED)
+        self.assertIsNotNone(declared["response"])
+
+    def test_top_identity_block_resolved_from_manifest(self):
+        with _GatewayDirectHarness() as h:
+            ident = h.tree["identity"]
+        self.assertEqual(ident["org_id_15"], IDS.ORG_ID_15)
+        self.assertEqual(ident["agent_api_name"], IDS.AGENT_API)
+        self.assertEqual(ident["agent_version"], IDS.AGENT_VERSION)
+
+    def test_counts_block_records_session_shape_and_zero_interactions(self):
+        with _GatewayDirectHarness() as h:
+            counts = h.tree["session"]["counts"]
+        self.assertEqual(counts["session_shape"],
+                         "interactions_not_materialized_yet")
+        self.assertEqual(counts["interactions_total"], 0)
+        self.assertEqual(counts["steps_total"], 0)
+        self.assertEqual(counts["gateway_requests"], 2)
+
+
+# -----------------------------------------------------------------------------
+# render_dc on the gateway-direct tree
+# -----------------------------------------------------------------------------
+
+
+class GatewayDirectRenderTests(unittest.TestCase):
+    """The gateway-direct render branch is short — covers identity,
+    lag banner, and gateway-chain table. Drives it end-to-end."""
+
+    def test_render_emits_lag_banner(self):
+        import render_dc  # noqa: WPS433
+        with _GatewayDirectHarness() as h:
+            md = render_dc.render(h.tree, manifest=None, session_dir=h.sdir)
+        # _STDM_LAG_NOTE is referenced in the gateway-direct render path
+        # — must surface as visible text. We assert on the substring
+        # "STDM" since the exact phrasing may evolve.
+        self.assertIn("STDM", md)
+
+    def test_render_lists_both_gateway_requests(self):
+        import render_dc  # noqa: WPS433
+        with _GatewayDirectHarness() as h:
+            md = render_dc.render(h.tree, manifest=None, session_dir=h.sdir)
+        # Gateway-direct render truncates IDs to 8-char prefixes — assert
+        # on the prefix substring + on the prompt-template name (verbatim
+        # in the per-call detail block).
+        self.assertIn(IDS.GW_REQ_DECLARED[:8], md)
+        self.assertIn(IDS.GW_REQ_WINDOW[:8], md)
+        self.assertIn("AiCopilot__ReactInitialPrompt", md)
+        self.assertIn("AiCopilot__PromptTemplateGenerationsInvocable", md)
+
+    def test_render_includes_session_id(self):
+        import render_dc  # noqa: WPS433
+        with _GatewayDirectHarness() as h:
+            md = render_dc.render(h.tree, manifest=None, session_dir=h.sdir)
+        self.assertIn(IDS.SID, md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_helpers.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_helpers.py
@@ -1,0 +1,287 @@
+"""Tests for ``assemble_dc`` pure helpers — independent of disk fixtures.
+
+Complements ``test_assemble_dc_gateway_direct.py`` (binding chain) by
+hitting the small, mechanical helpers that bridge raw DC rows and the
+assembled tree:
+
+- ``_clean``           NOT_SET sentinel collapse
+- ``_harvest_str``     unescape + quote-strip + UNSET_VALUE
+- ``_ts``              ISO-8601 → datetime; NOT_SET / non-string → None
+- ``_index_unique``    PK dedup with first-write-wins + collision record
+- ``_groupby``         group rows by FK, dropping NOT_SET keys
+- ``_extract_trace_id`` primary col with HTML-escaped fallback
+- ``_tier``            ACTION < TOPIC < GUARDRAIL < other
+- ``_window_contains`` half-open / closed timestamp interval semantics
+- ``_load``            disk read with malformed-json tolerance
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# _clean — NOT_SET → None
+# -----------------------------------------------------------------------------
+
+
+class CleanTests(unittest.TestCase):
+
+    def test_not_set_token_returns_none(self):
+        self.assertIsNone(assemble_dc._clean("NOT_SET"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(assemble_dc._clean(""))
+
+    def test_actual_value_passes_through(self):
+        self.assertEqual(assemble_dc._clean("real value"), "real value")
+        self.assertEqual(assemble_dc._clean(42), 42)
+
+
+# -----------------------------------------------------------------------------
+# _harvest_str — unescape + quote-strip + UNSET_VALUE collapse
+# -----------------------------------------------------------------------------
+
+
+class HarvestStrTests(unittest.TestCase):
+
+    def test_none_returns_none(self):
+        self.assertIsNone(assemble_dc._harvest_str(None))
+
+    def test_unescapes_html_entities(self):
+        self.assertEqual(
+            assemble_dc._harvest_str("&quot;0Xx000&quot;"),
+            "0Xx000",
+        )
+
+    def test_strips_outer_double_quotes(self):
+        self.assertEqual(assemble_dc._harvest_str('"value"'), "value")
+
+    def test_unset_value_collapses_to_none(self):
+        self.assertIsNone(assemble_dc._harvest_str("UNSET_VALUE"))
+
+    def test_not_set_collapses_to_none(self):
+        self.assertIsNone(assemble_dc._harvest_str("NOT_SET"))
+
+    def test_empty_string_collapses_to_none(self):
+        self.assertIsNone(assemble_dc._harvest_str(""))
+
+
+# -----------------------------------------------------------------------------
+# _ts — ISO-8601 timestamp parsing
+# -----------------------------------------------------------------------------
+
+
+class TsTests(unittest.TestCase):
+
+    def test_parses_iso_z_timestamp(self):
+        out = assemble_dc._ts("2026-04-22T10:00:00Z")
+        self.assertEqual(out, datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc))
+
+    def test_parses_iso_offset_timestamp(self):
+        out = assemble_dc._ts("2026-04-22T10:00:00+00:00")
+        self.assertEqual(out, datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc))
+
+    def test_returns_none_for_non_string(self):
+        self.assertIsNone(assemble_dc._ts(None))
+        self.assertIsNone(assemble_dc._ts(12345))
+
+    def test_returns_none_for_not_set(self):
+        self.assertIsNone(assemble_dc._ts("NOT_SET"))
+        self.assertIsNone(assemble_dc._ts(""))
+
+    def test_returns_none_for_unparseable(self):
+        self.assertIsNone(assemble_dc._ts("not-a-timestamp"))
+
+
+# -----------------------------------------------------------------------------
+# _index_unique
+# -----------------------------------------------------------------------------
+
+
+class IndexUniqueTests(unittest.TestCase):
+
+    def test_builds_dict_keyed_by_field(self):
+        rows = [{"id": "a", "v": 1}, {"id": "b", "v": 2}]
+        out = assemble_dc._index_unique(rows, "id", [], dmo_label="t")
+        self.assertEqual(set(out.keys()), {"a", "b"})
+
+    def test_first_write_wins_on_collision(self):
+        rows = [{"id": "a", "v": 1}, {"id": "a", "v": 2}]
+        collisions: list[dict] = []
+        out = assemble_dc._index_unique(rows, "id", collisions, dmo_label="dmo1")
+        self.assertEqual(out["a"]["v"], 1)
+        self.assertEqual(len(collisions), 1)
+        self.assertEqual(collisions[0]["dmo"], "dmo1")
+        self.assertEqual(collisions[0]["key"], "a")
+
+    def test_skips_NOT_SET_keys(self):
+        rows = [{"id": "NOT_SET", "v": 1}, {"id": "", "v": 2}, {"id": "a", "v": 3}]
+        out = assemble_dc._index_unique(rows, "id", [], dmo_label="t")
+        self.assertEqual(set(out.keys()), {"a"})
+
+
+# -----------------------------------------------------------------------------
+# _groupby
+# -----------------------------------------------------------------------------
+
+
+class GroupbyTests(unittest.TestCase):
+
+    def test_groups_rows_by_key(self):
+        rows = [{"k": "a", "v": 1}, {"k": "b", "v": 2}, {"k": "a", "v": 3}]
+        out = assemble_dc._groupby(rows, "k")
+        self.assertEqual([r["v"] for r in out["a"]], [1, 3])
+        self.assertEqual([r["v"] for r in out["b"]], [2])
+
+    def test_skips_NOT_SET_keys(self):
+        rows = [{"k": "a", "v": 1}, {"k": "NOT_SET", "v": 2}]
+        out = assemble_dc._groupby(rows, "k")
+        self.assertNotIn("NOT_SET", out)
+        self.assertIn("a", out)
+
+
+# -----------------------------------------------------------------------------
+# _extract_trace_id
+# -----------------------------------------------------------------------------
+
+
+class ExtractTraceIdTests(unittest.TestCase):
+
+    def test_uses_primary_column_when_populated(self):
+        out = assemble_dc._extract_trace_id({"ssot__TelemetryTraceId__c": "abc"})
+        self.assertEqual(out, "abc")
+
+    def test_falls_back_to_html_escaped_attribute_text(self):
+        out = assemble_dc._extract_trace_id({
+            "ssot__TelemetryTraceId__c": "",
+            "ssot__AttributeText__c": '&quot;internalTraceId&quot;:&quot;deadbeef&quot;',
+        })
+        self.assertEqual(out, "deadbeef")
+
+    def test_returns_none_when_no_trace_id_anywhere(self):
+        out = assemble_dc._extract_trace_id({
+            "ssot__TelemetryTraceId__c": "",
+            "ssot__AttributeText__c": "no trace here",
+        })
+        self.assertIsNone(out)
+
+    def test_returns_none_for_NOT_SET(self):
+        out = assemble_dc._extract_trace_id({
+            "ssot__TelemetryTraceId__c": "NOT_SET",
+            "ssot__AttributeText__c": "",
+        })
+        self.assertIsNone(out)
+
+
+# -----------------------------------------------------------------------------
+# _tier — ACTION < TOPIC < GUARDRAIL < other
+# -----------------------------------------------------------------------------
+
+
+class TierTests(unittest.TestCase):
+
+    def test_action_step_is_lowest_tier(self):
+        self.assertLess(
+            assemble_dc._tier("ACTION_STEP"),
+            assemble_dc._tier("TOPIC_STEP"),
+        )
+
+    def test_topic_step_outranks_guardrails(self):
+        self.assertLess(
+            assemble_dc._tier("TOPIC_STEP"),
+            assemble_dc._tier("TRUST_GUARDRAILS_STEP"),
+        )
+
+    def test_unknown_step_type_falls_to_end(self):
+        self.assertEqual(
+            assemble_dc._tier("MYSTERY"),
+            len(assemble_dc._TIER_ORDER),
+        )
+
+
+# -----------------------------------------------------------------------------
+# _window_contains
+# -----------------------------------------------------------------------------
+
+
+class WindowContainsTests(unittest.TestCase):
+
+    def _ts(self, h, m, s):
+        return datetime(2026, 4, 22, h, m, s, tzinfo=timezone.utc)
+
+    def test_in_range_inclusive_of_start_and_end(self):
+        gw = self._ts(10, 0, 5)
+        self.assertTrue(
+            assemble_dc._window_contains(gw, self._ts(10, 0, 0), self._ts(10, 0, 10))
+        )
+
+    def test_open_ended_when_end_is_none(self):
+        gw = self._ts(11, 0, 0)
+        self.assertTrue(
+            assemble_dc._window_contains(gw, self._ts(10, 0, 0), None)
+        )
+
+    def test_returns_false_when_start_is_none(self):
+        gw = self._ts(10, 0, 0)
+        self.assertFalse(
+            assemble_dc._window_contains(gw, None, self._ts(11, 0, 0))
+        )
+
+    def test_returns_false_when_before_start(self):
+        gw = self._ts(9, 0, 0)
+        self.assertFalse(
+            assemble_dc._window_contains(gw, self._ts(10, 0, 0), self._ts(11, 0, 0))
+        )
+
+    def test_returns_false_when_after_end(self):
+        gw = self._ts(12, 0, 0)
+        self.assertFalse(
+            assemble_dc._window_contains(gw, self._ts(10, 0, 0), self._ts(11, 0, 0))
+        )
+
+
+# -----------------------------------------------------------------------------
+# _load — disk read with tolerance
+# -----------------------------------------------------------------------------
+
+
+class LoadTests(unittest.TestCase):
+
+    def test_returns_empty_list_when_file_missing(self):
+        with TemporaryDirectory() as t:
+            warnings: list[str] = []
+            self.assertEqual(
+                assemble_dc._load(Path(t), "missing", warnings), []
+            )
+            # Missing file is normal — no warning recorded.
+            self.assertEqual(warnings, [])
+
+    def test_returns_loaded_rows_when_file_valid(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            (tmp / "dc.sessions.json").write_text(json.dumps([{"a": 1}, {"a": 2}]))
+            warnings: list[str] = []
+            out = assemble_dc._load(tmp, "sessions", warnings)
+            self.assertEqual(out, [{"a": 1}, {"a": 2}])
+            self.assertEqual(warnings, [])
+
+    def test_returns_empty_list_and_records_warning_on_malformed_json(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            (tmp / "dc.broken.json").write_text("<<<not json>>>")
+            warnings: list[str] = []
+            out = assemble_dc._load(tmp, "broken", warnings)
+            self.assertEqual(out, [])
+            self.assertEqual(warnings, ["broken"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_integration.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_assemble_dc_integration.py
@@ -1,0 +1,247 @@
+"""End-to-end integration tests for ``assemble_dc.assemble``.
+
+Drives the full assembler against the synthetic session fixture under
+``tests/fixtures/synthetic_session.py``. Each test materializes the
+fixture into a tmp DATA_ROOT, calls ``assemble_dc.assemble(SID)``, and
+asserts on the resulting tree.
+
+These tests cover the orchestration paths that the helper-only
+``test_assemble_dc_helpers.py`` doesn't touch:
+
+- declared Step → Generation → Response → Request chain
+- timestamp-window fallback for an un-declared gateway request
+- trace_id extraction from HTML-escaped AttributeText
+- session-identity resolution from AGENT participant
+- malformed dc.<name>.json → parse_warnings recorded, fixture survives
+- minimal-tree path when sessions[] is empty (session_not_found)
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import (  # type: ignore
+    IDS, make_rows, write_to_disk, session_dir_for,
+)
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+class _AssembleHarness:
+    """Context-manager that builds a tmp DATA_ROOT, materializes the
+    fixture, patches ``paths.DATA_ROOT``, and yields ``(tree, sdir)``."""
+
+    def __init__(self, mutate_files=None):
+        self.mutate_files = mutate_files
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        sdir = write_to_disk(self._tmpdir)
+        if self.mutate_files:
+            self.mutate_files(sdir)
+        self._patch = mock.patch.object(paths, "DATA_ROOT", self._tmpdir)
+        self._patch.start()
+        self.tree, self.sdir = assemble_dc.assemble(IDS.SID)
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+
+def _turn(tree: dict) -> dict:
+    return next(
+        iv for iv in tree["session"]["interactions"]
+        if iv.get("type") == "TURN"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Top-level shape
+# -----------------------------------------------------------------------------
+
+
+class AssembleTreeShapeTests(unittest.TestCase):
+
+    def test_tree_top_level_keys(self):
+        with _AssembleHarness() as h:
+            self.assertIn("identity", h.tree)
+            self.assertIn("session", h.tree)
+            self.assertIn("catalog", h.tree)
+
+    def test_session_dir_path_is_under_data_root(self):
+        with _AssembleHarness() as h:
+            # On macOS the tmp path resolves through /private/var → /var
+            # (or vice versa). Compare via .resolve() so the symlink
+            # discrepancy doesn't fail the assertion.
+            expected = session_dir_for(h._tmpdir).resolve()
+            self.assertEqual(h.sdir.resolve(), expected)
+
+    def test_three_interactions_in_chronological_order(self):
+        with _AssembleHarness() as h:
+            ivs = h.tree["session"]["interactions"]
+        types = [iv["type"] for iv in ivs]
+        self.assertEqual(types, ["SESSION_START", "TURN", "SESSION_END"])
+
+    def test_turn_has_three_steps_in_order(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        names = [s.get("name") for s in turn["steps"]]
+        # Step names from the fixture's ssot__Name__c column
+        self.assertIn("TopicSelection", names)
+        self.assertIn("PrimaryAction", names)
+        self.assertIn("FinalGuard", names)
+
+    def test_turn_has_two_messages_user_and_agent(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        self.assertEqual(len(turn["messages"]), 2)
+
+
+# -----------------------------------------------------------------------------
+# Identity resolution
+# -----------------------------------------------------------------------------
+
+
+class AssembleIdentityTests(unittest.TestCase):
+
+    def test_identity_extracted_from_agent_participant(self):
+        with _AssembleHarness() as h:
+            ident = h.tree["identity"]
+        self.assertEqual(ident["org_id_15"], IDS.ORG_ID_15)
+        self.assertEqual(ident["agent_api_name"], IDS.AGENT_API)
+        self.assertEqual(ident["agent_version"], IDS.AGENT_VERSION)
+
+
+# -----------------------------------------------------------------------------
+# Trace_id extraction (HTML-escaped fallback)
+# -----------------------------------------------------------------------------
+
+
+class AssembleTraceIdTests(unittest.TestCase):
+
+    def test_turn_trace_id_pulled_from_html_escaped_attribute_text(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        # The fixture intentionally puts trace_id ONLY in AttributeText
+        # (HTML-escaped JSON); the primary TelemetryTraceId__c column is
+        # empty. This exercises the fallback path in assemble_dc.
+        self.assertEqual(turn["trace_id"], IDS.TRACE_ID)
+
+
+# -----------------------------------------------------------------------------
+# Gateway binding (declared chain + timestamp-window fallback)
+# -----------------------------------------------------------------------------
+
+
+class AssembleGatewayBindingTests(unittest.TestCase):
+
+    def test_action_step_has_declared_gateway_request(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        action_step = next(
+            s for s in turn["steps"] if s.get("name") == "PrimaryAction"
+        )
+        gw = action_step["gateway_request"]
+        self.assertIsNotNone(gw)
+        self.assertEqual(gw["binding_method"], "declared")
+        self.assertEqual(gw["gateway_request_id"], IDS.GW_REQ_DECLARED)
+        self.assertEqual(gw["model"], "gpt-4o")
+        self.assertEqual(gw["total_tokens"], 1250)
+
+    def test_topic_and_guardrail_steps_have_no_gateway_binding(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        for s in turn["steps"]:
+            if s.get("name") in ("TopicSelection", "FinalGuard"):
+                self.assertIsNone(s.get("gateway_request"))
+
+    def test_timestamp_window_pass_picks_up_undeclared_gateway_request(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        ts_calls = turn.get("timestamp_bound_gateway_calls", [])
+        # Exactly one gateway request lives in the TURN window without a
+        # declared binding (GW_REQ_WINDOW). The declared one is consumed
+        # by step-action and is excluded from the ts-window pass.
+        self.assertEqual(len(ts_calls), 1)
+        self.assertEqual(
+            ts_calls[0]["gateway_request_id"], IDS.GW_REQ_WINDOW,
+        )
+
+    def test_declared_response_carries_finish_reason(self):
+        with _AssembleHarness() as h:
+            turn = _turn(h.tree)
+        action_step = next(
+            s for s in turn["steps"] if s.get("name") == "PrimaryAction"
+        )
+        # parameters__c is HTML-escaped JSON in the fixture; the
+        # renderer is responsible for decoding, but the raw string
+        # must be preserved unchanged in the assembled tree.
+        params = action_step["gateway_request"]["response"]["parameters__c"]
+        self.assertIn("finish_reason", params)
+        self.assertIn("&quot;", params)
+
+
+# -----------------------------------------------------------------------------
+# Malformed-input tolerance (parse_warnings)
+# -----------------------------------------------------------------------------
+
+
+class AssembleParseWarningsTests(unittest.TestCase):
+
+    def test_malformed_dc_file_recorded_in_parse_warnings(self):
+        def corrupt_messages(sdir: Path) -> None:
+            (sdir / "dc.messages.json").write_text("<<<not json>>>")
+
+        with _AssembleHarness(mutate_files=corrupt_messages) as h:
+            # parse_warnings lives on session.counts (cf. _build_counts).
+            warnings = h.tree["session"]["counts"].get("parse_warnings") or []
+        self.assertIn("messages", warnings)
+
+
+# -----------------------------------------------------------------------------
+# session_not_found short-circuit
+# -----------------------------------------------------------------------------
+
+
+class AssembleSessionNotFoundTests(unittest.TestCase):
+
+    def test_empty_sessions_returns_minimal_tree(self):
+        def empty_sessions(sdir: Path) -> None:
+            (sdir / "dc.sessions.json").write_text("[]")
+
+        with _AssembleHarness(mutate_files=empty_sessions) as h:
+            tree = h.tree
+        # Minimal-tree shape signaled by session_shape == 'session_not_found'
+        # in the manifest section, plus an empty interactions list.
+        self.assertEqual(tree["session"].get("interactions", []), [])
+
+
+# -----------------------------------------------------------------------------
+# Public API path: tree dict is JSON-serializable
+# -----------------------------------------------------------------------------
+
+
+class AssembleSerializableTests(unittest.TestCase):
+
+    def test_tree_round_trips_through_json(self):
+        with _AssembleHarness() as h:
+            blob = json.dumps(h.tree, default=str)
+            back = json.loads(blob)
+        # Sanity: re-loaded keys match originals
+        self.assertEqual(set(back.keys()), set(h.tree.keys()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_dc_and_resolve_session.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_dc_and_resolve_session.py
@@ -1,0 +1,433 @@
+"""Tests for ``dc`` (Data Cloud transport) + ``resolve_session``
+(messaging-id → UUID resolver).
+
+Both modules sit at the bottom of the dependency tree and have small,
+well-defined public APIs that are mostly mockable at the subprocess /
+urllib boundary.
+"""
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import unittest
+import urllib.error
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import dc  # type: ignore
+import resolve_session  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import IDS, write_to_disk  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# dc.load_sql / dc.parse
+# -----------------------------------------------------------------------------
+
+
+class LoadSqlTests(unittest.TestCase):
+
+    def test_substitutes_placeholders_and_strips(self):
+        # discover_sessions has SELECT_LIST/JOINS/WHERE_CLAUSE/LIMIT placeholders.
+        sql = dc.load_sql(
+            "discover_sessions",
+            SELECT_LIST="*",
+            JOINS="",
+            WHERE_CLAUSE="1=1",
+            LIMIT="10",
+        )
+        self.assertIn("SELECT *", sql)
+        self.assertIn("LIMIT 10", sql)
+
+
+class ParseTests(unittest.TestCase):
+
+    def test_returns_data_array(self):
+        self.assertEqual(dc.parse({"data": [{"a": 1}]}), [{"a": 1}])
+
+    def test_returns_empty_list_when_data_missing(self):
+        self.assertEqual(dc.parse({}), [])
+
+    def test_returns_empty_list_for_falsy_input(self):
+        self.assertEqual(dc.parse(None), [])
+        self.assertEqual(dc.parse({}), [])
+
+
+# -----------------------------------------------------------------------------
+# dc.resolve_org — sf CLI shell-out
+# -----------------------------------------------------------------------------
+
+
+class ResolveOrgTests(unittest.TestCase):
+    """Tests for the two-path access-token retrieval per forcedotcom/cli#3560.
+
+    Path 1 (primary): ``sf org auth show-access-token --json --no-prompt``
+    Path 2 (fallback): ``sf org display`` + ``SF_TEMP_SHOW_SECRETS=true``
+
+    Most tests mock ``subprocess.run`` with a side-effect callable that
+    returns a different stub depending on which sf subcommand was invoked,
+    so we can exercise primary success, primary failure → fallback, and
+    full-failure paths without spawning real processes.
+    """
+
+    REDACTED_TOKEN = "[REDACTED] Use 'sf org auth show-access-token' to view"
+
+    def _cp(self, stdout: str, *, returncode: int = 0, stderr: str = ""):
+        return SimpleNamespace(
+            returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+
+    def _display_payload(self, *, access_token: str = "TOKEN_FROM_DISPLAY") -> str:
+        return json.dumps({"result": {
+            "instanceUrl": "https://example.salesforce.com",
+            "accessToken": access_token,
+        }})
+
+    def _show_token_payload(self, *, access_token: str = "TOKEN_FROM_SHOW") -> str:
+        return json.dumps({"result": {"accessToken": access_token}})
+
+    def _route(self, primary_ok=True, primary_unknown=False,
+               primary_redacted=False, display_redacted=False):
+        """Build a fake_run that routes by argv shape.
+
+        - primary_ok=True   → show-access-token returns clean token
+        - primary_unknown   → show-access-token raises CalledProcessError
+                              (older sf CLI without the subcommand)
+        - primary_redacted  → show-access-token returns the placeholder
+        - display_redacted  → org_display token field is the placeholder
+                              (so fallback also fails — test full-failure)
+        """
+        def fake_run(argv, **kwargs):
+            # display call
+            if "display" in argv:
+                return self._cp(
+                    self._display_payload(
+                        access_token=(self.REDACTED_TOKEN if display_redacted
+                                      else "TOKEN_FROM_DISPLAY"),
+                    ),
+                )
+            # show-access-token call
+            if "show-access-token" in argv:
+                if primary_unknown:
+                    raise subprocess.CalledProcessError(
+                        returncode=1, cmd=argv,
+                        stderr="show-access-token is not a sf command",
+                    )
+                token = (self.REDACTED_TOKEN if primary_redacted
+                         else "TOKEN_FROM_SHOW")
+                return self._cp(self._show_token_payload(access_token=token))
+            raise AssertionError(f"unexpected argv: {argv}")
+        return fake_run
+
+    def test_primary_path_returns_show_token(self):
+        """Happy path — dedicated command returns a clean token."""
+        with mock.patch.object(dc.subprocess, "run", side_effect=self._route()):
+            url, token = dc.resolve_org("my-org")
+        self.assertEqual(url, "https://example.salesforce.com")
+        self.assertEqual(token, "TOKEN_FROM_SHOW")
+
+    def test_primary_unknown_falls_back_to_display_token(self):
+        """Older sf CLI: show-access-token unknown → use display payload."""
+        with mock.patch.object(
+            dc.subprocess, "run",
+            side_effect=self._route(primary_unknown=True),
+        ):
+            url, token = dc.resolve_org("my-org")
+        self.assertEqual(url, "https://example.salesforce.com")
+        self.assertEqual(token, "TOKEN_FROM_DISPLAY")
+
+    def test_primary_redacted_falls_back_to_display_token(self):
+        """Edge case: dedicated command returns the placeholder string —
+        treat as failure and try the display fallback."""
+        with mock.patch.object(
+            dc.subprocess, "run",
+            side_effect=self._route(primary_redacted=True),
+        ):
+            url, token = dc.resolve_org("my-org")
+        self.assertEqual(token, "TOKEN_FROM_DISPLAY")
+
+    def test_both_paths_redacted_raises(self):
+        """If both paths return the placeholder, surface a clean SystemExit
+        rather than handing back the redaction string to downstream callers
+        (which would cause INVALID_AUTH_HEADER 401 on every Tooling/REST call)."""
+        with mock.patch.object(
+            dc.subprocess, "run",
+            side_effect=self._route(primary_redacted=True, display_redacted=True),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                dc.resolve_org("my-org")
+        self.assertIn("could not retrieve a usable access token", str(ctx.exception))
+
+    def test_raises_systemexit_when_sf_cli_missing(self):
+        """sf binary not on PATH — bail with the upgrade hint."""
+        with mock.patch.object(
+            dc.subprocess, "run", side_effect=FileNotFoundError("sf"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                dc.resolve_org("my-org")
+        self.assertIn("sf CLI not found", str(ctx.exception))
+
+    def test_raises_systemexit_on_display_failure(self):
+        """org_display itself failing is fatal — no instanceUrl, no recovery."""
+        err = subprocess.CalledProcessError(
+            returncode=1, cmd=["sf", "org", "display"], stderr="No AuthInfo found",
+        )
+        with mock.patch.object(dc.subprocess, "run", side_effect=err):
+            with self.assertRaises(SystemExit):
+                dc.resolve_org("my-org")
+
+    def test_primary_path_argv_contains_show_access_token(self):
+        """Tripwire — primary call MUST be `sf org auth show-access-token`
+        with `--no-prompt`. Without `--no-prompt` the command blocks on a
+        confirmation banner that --json doesn't suppress on its own."""
+        captured_argvs: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            captured_argvs.append(argv)
+            if "display" in argv:
+                return self._cp(self._display_payload())
+            return self._cp(self._show_token_payload())
+
+        with mock.patch.object(dc.subprocess, "run", side_effect=fake_run):
+            dc.resolve_org("my-org")
+
+        # display call should still pass --verbose + SF_TEMP_SHOW_SECRETS
+        # (so the fallback path stays viable on this same invocation).
+        self.assertTrue(any("display" in a for a in captured_argvs))
+        # primary call shape:
+        primary = next(a for a in captured_argvs if "show-access-token" in a)
+        self.assertIn("--no-prompt", primary)
+        self.assertIn("--json", primary)
+        self.assertIn("--target-org", primary)
+
+    def test_display_call_still_passes_verbose_and_show_secrets_env(self):
+        """The legacy fallback path stays armed: org_display still runs
+        with `--verbose` (so accessToken is emitted) and
+        `SF_TEMP_SHOW_SECRETS=true` (so the token isn't redacted on sf
+        CLI versions that still honour the workaround)."""
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            if "display" in argv:
+                captured["argv"] = argv
+                captured["env"] = kwargs.get("env")
+                return self._cp(self._display_payload())
+            return self._cp(self._show_token_payload())
+
+        with mock.patch.object(dc.subprocess, "run", side_effect=fake_run):
+            dc.resolve_org("my-org")
+
+        self.assertIn("--verbose", captured["argv"])
+        self.assertIsNotNone(captured["env"])
+        self.assertEqual(captured["env"].get("SF_TEMP_SHOW_SECRETS"), "true")
+
+
+# -----------------------------------------------------------------------------
+# dc.post — HTTP path (urllib mock)
+# -----------------------------------------------------------------------------
+
+
+class PostTests(unittest.TestCase):
+
+    def _fake_response(self, body: bytes):
+        # Context-manager mock for urllib.request.urlopen
+        cm = mock.MagicMock()
+        cm.__enter__.return_value.read.return_value = body
+        cm.__exit__.return_value = False
+        return cm
+
+    def test_returns_rows_on_2xx(self):
+        body = json.dumps({"data": [{"a": 1}, {"a": 2}]}).encode()
+        with mock.patch.object(
+            dc.urllib.request, "urlopen", return_value=self._fake_response(body),
+        ):
+            out = dc.post(
+                "SELECT 1", "https://x.salesforce.com", "TOKEN", "sessions",
+            )
+        self.assertEqual(out, [{"a": 1}, {"a": 2}])
+
+    def test_raises_dcqueryerror_with_query_name_on_http_error(self):
+        # HTTPError carries (url, code, msg, hdrs, fp). We need fp.read() to
+        # work — the impl calls e.read() to grab the body.
+        err = urllib.error.HTTPError(
+            url="https://x.salesforce.com",
+            code=400, msg="Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b"sql parse error: missing FROM"),
+        )
+        with mock.patch.object(
+            dc.urllib.request, "urlopen", side_effect=err,
+        ):
+            with self.assertRaises(dc.DCQueryError) as ctx:
+                dc.post("SELECT bad", "https://x", "TOKEN", "sessions")
+        msg = str(ctx.exception)
+        self.assertIn("sessions", msg)
+        self.assertIn("http=400", msg)
+        self.assertIn("sql parse error", msg)
+
+
+# -----------------------------------------------------------------------------
+# resolve_session.is_messaging_id — pure shape check
+# -----------------------------------------------------------------------------
+
+
+class IsMessagingIdTests(unittest.TestCase):
+
+    def test_15_char_0Mw_prefix_matches(self):
+        self.assertTrue(resolve_session.is_messaging_id("0MwTESTMSG12345"))
+
+    def test_18_char_0Mw_prefix_matches(self):
+        self.assertTrue(resolve_session.is_messaging_id("0MwTESTMSG12345AAA"))
+
+    def test_uuid_does_not_match(self):
+        # 36 chars, dashes — UUIDs never accidentally pass.
+        self.assertFalse(resolve_session.is_messaging_id(IDS.SID))
+
+    def test_empty_does_not_match(self):
+        self.assertFalse(resolve_session.is_messaging_id(""))
+
+    def test_wrong_prefix_does_not_match(self):
+        self.assertFalse(resolve_session.is_messaging_id("FOOVF00000AtTbV"))
+
+
+# -----------------------------------------------------------------------------
+# resolve_session.resolve_from_disk — scans DATA_ROOT
+# -----------------------------------------------------------------------------
+
+
+class ResolveFromDiskTests(unittest.TestCase):
+
+    def test_uuid_input_passes_through_unchanged(self):
+        self.assertEqual(
+            resolve_session.resolve_from_disk(IDS.SID), IDS.SID,
+        )
+
+    def test_finds_uuid_when_messaging_id_in_dc_sessions(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            write_to_disk(tmp)  # synthetic fixture has the messaging id wired
+            with mock.patch.object(
+                resolve_session, "DATA_ROOT", tmp,
+            ):
+                out = resolve_session.resolve_from_disk("0MwTESTMSG12345AAA")
+        self.assertEqual(out, IDS.SID)
+
+    def test_returns_none_when_messaging_id_not_present_on_disk(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            write_to_disk(tmp)
+            with mock.patch.object(
+                resolve_session, "DATA_ROOT", tmp,
+            ):
+                out = resolve_session.resolve_from_disk("0Mw000000000000")
+        self.assertIsNone(out)
+
+    def test_returns_none_when_data_root_missing(self):
+        with TemporaryDirectory() as t:
+            ghost = Path(t) / "no-such"
+            with mock.patch.object(
+                resolve_session, "DATA_ROOT", ghost,
+            ):
+                out = resolve_session.resolve_from_disk("0MwTESTMSG12345AAA")
+        self.assertIsNone(out)
+
+    def test_skips_archive_dirs(self):
+        # Plant a duplicate inside an "<uuid> - archive 1" dir; the resolver
+        # should ignore it. Without the skip, the extra row could trigger
+        # spurious multi-match.
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            write_to_disk(tmp)
+            archive = tmp / IDS.ORG_ID_15 / f"{IDS.AGENT_API}__{IDS.AGENT_VERSION}" / f"{IDS.SID} - archive 1"
+            archive.mkdir(parents=True)
+            (archive / "dc.sessions.json").write_text(json.dumps([{
+                "ssot__Id__c": "different-uuid-but-same-msg",
+                "ssot__RelatedMessagingSessionId__c": "0MwTESTMSG12345AAA",
+            }]))
+            with mock.patch.object(resolve_session, "DATA_ROOT", tmp):
+                out = resolve_session.resolve_from_disk("0MwTESTMSG12345AAA")
+        # Resolver should return the canonical UUID, ignoring the archive
+        # row. (If the archive weren't skipped, this would multi-match
+        # raise.)
+        self.assertEqual(out, IDS.SID)
+
+
+# -----------------------------------------------------------------------------
+# resolve_session.resolve_disk_or_live — combined path
+# -----------------------------------------------------------------------------
+
+
+class ResolveDiskOrLiveTests(unittest.TestCase):
+
+    def test_uuid_input_passes_through(self):
+        self.assertEqual(
+            resolve_session.resolve_disk_or_live(IDS.SID), IDS.SID,
+        )
+
+    def test_disk_hit_returns_uuid_without_dc_call(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            write_to_disk(tmp)
+            with mock.patch.object(resolve_session, "DATA_ROOT", tmp):
+                with mock.patch.object(resolve_session, "_live_lookup") as live:
+                    out = resolve_session.resolve_disk_or_live(
+                        "0MwTESTMSG12345AAA", org="my-org",
+                    )
+            live.assert_not_called()
+        self.assertEqual(out, IDS.SID)
+
+    def test_disk_miss_no_org_raises_with_hint(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            with mock.patch.object(resolve_session, "DATA_ROOT", tmp):
+                with self.assertRaises(SystemExit) as ctx:
+                    resolve_session.resolve_disk_or_live(
+                        "0MwTESTMSG12345AAA",
+                    )
+        self.assertIn("cannot resolve messaging id", str(ctx.exception))
+
+
+# -----------------------------------------------------------------------------
+# resolve_session.resolve — live DC-backed path
+# -----------------------------------------------------------------------------
+
+
+class ResolveLiveTests(unittest.TestCase):
+
+    def test_single_row_returns_uuid(self):
+        with mock.patch.object(
+            resolve_session, "_live_lookup",
+            return_value=[{"ssot__Id__c": "uuid-1"}],
+        ):
+            out = resolve_session.resolve("0MwTESTMSG12345AAA", org="my-org")
+        self.assertEqual(out, "uuid-1")
+
+    def test_zero_rows_raises(self):
+        with mock.patch.object(
+            resolve_session, "_live_lookup", return_value=[],
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                resolve_session.resolve("0MwTESTMSG12345AAA", org="my-org")
+        self.assertIn("no ssot__AIAgentSession", str(ctx.exception))
+
+    def test_multi_row_raises_with_candidate_list(self):
+        rows = [
+            {"ssot__Id__c": "uuid-A", "ssot__StartTimestamp__c": "t"},
+            {"ssot__Id__c": "uuid-B", "ssot__StartTimestamp__c": "t"},
+        ]
+        with mock.patch.object(
+            resolve_session, "_live_lookup", return_value=rows,
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                resolve_session.resolve("0MwTESTMSG12345AAA", org="my-org")
+        self.assertIn("uuid-A", str(ctx.exception))
+        self.assertIn("uuid-B", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_discover_sessions.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_discover_sessions.py
@@ -1,0 +1,458 @@
+"""Tests for ``discover_sessions`` — DC-only session picker.
+
+Covers:
+- ``parse_time_expr``     pure str → TimeRange (12 supported expressions)
+- ``compose_sql``         pure args → SQL string (conditional JOINs / WHEREs)
+- ``fetch_agent_names``   DC follow-up call (mocks ``post``)
+- ``render_picker``       pure rows → markdown
+- ``main``                argv → exit code (mocks ``resolve_org`` + ``post``)
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import discover_sessions  # type: ignore
+from dc import DCQueryError  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# parse_time_expr — pure
+# -----------------------------------------------------------------------------
+
+
+class ParseTimeExprTests(unittest.TestCase):
+
+    def test_default_none_returns_last_24_hours(self):
+        tr = discover_sessions.parse_time_expr(None, "UTC")
+        delta = tr.end_utc - tr.start_utc
+        self.assertEqual(delta, timedelta(hours=24))
+        self.assertIn("default", tr.expr)
+
+    def test_last_n_hours(self):
+        tr = discover_sessions.parse_time_expr("last 2 hours", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(hours=2))
+        self.assertEqual(tr.expr, "last 2 hours")
+
+    def test_last_n_minutes(self):
+        tr = discover_sessions.parse_time_expr("last 30 minutes", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(minutes=30))
+
+    def test_last_n_days(self):
+        tr = discover_sessions.parse_time_expr("last 3 days", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(days=3))
+
+    def test_last_n_bare_defaults_to_hours(self):
+        # Spec: "last 10" is ambiguous; the regex treats unit-less as hours.
+        tr = discover_sessions.parse_time_expr("last 10", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(hours=10))
+
+    def test_today_uses_local_tz_calendar_day(self):
+        tr = discover_sessions.parse_time_expr("today", "UTC")
+        # End - start should be exactly 24 hours.
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(days=1))
+
+    def test_yesterday_window_precedes_today(self):
+        today = discover_sessions.parse_time_expr("today", "UTC")
+        yest = discover_sessions.parse_time_expr("yesterday", "UTC")
+        self.assertEqual(yest.end_utc, today.start_utc)
+        self.assertEqual(yest.end_utc - yest.start_utc, timedelta(days=1))
+
+    def test_bare_iso_date(self):
+        tr = discover_sessions.parse_time_expr("2026-04-22", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(days=1))
+        self.assertEqual(tr.start_utc.year, 2026)
+        self.assertEqual(tr.start_utc.month, 4)
+        self.assertEqual(tr.start_utc.day, 22)
+
+    def test_iso_date_range_inclusive(self):
+        # "2026-04-22 to 2026-04-25" → 4 calendar days (22, 23, 24, 25).
+        tr = discover_sessions.parse_time_expr("2026-04-22 to 2026-04-25", "UTC")
+        self.assertEqual(tr.end_utc - tr.start_utc, timedelta(days=4))
+
+    def test_explicit_iso_datetime(self):
+        tr = discover_sessions.parse_time_expr(
+            "2026-04-22T10:00:00Z", "UTC"
+        )
+        self.assertEqual(tr.start_utc.year, 2026)
+        self.assertIn("since", tr.expr)
+
+    def test_unparseable_expression_raises(self):
+        with self.assertRaises(SystemExit) as ctx:
+            discover_sessions.parse_time_expr("nope", "UTC")
+        self.assertIn("cannot parse", str(ctx.exception))
+
+    def test_unknown_tz_raises(self):
+        with self.assertRaises(SystemExit) as ctx:
+            discover_sessions.parse_time_expr("today", "Mars/Olympus")
+        self.assertIn("unknown IANA timezone", str(ctx.exception))
+
+
+# -----------------------------------------------------------------------------
+# compose_sql — pure
+# -----------------------------------------------------------------------------
+
+
+def _basic_tr() -> discover_sessions.TimeRange:
+    return discover_sessions.TimeRange(
+        start_utc=datetime(2026, 4, 22, 0, 0, 0, tzinfo=timezone.utc),
+        end_utc=datetime(2026, 4, 22, 23, 0, 0, tzinfo=timezone.utc),
+        expr="test", tz_name="UTC",
+    )
+
+
+class ComposeSqlTests(unittest.TestCase):
+
+    def test_no_filters_skips_joins_and_uses_no_distinct(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep=None, limit=20,
+        )
+        # Strip SQL comments so the JOIN/DISTINCT mentions in the template
+        # docblock don't fool the naive substring check.
+        executable = "\n".join(
+            line for line in sql.splitlines() if not line.strip().startswith("--")
+        )
+        self.assertNotIn("JOIN ", executable)
+        self.assertNotIn("DISTINCT", executable)
+        self.assertIn("ssot__StartTimestamp__c >= '2026-04-22T00:00:00.000Z'", executable)
+        self.assertIn("ssot__StartTimestamp__c < '2026-04-22T23:00:00.000Z'", executable)
+
+    def test_agent_filter_adds_participant_join(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent="MyAgent", channel=None,
+            outcome=None, grep=None, limit=20,
+        )
+        self.assertIn("ssot__AiAgentSessionParticipant__dlm", sql)
+        self.assertIn("p.ssot__AiAgentApiName__c = 'MyAgent'", sql)
+        self.assertIn("DISTINCT", sql)
+
+    def test_messaging_channel_maps_to_scrt2_string(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel="Messaging",
+            outcome=None, grep=None, limit=20,
+        )
+        self.assertIn("'SCRT2 - EmbeddedMessaging'", sql)
+
+    def test_unknown_channel_passes_through(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel="Custom_Channel",
+            outcome=None, grep=None, limit=20,
+        )
+        self.assertIn("'Custom_Channel'", sql)
+
+    def test_outcome_filter_added(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome="ESCALATED", grep=None, limit=20,
+        )
+        self.assertIn("ssot__AiAgentSessionEndType__c = 'ESCALATED'", sql)
+
+    def test_grep_adds_interaction_message_joins(self):
+        # Default --grep is case-insensitive (§16d) — both sides are
+        # wrapped in LOWER(...). The case-sensitive variant is covered
+        # by test_grep_case_sensitive_opt_in below.
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep="refund", limit=20,
+        )
+        self.assertIn("ssot__AiAgentInteraction__dlm", sql)
+        self.assertIn("ssot__AiAgentInteractionMessage__dlm", sql)
+        self.assertIn("LOWER(m.ssot__ContentText__c) LIKE LOWER('%refund%')", sql)
+        self.assertIn("ESCAPE '!'", sql)
+
+    def test_grep_case_sensitive_opt_in(self):
+        # --grep-case-sensitive bypasses the LOWER() wrap — restores the
+        # exact-match shape for the rare user who wants it.
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep="Refund", grep_case_sensitive=True, limit=20,
+        )
+        self.assertIn("m.ssot__ContentText__c LIKE '%Refund%'", sql)
+        self.assertNotIn("LOWER(", sql)
+        self.assertIn("ESCAPE '!'", sql)
+
+    def test_grep_escapes_like_wildcards(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep="100%_off", limit=20,
+        )
+        # Both `%` and `_` get the `!` escape prefix
+        self.assertIn("100!%!_off", sql)
+
+    def test_grep_escapes_single_quotes(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep="O'Brien", limit=20,
+        )
+        # Single quote doubled per SQL escaping rule
+        self.assertIn("O''Brien", sql)
+
+    def test_limit_substituted(self):
+        sql = discover_sessions.compose_sql(
+            tr=_basic_tr(), agent=None, channel=None,
+            outcome=None, grep=None, limit=42,
+        )
+        self.assertIn("42", sql)
+
+
+# -----------------------------------------------------------------------------
+# fetch_agent_names — mocks dc.post
+# -----------------------------------------------------------------------------
+
+
+class FetchAgentNamesTests(unittest.TestCase):
+
+    def test_empty_session_ids_returns_empty_dict_no_post(self):
+        with mock.patch.object(discover_sessions, "post") as p:
+            out = discover_sessions.fetch_agent_names(
+                [], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {})
+        p.assert_not_called()
+
+    def test_returns_dict_keyed_by_session_id(self):
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.return_value = [
+                {
+                    "ssot__AiAgentSessionId__c": "sid1",
+                    "ssot__AiAgentApiName__c": "AgentA",
+                },
+                {
+                    "ssot__AiAgentSessionId__c": "sid2",
+                    "ssot__AiAgentApiName__c": "AgentB",
+                },
+            ]
+            out = discover_sessions.fetch_agent_names(
+                ["sid1", "sid2"], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {"sid1": "AgentA", "sid2": "AgentB"})
+
+    def test_skips_rows_with_empty_agent_name(self):
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.return_value = [
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": ""},
+                {"ssot__AiAgentSessionId__c": "sid2", "ssot__AiAgentApiName__c": "AgentB"},
+            ]
+            out = discover_sessions.fetch_agent_names(
+                ["sid1", "sid2"], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {"sid2": "AgentB"})
+
+    def test_dcqueryerror_returns_empty_dict_non_fatal(self):
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.side_effect = DCQueryError("boom")
+            out = discover_sessions.fetch_agent_names(
+                ["sid1"], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {})
+
+    def test_uses_user_row_name_when_agent_row_is_not_set(self):
+        # MyAgent-shape session: AGENT row carries 'NOT_SET',
+        # USER row carries the real api_name. Old code filtered to
+        # role=AGENT and would return 'NOT_SET' (or nothing). New code
+        # is role-agnostic and recovers the api_name from the USER row.
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.return_value = [
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": "NOT_SET"},
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": "MyAgent"},
+            ]
+            out = discover_sessions.fetch_agent_names(
+                ["sid1"], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {"sid1": "MyAgent"})
+
+    def test_drops_session_when_every_row_is_not_set(self):
+        # No usable api_name anywhere — picker should show '—' for the
+        # session, which is more honest than displaying the literal
+        # 'NOT_SET' string. Implementation contract: missing key in dict.
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.return_value = [
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": "NOT_SET"},
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": ""},
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": None},
+            ]
+            out = discover_sessions.fetch_agent_names(
+                ["sid1"], instance_url="https://x", token="t",
+            )
+        self.assertNotIn("sid1", out)
+        self.assertEqual(out, {})
+
+    def test_picks_lexicographic_first_on_handoff_session(self):
+        # Multi-agent handoff: two distinct AGENT api_names appear on
+        # different rows for the same session. Dominant-agent rule
+        # (sorted(...)[0]) matches the policy used by fetch_dc and the
+        # migration script — every writer agrees on the session's namesake.
+        with mock.patch.object(discover_sessions, "post") as p:
+            p.return_value = [
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": "ZAgent"},
+                {"ssot__AiAgentSessionId__c": "sid1", "ssot__AiAgentApiName__c": "AAgent"},
+            ]
+            out = discover_sessions.fetch_agent_names(
+                ["sid1"], instance_url="https://x", token="t",
+            )
+        self.assertEqual(out, {"sid1": "AAgent"})
+
+    def test_sql_does_not_filter_by_role(self):
+        # Lock the no-role-filter contract — if a future "tighten this
+        # back up" refactor re-adds the AGENT filter, MyAgent
+        # sessions silently regress to '—' or 'NOT_SET' in the picker.
+        captured = {}
+
+        def fake_post(sql, *_a, **_k):
+            captured["sql"] = sql
+            return []
+
+        with mock.patch.object(discover_sessions, "post", side_effect=fake_post):
+            discover_sessions.fetch_agent_names(
+                ["sid1"], instance_url="https://x", token="t",
+            )
+        self.assertNotIn("AiAgentSessionParticipantRole", captured["sql"])
+        self.assertNotIn("'AGENT'", captured["sql"])
+
+
+# -----------------------------------------------------------------------------
+# render_picker — pure
+# -----------------------------------------------------------------------------
+
+
+def _picker_filters(**overrides) -> dict:
+    base = {"agent": None, "channel": None, "outcome": None, "grep": None}
+    base.update(overrides)
+    return base
+
+
+class RenderPickerTests(unittest.TestCase):
+
+    def test_zero_rows_emits_widen_hint_with_composed_sql(self):
+        out = discover_sessions.render_picker(
+            rows=[], agent_by_sid={}, org="my-org",
+            tr=_basic_tr(), filters=_picker_filters(),
+            composed_sql="SELECT 1",
+        )
+        self.assertIn("No sessions matched", out)
+        self.assertIn("```sql\nSELECT 1\n```", out)
+        self.assertIn("Try widening", out)
+
+    def test_renders_markdown_table_with_one_row(self):
+        rows = [{
+            "ssot__Id__c": "019dface-0000-7000-8000-000000000001",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:00Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:01:30Z",
+            "ssot__AiAgentChannelType__c": "SCRT2 - EmbeddedMessaging",
+            "ssot__AiAgentSessionEndType__c": "USER_ENDED",
+        }]
+        out = discover_sessions.render_picker(
+            rows=rows, agent_by_sid={"019dface-0000-7000-8000-000000000001": "AgentA"},
+            org="my-org", tr=_basic_tr(),
+            filters=_picker_filters(), composed_sql="",
+        )
+        self.assertIn("Found **1** session", out)
+        self.assertIn("`019dface-0000-7000-8000-000000000001`", out)
+        self.assertIn("AgentA", out)
+        # Reverse-aliased channel
+        self.assertIn("Messaging", out)
+        # Duration formatter
+        self.assertIn("1m 30s", out)
+        self.assertIn("USER_ENDED", out)
+
+    def test_handles_session_without_known_agent_with_dash(self):
+        rows = [{
+            "ssot__Id__c": "sid1",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:00Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:00:30Z",
+            "ssot__AiAgentChannelType__c": "Builder",
+            "ssot__AiAgentSessionEndType__c": None,
+        }]
+        out = discover_sessions.render_picker(
+            rows=rows, agent_by_sid={}, org="my-org",
+            tr=_basic_tr(), filters=_picker_filters(), composed_sql="",
+        )
+        self.assertIn("| — |", out)  # agent + outcome both render as "—"
+        self.assertIn("30s", out)
+
+    def test_filter_bits_appear_in_header(self):
+        rows = [{
+            "ssot__Id__c": "sid1",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:00Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:00:30Z",
+            "ssot__AiAgentChannelType__c": "Builder",
+            "ssot__AiAgentSessionEndType__c": "ESCALATED",
+        }]
+        out = discover_sessions.render_picker(
+            rows=rows, agent_by_sid={}, org="my-org", tr=_basic_tr(),
+            filters=_picker_filters(agent="MyAgent", outcome="ESCALATED"),
+            composed_sql="",
+        )
+        self.assertIn("agent=MyAgent", out)
+        self.assertIn("outcome=ESCALATED", out)
+
+
+# -----------------------------------------------------------------------------
+# main — argv-driven exit codes
+# -----------------------------------------------------------------------------
+
+
+class MainTests(unittest.TestCase):
+
+    def _argv(self, *extra: str) -> list[str]:
+        # `--org` is required; everything else has a default or is optional.
+        return ["discover_sessions.py", "--org", "my-org", *extra]
+
+    def test_main_exit_zero_when_rows_returned(self):
+        with mock.patch.object(discover_sessions.sys, "argv", self._argv()):
+            with mock.patch.object(
+                discover_sessions, "resolve_org",
+                return_value=("https://example.salesforce.com", "TOKEN"),
+            ):
+                with mock.patch.object(
+                    discover_sessions, "post",
+                    return_value=[{
+                        "ssot__Id__c": "sid1",
+                        "ssot__StartTimestamp__c": "2026-04-22T00:00:00Z",
+                        "ssot__EndTimestamp__c": "2026-04-22T00:01:00Z",
+                        "ssot__AiAgentChannelType__c": "Builder",
+                        "ssot__AiAgentSessionEndType__c": "USER_ENDED",
+                    }],
+                ):
+                    rc = discover_sessions.main()
+        self.assertEqual(rc, 0)
+
+    def test_main_exit_two_when_zero_rows(self):
+        with mock.patch.object(discover_sessions.sys, "argv", self._argv()):
+            with mock.patch.object(
+                discover_sessions, "resolve_org",
+                return_value=("https://x", "T"),
+            ):
+                with mock.patch.object(discover_sessions, "post", return_value=[]):
+                    rc = discover_sessions.main()
+        self.assertEqual(rc, 2)
+
+    def test_main_exit_one_when_dc_query_fails(self):
+        with mock.patch.object(discover_sessions.sys, "argv", self._argv()):
+            with mock.patch.object(
+                discover_sessions, "resolve_org",
+                return_value=("https://x", "T"),
+            ):
+                with mock.patch.object(
+                    discover_sessions, "post",
+                    side_effect=DCQueryError("HTTP 500"),
+                ):
+                    rc = discover_sessions.main()
+        self.assertEqual(rc, 1)
+
+    def test_main_rejects_zero_or_negative_limit(self):
+        with mock.patch.object(
+            discover_sessions.sys, "argv",
+            self._argv("--limit", "0"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                discover_sessions.main()
+        self.assertIn("--limit must be >= 1", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_discover_sessions_grep_ci.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_discover_sessions_grep_ci.py
@@ -1,0 +1,193 @@
+"""Regression guard for §16d — case-insensitive ``--grep`` default.
+
+§16d flipped the default behaviour of ``--grep`` from case-sensitive
+exact match to case-insensitive (``LOWER(...) LIKE LOWER(...)``).
+Operators almost always type the quoted phrase in whatever case they
+remember, not the case the agent rendered it in — the old default
+silently dropped legitimate matches.
+
+The compose_sql shape is already pinned in
+``test_discover_sessions.py`` (LOWER wrap on default, bypass on opt-in,
+escape semantics). What this file pins down is the
+**argparse → filters dict → picker header** pipeline — the integration
+seams where a refactor could:
+
+  - flip the argparse default back to ``True`` (forgot ``default=False``)
+  - drop the ``grep_case_sensitive`` key from the filters dict (header
+    no longer warns the operator that the picker is in opt-in mode)
+  - surface ``grep_case_sensitive`` even when ``--grep`` isn't set
+    (false signal in the header for unrelated runs)
+"""
+from __future__ import annotations
+
+import argparse
+import unittest
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import discover_sessions  # type: ignore
+
+
+class GrepCaseSensitiveArgparseDefaultTests(unittest.TestCase):
+    """The argparse flag must default to ``False`` so case-insensitive
+    is the path of least resistance."""
+
+    def _build_parser(self) -> argparse.ArgumentParser:
+        # Re-export the parser the same way main() does — we don't have
+        # a parser factory, so spy on the module-level ``argparse`` to
+        # capture the parser before main() invokes parse_args().
+        captured: dict[str, argparse.ArgumentParser] = {}
+        real_parse_args = argparse.ArgumentParser.parse_args
+
+        def capture(self, *a, **kw):  # type: ignore[no-redef]
+            captured["parser"] = self
+            # Stop main() before it calls anything network-y.
+            raise SystemExit(0)
+
+        with mock.patch.object(argparse.ArgumentParser, "parse_args", capture):
+            with mock.patch.object(
+                discover_sessions.sys, "argv",
+                ["discover_sessions.py", "--org", "x"],
+            ):
+                with self.assertRaises(SystemExit):
+                    discover_sessions.main()
+        # Restore (the patch.object exit already did this, but be explicit
+        # in case something held onto the bound method.)
+        argparse.ArgumentParser.parse_args = real_parse_args
+        return captured["parser"]
+
+    def test_grep_case_sensitive_default_is_false(self):
+        # parse_args without --grep-case-sensitive must return False.
+        parser = self._build_parser()
+        ns = parser.parse_args(["--org", "x"])
+        self.assertFalse(ns.grep_case_sensitive,
+                         "default flipped — case-insensitive was the §16d "
+                         "decision; flipping default=False back to True "
+                         "regresses to the pre-§16d behaviour")
+
+    def test_grep_case_sensitive_opt_in_via_flag(self):
+        # Pass the flag explicitly — must be True.
+        parser = self._build_parser()
+        ns = parser.parse_args(["--org", "x", "--grep-case-sensitive"])
+        self.assertTrue(ns.grep_case_sensitive)
+
+
+class FiltersDictSurfacesCaseSensitiveTests(unittest.TestCase):
+    """The filters dict feeds render_picker's header. Without a marker,
+    the operator can't tell whether their grep is in case-insensitive
+    (default) or case-sensitive (opt-in) mode — a silent footgun when
+    a query returns zero rows in opt-in mode by accident."""
+
+    def _run_main_and_capture_filters(self, *extra_argv: str) -> dict:
+        # Stub resolve_org + post so main() doesn't talk to DC, then
+        # intercept render_picker to capture the filters dict main()
+        # constructed.
+        captured: dict[str, dict] = {}
+
+        def fake_render(*, filters, **_kw):
+            captured["filters"] = filters
+            return "ok"
+
+        argv = ["discover_sessions.py", "--org", "x", *extra_argv]
+        with mock.patch.object(discover_sessions.sys, "argv", argv), \
+             mock.patch.object(
+                 discover_sessions, "resolve_org",
+                 return_value=("https://x", "T"),
+             ), \
+             mock.patch.object(
+                 discover_sessions, "post",
+                 return_value=[{
+                     "ssot__Id__c": "sid1",
+                     "ssot__StartTimestamp__c": "2026-04-22T00:00:00Z",
+                     "ssot__EndTimestamp__c": "2026-04-22T00:01:00Z",
+                     "ssot__AiAgentChannelType__c": "Builder",
+                     "ssot__AiAgentSessionEndType__c": "USER_ENDED",
+                 }],
+             ), \
+             mock.patch.object(
+                 discover_sessions, "render_picker",
+                 side_effect=fake_render,
+             ):
+            discover_sessions.main()
+        return captured["filters"]
+
+    def test_filters_omit_case_sensitive_when_grep_unset(self):
+        # No --grep at all: surfacing case-sensitive=yes in the header
+        # would be a meaningless artifact (there's no grep to be
+        # case-sensitive about). Contract: the value is None so
+        # render_picker's `if v:` filter drops the bit.
+        filters = self._run_main_and_capture_filters()
+        self.assertIsNone(filters["grep_case_sensitive"])
+
+    def test_filters_omit_case_sensitive_when_grep_set_but_default(self):
+        # --grep set, --grep-case-sensitive NOT set: default mode is
+        # case-insensitive. Don't surface the marker — the absence is
+        # the default and surfacing "yes/no" on every grep would just
+        # add noise to the picker header.
+        filters = self._run_main_and_capture_filters("--grep", "refund")
+        self.assertEqual(filters["grep"], "refund")
+        self.assertIsNone(filters["grep_case_sensitive"])
+
+    def test_filters_surface_case_sensitive_only_when_both_set(self):
+        # The interesting case: operator opted in. The header MUST tell
+        # them, otherwise a zero-row return looks identical to a
+        # case-insensitive zero-row return.
+        filters = self._run_main_and_capture_filters(
+            "--grep", "Refund", "--grep-case-sensitive",
+        )
+        self.assertEqual(filters["grep"], "Refund")
+        self.assertEqual(filters["grep_case_sensitive"], "yes")
+
+
+class RenderPickerHeaderShowsCaseSensitiveTests(unittest.TestCase):
+    """End-to-end: when filters dict surfaces ``grep_case_sensitive``,
+    render_picker must include it in the header."""
+
+    def _row(self) -> dict:
+        return {
+            "ssot__Id__c": "sid1",
+            "ssot__StartTimestamp__c": "2026-04-22T10:00:00Z",
+            "ssot__EndTimestamp__c": "2026-04-22T10:00:30Z",
+            "ssot__AiAgentChannelType__c": "Builder",
+            "ssot__AiAgentSessionEndType__c": "USER_ENDED",
+        }
+
+    def _tr(self) -> "discover_sessions.TimeRange":
+        from datetime import datetime, timezone
+        return discover_sessions.TimeRange(
+            start_utc=datetime(2026, 4, 22, 0, 0, 0, tzinfo=timezone.utc),
+            end_utc=datetime(2026, 4, 22, 23, 0, 0, tzinfo=timezone.utc),
+            expr="test", tz_name="UTC",
+        )
+
+    def test_header_includes_case_sensitive_bit_when_set(self):
+        out = discover_sessions.render_picker(
+            rows=[self._row()], agent_by_sid={}, org="my-org",
+            tr=self._tr(),
+            filters={
+                "agent": None, "channel": None, "outcome": None,
+                "grep": "Refund", "grep_case_sensitive": "yes",
+            },
+            composed_sql="",
+        )
+        self.assertIn("grep=Refund", out)
+        self.assertIn("grep_case_sensitive=yes", out)
+
+    def test_header_omits_case_sensitive_bit_in_default_mode(self):
+        # Default-mode grep (no opt-in): the bit must NOT appear.
+        out = discover_sessions.render_picker(
+            rows=[self._row()], agent_by_sid={}, org="my-org",
+            tr=self._tr(),
+            filters={
+                "agent": None, "channel": None, "outcome": None,
+                "grep": "refund", "grep_case_sensitive": None,
+            },
+            composed_sql="",
+        )
+        self.assertIn("grep=refund", out)
+        self.assertNotIn("grep_case_sensitive", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_helpers.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_helpers.py
@@ -1,0 +1,266 @@
+"""Tests for ``fetch_dc`` helpers + DC-access-denied flow.
+
+Complements ``test_fetch_dc_identity.py`` (which targets ``_resolve_identity``
+specifically). This file lifts coverage of the other public helpers:
+
+- ``DcAccessDenied``                   exception carrier
+- ``preflight_dc_access``              401/403 classification + happy path
+- ``_emit_dc_access_denied_preamble``  headless JSON shape
+- ``_handle_dc_access_denied``         interactive (tty) vs headless branches
+- ``_in_list``                          SQL IN-fragment helper (dedup + NOT_SET filter)
+- ``_extract_trace_ids``                runtime trace-id extraction (DMO + HTML-escaped)
+- ``_preflight_templates``              SQL template existence check
+
+All subprocess + DC-access boundaries are mocked.
+"""
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import fetch_dc  # type: ignore
+from dc import DCQueryError  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# DcAccessDenied — small carrier
+# -----------------------------------------------------------------------------
+
+
+class DcAccessDeniedTests(unittest.TestCase):
+
+    def test_str_includes_reason_and_detail(self):
+        e = fetch_dc.DcAccessDenied("401", "Unauthorized")
+        self.assertEqual(e.reason, "401")
+        self.assertEqual(e.detail, "Unauthorized")
+        self.assertIn("401: Unauthorized", str(e))
+
+
+# -----------------------------------------------------------------------------
+# preflight_dc_access — classify HTTP error code
+# -----------------------------------------------------------------------------
+
+
+class PreflightDcAccessTests(unittest.TestCase):
+
+    def test_returns_url_and_token_on_success(self):
+        with mock.patch.object(
+            fetch_dc, "resolve_org",
+            return_value=("https://example.salesforce.com", "TOKEN"),
+        ):
+            with mock.patch.object(fetch_dc, "post", return_value=[]):
+                url, token = fetch_dc.preflight_dc_access("sid", "my-org")
+        self.assertEqual(url, "https://example.salesforce.com")
+        self.assertEqual(token, "TOKEN")
+
+    def test_raises_dc_access_denied_on_401(self):
+        with mock.patch.object(
+            fetch_dc, "resolve_org",
+            return_value=("https://x", "T"),
+        ):
+            with mock.patch.object(
+                fetch_dc, "post",
+                side_effect=DCQueryError("http=401 Unauthorized"),
+            ):
+                with self.assertRaises(fetch_dc.DcAccessDenied) as ctx:
+                    fetch_dc.preflight_dc_access("sid", "my-org")
+        self.assertEqual(ctx.exception.reason, "401")
+
+    def test_raises_dc_access_denied_on_403(self):
+        with mock.patch.object(
+            fetch_dc, "resolve_org",
+            return_value=("https://x", "T"),
+        ):
+            with mock.patch.object(
+                fetch_dc, "post",
+                side_effect=DCQueryError("http=403 Forbidden"),
+            ):
+                with self.assertRaises(fetch_dc.DcAccessDenied) as ctx:
+                    fetch_dc.preflight_dc_access("sid", "my-org")
+        self.assertEqual(ctx.exception.reason, "403")
+
+    def test_raises_dc_access_denied_on_other_dc_error(self):
+        with mock.patch.object(
+            fetch_dc, "resolve_org",
+            return_value=("https://x", "T"),
+        ):
+            with mock.patch.object(
+                fetch_dc, "post",
+                side_effect=DCQueryError("http=500 ISE"),
+            ):
+                with self.assertRaises(fetch_dc.DcAccessDenied) as ctx:
+                    fetch_dc.preflight_dc_access("sid", "my-org")
+        # 5xx falls into the catch-all dc_probe_failed bucket.
+        self.assertEqual(ctx.exception.reason, "dc_probe_failed")
+
+
+# -----------------------------------------------------------------------------
+# _emit_dc_access_denied_preamble — JSON shape
+# -----------------------------------------------------------------------------
+
+
+class EmitPreambleTests(unittest.TestCase):
+
+    def test_emits_single_line_json_with_two_options(self):
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            fetch_dc._emit_dc_access_denied_preamble("401", "Unauthorized")
+        printed = buf.getvalue().strip()
+        # One single-line JSON record
+        self.assertEqual(printed.count("\n"), 0)
+        payload = json.loads(printed)
+        self.assertEqual(payload["status"], "DC_ACCESS_DENIED")
+        self.assertEqual(payload["reason"], "401")
+        self.assertEqual(payload["detail"], "Unauthorized")
+        # Standalone d360 has retry + cancel only — no sibling-skill switch.
+        self.assertEqual(len(payload["options"]), 2)
+        codes = [o["code"] for o in payload["options"]]
+        self.assertEqual(codes, ["1", "2"])
+        actions = [o["action"] for o in payload["options"]]
+        self.assertEqual(actions, ["retry", "cancel"])
+
+
+# -----------------------------------------------------------------------------
+# _handle_dc_access_denied — branches on tty vs not, + interactive choices
+# -----------------------------------------------------------------------------
+
+
+class HandleDcAccessDeniedTests(unittest.TestCase):
+
+    def _exc(self) -> fetch_dc.DcAccessDenied:
+        return fetch_dc.DcAccessDenied("401", "Unauthorized")
+
+    def test_headless_emits_preamble_and_returns_exit_code(self):
+        with mock.patch.object(
+            fetch_dc, "_emit_dc_access_denied_preamble"
+        ) as emit:
+            rc = fetch_dc._handle_dc_access_denied(
+                self._exc(), session_id="sid", is_tty=False,
+            )
+        emit.assert_called_once_with("401", "Unauthorized")
+        self.assertEqual(rc, fetch_dc.EXIT_DC_ACCESS_DENIED)
+
+    def test_interactive_choice_1_returns_exit_code(self):
+        # User picks "1" → caller signaled to retry.
+        with mock.patch.object(fetch_dc.sys, "stdin", io.StringIO("1\n")):
+            with mock.patch.object(fetch_dc, "_log"):
+                rc = fetch_dc._handle_dc_access_denied(
+                    self._exc(), session_id="sid", is_tty=True,
+                )
+        self.assertEqual(rc, fetch_dc.EXIT_DC_ACCESS_DENIED)
+
+    def test_interactive_choice_2_returns_zero_cancel(self):
+        # Standalone d360: choice "2" is cancel (no sibling-skill switch).
+        with mock.patch.object(fetch_dc.sys, "stdin", io.StringIO("2\n")):
+            with mock.patch.object(fetch_dc, "_log"):
+                rc = fetch_dc._handle_dc_access_denied(
+                    self._exc(), session_id="sid", is_tty=True,
+                )
+        self.assertEqual(rc, 0)
+
+    def test_interactive_unknown_choice_treated_as_cancel(self):
+        # "" / "9" / random → cancel.
+        with mock.patch.object(fetch_dc.sys, "stdin", io.StringIO("\n")):
+            with mock.patch.object(fetch_dc, "_log"):
+                rc = fetch_dc._handle_dc_access_denied(
+                    self._exc(), session_id="sid", is_tty=True,
+                )
+        self.assertEqual(rc, 0)
+
+    def test_interactive_keyboard_interrupt_returns_zero(self):
+        # stdin.readline() raising KeyboardInterrupt → graceful 0.
+        fake_stdin = mock.MagicMock()
+        fake_stdin.readline.side_effect = KeyboardInterrupt
+        with mock.patch.object(fetch_dc.sys, "stdin", fake_stdin):
+            with mock.patch.object(fetch_dc, "_log"):
+                rc = fetch_dc._handle_dc_access_denied(
+                    self._exc(), session_id="sid", is_tty=True,
+                )
+        self.assertEqual(rc, 0)
+
+
+# -----------------------------------------------------------------------------
+# _in_list — SQL IN-clause fragment builder
+# -----------------------------------------------------------------------------
+
+
+class InListTests(unittest.TestCase):
+
+    def test_renders_quoted_csv_inside_parens(self):
+        self.assertEqual(fetch_dc._in_list(["a", "b", "c"]), "('a','b','c')")
+
+    def test_dedups_and_preserves_first_occurrence_order(self):
+        self.assertEqual(
+            fetch_dc._in_list(["a", "b", "a", "c", "b"]), "('a','b','c')"
+        )
+
+    def test_drops_empty_string(self):
+        self.assertEqual(fetch_dc._in_list(["a", "", "b"]), "('a','b')")
+
+    def test_drops_NOT_SET_token(self):
+        self.assertEqual(
+            fetch_dc._in_list(["a", "NOT_SET", "b"]), "('a','b')"
+        )
+
+    def test_empty_input_returns_empty_parens(self):
+        # All inputs filtered → "()". SQL won't accept this but that's the
+        # caller's concern — the helper itself is mechanical.
+        self.assertEqual(fetch_dc._in_list([]), "()")
+        self.assertEqual(fetch_dc._in_list(["", "NOT_SET"]), "()")
+
+
+# -----------------------------------------------------------------------------
+# _extract_trace_ids — DMO field + HTML-escaped fallback
+# -----------------------------------------------------------------------------
+
+
+class ExtractTraceIdsTests(unittest.TestCase):
+
+    def test_uses_telemetry_trace_id_when_populated(self):
+        rows = [{"ssot__TelemetryTraceId__c": "abc123"}]
+        self.assertEqual(fetch_dc._extract_trace_ids(rows), ["abc123"])
+
+    def test_falls_back_to_attribute_text_internalTraceId(self):
+        # Simulate the HTML-escaped JSON-in-a-string shape DC stores.
+        rows = [{
+            "ssot__TelemetryTraceId__c": "",
+            "ssot__AttributeText__c": '&quot;internalTraceId&quot;:&quot;deadbeef&quot;',
+        }]
+        self.assertEqual(fetch_dc._extract_trace_ids(rows), ["deadbeef"])
+
+    def test_dedupes_preserving_first_occurrence(self):
+        rows = [
+            {"ssot__TelemetryTraceId__c": "x"},
+            {"ssot__TelemetryTraceId__c": "y"},
+            {"ssot__TelemetryTraceId__c": "x"},
+        ]
+        self.assertEqual(fetch_dc._extract_trace_ids(rows), ["x", "y"])
+
+    def test_drops_NOT_SET_token(self):
+        rows = [{"ssot__TelemetryTraceId__c": "NOT_SET"}]
+        self.assertEqual(fetch_dc._extract_trace_ids(rows), [])
+
+    def test_returns_empty_when_no_trace_id_anywhere(self):
+        rows = [{"ssot__TelemetryTraceId__c": "", "ssot__AttributeText__c": ""}]
+        self.assertEqual(fetch_dc._extract_trace_ids(rows), [])
+
+
+# -----------------------------------------------------------------------------
+# _preflight_templates — SQL templates exist on disk
+# -----------------------------------------------------------------------------
+
+
+class PreflightTemplatesTests(unittest.TestCase):
+
+    def test_succeeds_when_all_templates_present(self):
+        # All the production .sql files ship in assets/dc/. This call should
+        # complete cleanly under the in-tree install.
+        fetch_dc._preflight_templates()  # raises if any missing
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_identity.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_identity.py
@@ -1,0 +1,528 @@
+"""Tests for ``fetch_dc._resolve_identity`` + ``sf org display`` fallback.
+
+Closes a real-world failure mode: ``sessions[0].ssot__InternalOrganizationId__c``
+is occasionally null in SSOT materialization despite every other field
+being populated (e.g. session ``019dface-0000-7000-8000-000000000001`` in
+``my-org-alias``). The authenticated ``sf`` alias knows the org id
+regardless, so we fall back to ``sf org display --target-org <alias> --json``
+and parse ``.result.id``. If that also fails, a unified diagnostic
+surfaces both failure modes.
+
+Every test patches ``subprocess.run`` at the ``fetch_dc`` module level so
+no real CLI is ever invoked.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import fetch_dc  # type: ignore
+
+
+_ORG_ALIAS = "my-org-alias"
+_FULL_ORG_ID_18 = "00D0000000000000EA"
+_EXPECTED_ORG_ID_15 = "00D000000000000"
+_AGENT_API = "DemoAgent"
+_AGENT_VER = "v5"
+
+
+def _agent_participant() -> dict:
+    return {
+        "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+        "ssot__AiAgentApiName__c": _AGENT_API,
+        "ssot__AiAgentVersionApiName__c": _AGENT_VER,
+    }
+
+
+def _sf_cli_success_stdout(org_id: str = _FULL_ORG_ID_18) -> str:
+    """Shape mirrors the real ``sf org display --json`` payload."""
+    return json.dumps({
+        "status": 0,
+        "result": {
+            "id": org_id,
+            "instanceUrl": "https://example.my.salesforce.com",
+            "accessToken": "REDACTED",
+        },
+    })
+
+
+class ResolveIdentityDmoPopulatedTests(unittest.TestCase):
+    """Happy path — DMO field carries a valid 18-char id, no subprocess spawn."""
+
+    def test_resolve_identity_uses_dmo_when_populated(self):
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [_agent_participant()]
+
+        with mock.patch.object(fetch_dc.subprocess, "run") as m_run:
+            org_id_15, agent, ver = fetch_dc._resolve_identity(
+                sessions, participants, _ORG_ALIAS,
+            )
+
+        self.assertEqual(org_id_15, _EXPECTED_ORG_ID_15)
+        self.assertEqual(agent, _AGENT_API)
+        self.assertEqual(ver, _AGENT_VER)
+        m_run.assert_not_called()
+
+
+class ResolveIdentityDmoFallbackTests(unittest.TestCase):
+    """DMO field null/empty/short — fall back to ``sf org display``."""
+
+    def _patch_sf_cli_ok(self, org_id: str = _FULL_ORG_ID_18):
+        return mock.patch.object(
+            fetch_dc.subprocess, "run",
+            return_value=SimpleNamespace(
+                stdout=_sf_cli_success_stdout(org_id),
+                stderr="",
+                returncode=0,
+            ),
+        )
+
+    def test_resolve_identity_falls_back_to_sf_cli_when_dmo_null(self):
+        sessions = [{"ssot__InternalOrganizationId__c": None}]
+        participants = [_agent_participant()]
+
+        with self._patch_sf_cli_ok() as m_run:
+            org_id_15, agent, ver = fetch_dc._resolve_identity(
+                sessions, participants, _ORG_ALIAS,
+            )
+
+        self.assertEqual(org_id_15, _EXPECTED_ORG_ID_15)
+        self.assertEqual(agent, _AGENT_API)
+        self.assertEqual(ver, _AGENT_VER)
+        # Exact argv shape matters — it's the public contract with the sf CLI.
+        args, kwargs = m_run.call_args
+        self.assertEqual(
+            args[0],
+            ["sf", "org", "display", "--target-org", _ORG_ALIAS, "--json"],
+        )
+        self.assertTrue(kwargs.get("check"))
+        self.assertTrue(kwargs.get("capture_output"))
+        self.assertTrue(kwargs.get("text"))
+
+    def test_resolve_identity_falls_back_when_dmo_empty_string(self):
+        sessions = [{"ssot__InternalOrganizationId__c": ""}]
+        participants = [_agent_participant()]
+
+        with self._patch_sf_cli_ok():
+            org_id_15, _, _ = fetch_dc._resolve_identity(
+                sessions, participants, _ORG_ALIAS,
+            )
+        self.assertEqual(org_id_15, _EXPECTED_ORG_ID_15)
+
+    def test_resolve_identity_falls_back_when_dmo_shorter_than_15(self):
+        sessions = [{"ssot__InternalOrganizationId__c": "shortid"}]
+        participants = [_agent_participant()]
+
+        with self._patch_sf_cli_ok():
+            org_id_15, _, _ = fetch_dc._resolve_identity(
+                sessions, participants, _ORG_ALIAS,
+            )
+        self.assertEqual(org_id_15, _EXPECTED_ORG_ID_15)
+
+
+class ResolveIdentityBothSourcesFailTests(unittest.TestCase):
+    """When both the DMO field AND the CLI fallback fail, surface both."""
+
+    def test_resolve_identity_raises_when_both_sources_fail(self):
+        sessions = [{"ssot__InternalOrganizationId__c": None}]
+        participants = [_agent_participant()]
+
+        err = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["sf", "org", "display", "--target-org", _ORG_ALIAS, "--json"],
+            stderr="No AuthInfo found for name " + _ORG_ALIAS,
+        )
+        with mock.patch.object(fetch_dc.subprocess, "run", side_effect=err):
+            with self.assertRaises(SystemExit) as ctx:
+                fetch_dc._resolve_identity(
+                    sessions, participants, _ORG_ALIAS,
+                )
+
+        msg = str(ctx.exception)
+        # Must mention both failure modes so users know which to fix.
+        self.assertIn("both DMO field and sf org display failed", msg)
+        self.assertIn(_ORG_ALIAS, msg)
+        self.assertIn("CalledProcessError", msg)
+
+
+class ResolveIdentityNoAgentParticipantsTests(unittest.TestCase):
+    """Recently-created sessions can land here while STDM is still
+    materializing — the AGENT participant rows haven't been written yet.
+    The error must hint at retry rather than implying a malformed session.
+    """
+
+    def test_resolve_identity_raises_with_retry_hint_when_no_agent_participants(self):
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        # No AGENT-role participants; only a USER row.
+        participants = [{
+            "ssot__AiAgentSessionParticipantRole__c": "USER",
+            "ssot__AiAgentApiName__c": "",
+            "ssot__AiAgentVersionApiName__c": "",
+        }]
+
+        with self.assertRaises(SystemExit) as ctx:
+            fetch_dc._resolve_identity(sessions, participants, _ORG_ALIAS)
+
+        msg = str(ctx.exception)
+        # Identifying string for the error class.
+        self.assertIn("no AGENT participants", msg)
+        # New (Fix #6) wording — leads with retry, then falls back to malformed.
+        self.assertIn("retry in a few minutes", msg)
+        self.assertIn("STDM materialization", msg)
+
+    def test_resolve_identity_raises_when_only_empty_field_participants(self):
+        # AGENT-role row exists but agent_api_name + agent_version are blank.
+        # Same outcome — no usable identity, same retry-hint error.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [{
+            "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+            "ssot__AiAgentApiName__c": "",
+            "ssot__AiAgentVersionApiName__c": "",
+        }]
+
+        with self.assertRaises(SystemExit) as ctx:
+            fetch_dc._resolve_identity(sessions, participants, _ORG_ALIAS)
+
+        self.assertIn("no AGENT participants", str(ctx.exception))
+
+
+class ResolveIdentityUserRowFallbackTests(unittest.TestCase):
+    """Some agent shapes (e.g. the OOTB ``MyAgent`` template) leave
+    AGENT-row ``ssot__AiAgentApiName__c`` / ``ssot__AiAgentVersionApiName__c``
+    as ``NOT_SET`` indefinitely, while USER-role rows correctly carry the
+    api_name. The downstream session is otherwise complete (interactions,
+    steps, generations all materialize), so refusing to run wastes signal.
+
+    The fallback promotes the api_name from any participant row, stamps
+    version=``v0`` (placeholder satisfying ``^v[0-9]+$`` per fs_guard), and
+    proceeds. Tests guard against regression — a future "tighten this back
+    up" refactor would re-break the MyAgent case silently.
+    """
+
+    def test_falls_back_to_user_row_api_name_when_agent_rows_not_set(self):
+        # Mirrors a real session shape observed in production:
+        # USER rows carry the api_name, AGENT rows are 'NOT_SET'.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "NOT_SET",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+
+        org_id_15, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+
+        self.assertEqual(org_id_15, _EXPECTED_ORG_ID_15)
+        self.assertEqual(agent, "MyAgent")
+        # Placeholder must satisfy the AGENT_VERSION_RE used by paths.session_dir.
+        self.assertEqual(ver, "v0")
+
+    def test_fallback_handles_blank_api_name_on_agent_row(self):
+        # AGENT row api_name is empty string (rather than the literal
+        # 'NOT_SET'). Both shapes mean the same thing per _NOT_SET.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",
+                "ssot__AiAgentVersionApiName__c": "",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "",
+                "ssot__AiAgentVersionApiName__c": "",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "MyAgent")
+        self.assertEqual(ver, "v0")
+
+    def test_fallback_picks_lexicographic_first_when_multiple_user_names(self):
+        # Multi-agent handoff session where USER rows mention both agents.
+        # The fallback uses sorted({...})[0] to match the dominant-agent
+        # policy used elsewhere in the pipeline.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "ZAgent",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "AAgent",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "NOT_SET",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "AAgent")
+        self.assertEqual(ver, "v0")
+
+    def test_agent_row_with_only_version_not_set_still_uses_strict_path(self):
+        # Defensive: AGENT row has a real api_name but version=NOT_SET. The
+        # strict candidate filter rejects it, but the fallback should still
+        # promote the api_name (avoiding a needless raise just because version
+        # was missing on the AGENT row).
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [{
+            "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+            "ssot__AiAgentApiName__c": "RealAgent",
+            "ssot__AiAgentVersionApiName__c": "NOT_SET",
+        }]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "RealAgent")
+        self.assertEqual(ver, "v0")
+
+    def test_fallback_rejects_api_name_with_invalid_shape(self):
+        # Even though a non-empty api_name is present on a USER row, if it
+        # doesn't satisfy ^[A-Za-z0-9_]+$ (fs_guard.API_NAME_RE) the fallback
+        # MUST fall through to the original SystemExit. Without this guard,
+        # paths.session_dir would later reject the dir with an opaque
+        # ValidationError far from where the bad value originated.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        for bad_name in ("Service Agent", "agent-v1", "agent.v1", "héllo"):
+            with self.subTest(bad_name=bad_name):
+                participants = [{
+                    "ssot__AiAgentSessionParticipantRole__c": "USER",
+                    "ssot__AiAgentApiName__c": bad_name,
+                    "ssot__AiAgentVersionApiName__c": "NOT_SET",
+                }]
+                with self.assertRaises(SystemExit) as ctx:
+                    fetch_dc._resolve_identity(
+                        sessions, participants, _ORG_ALIAS,
+                    )
+                # Falls through to the strict-path SystemExit, NOT a path-
+                # validation traceback from fs_guard.
+                self.assertIn("no AGENT participants", str(ctx.exception))
+
+    def test_fallback_skips_invalid_picks_valid_when_both_present(self):
+        # If multiple api_names are seen, the regex filter should drop the
+        # invalid ones and the fallback should still succeed with a valid one.
+        # Defense against a real session that mixes a malformed display-name
+        # row (e.g. legacy data) with a clean USER row.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "Service Agent",  # invalid
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",  # valid
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "MyAgent")
+        self.assertEqual(ver, "v0")
+
+    def test_fallback_returned_version_matches_agent_version_regex(self):
+        # Belt-and-braces: the placeholder version we return MUST match
+        # the ^v[0-9]+$ shape enforced by paths.session_dir / fs_guard
+        # (see scripts/_shared/paths.py:_validate_agent_triple). If a
+        # future change picks a different placeholder ('NOT_SET',
+        # 'unknown', 'v0.0', etc.) directory creation downstream will
+        # blow up. Test the exact contract here without taking a
+        # cross-skill import dependency.
+        import re
+
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [{
+            "ssot__AiAgentSessionParticipantRole__c": "USER",
+            "ssot__AiAgentApiName__c": "MyAgent",
+            "ssot__AiAgentVersionApiName__c": "NOT_SET",
+        }]
+        _, _, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertRegex(ver, r"^v[0-9]+$")
+
+
+class ResolveIdentityCrossRoleVersionHarvestTests(unittest.TestCase):
+    """Real-data shape: AGENT participant rows had api_name + version both
+    NOT_SET, but the USER rows carried the real (api_name, version) pair.
+    The prior fallback only harvested api_name from non-AGENT rows and
+    stamped version=``v0``, so the dir landed at ``<agent>__v0/`` while
+    ``assemble_dc`` reconciled the real version into the tree from
+    ``session.identity`` — dir + tree out of sync.
+
+    The cross-role harvest closes that gap: when the strict AGENT-only
+    candidate list is empty, scan ALL participant rows for a valid
+    (api_name, version) pair before falling back to the v0 placeholder.
+    Real version wins; placeholder is genuinely a last resort.
+    """
+
+    def test_user_row_carries_real_version_dir_lands_correctly(self):
+        # The exact shape found on a live session. AGENT rows: NOT_SET on
+        # both fields. USER rows: real pair.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",
+                "ssot__AiAgentVersionApiName__c": "v24",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",
+                "ssot__AiAgentVersionApiName__c": "v24",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "NOT_SET",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "MyAgent")
+        # MUST be the real version, NOT the v0 placeholder — that's the
+        # whole point of the cross-role harvest.
+        self.assertEqual(ver, "v24")
+
+    def test_falls_through_to_v0_placeholder_when_no_role_carries_version(self):
+        # Builder Previewer shape: api_name lands on a USER row but no
+        # participant row carries a real version. Must drop through to
+        # the v0 placeholder branch (which keeps the pipeline runnable
+        # for that legitimate session shape).
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "MyAgent",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "NOT_SET",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "MyAgent")
+        self.assertEqual(ver, "v0")
+
+    def test_cross_role_rejects_malformed_version(self):
+        # Someone wrote a malformed version into a USER row (e.g.
+        # 'v1.0', '1', '24'). Must NOT adopt it — fs_guard will reject
+        # the dir later. Fall through to v0 placeholder so the pipeline
+        # still runs and the assemble_dc reconcile can promote later
+        # if a real version shows up elsewhere in the tree.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        for bad_version in ("v1.0", "1", "24", "version-24", ""):
+            with self.subTest(bad_version=bad_version):
+                participants = [
+                    {
+                        "ssot__AiAgentSessionParticipantRole__c": "USER",
+                        "ssot__AiAgentApiName__c": "MyAgent",
+                        "ssot__AiAgentVersionApiName__c": bad_version,
+                    },
+                    {
+                        "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                        "ssot__AiAgentApiName__c": "NOT_SET",
+                        "ssot__AiAgentVersionApiName__c": "NOT_SET",
+                    },
+                ]
+                _, agent, ver = fetch_dc._resolve_identity(
+                    sessions, participants, _ORG_ALIAS,
+                )
+                self.assertEqual(agent, "MyAgent")
+                # Bad version rejected; placeholder kicks in.
+                self.assertEqual(ver, "v0")
+
+    def test_strict_agent_row_precedence_beats_user_row(self):
+        # When BOTH AGENT and USER rows carry valid (api_name, version)
+        # pairs, the strict-AGENT path runs first and the cross-role
+        # branch is unreachable. Pin this precedence so a future
+        # refactor can't accidentally reorder the resolution. If the
+        # AGENT row's pair were ever shadowed by a USER row's pair, the
+        # dominant-agent invariant on handoff sessions breaks.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "AAgent",  # lex-first across both rows
+                "ssot__AiAgentVersionApiName__c": "v1",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "ZAgent",  # lex-LAST overall
+                "ssot__AiAgentVersionApiName__c": "v9",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        # AGENT-row precedence: ZAgent/v9 wins, NOT AAgent/v1.
+        self.assertEqual(agent, "ZAgent")
+        self.assertEqual(ver, "v9")
+
+    def test_cross_role_picks_lex_first_when_multiple_valid_pairs(self):
+        # Handoff with two valid (api_name, version) pairs across USER
+        # rows. The strict-path dominant-agent rule applies: lex-first
+        # wins. This keeps the cross-role harvest aligned with the
+        # AGENT-only path's selection policy.
+        sessions = [{"ssot__InternalOrganizationId__c": _FULL_ORG_ID_18}]
+        participants = [
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "ZAgent",
+                "ssot__AiAgentVersionApiName__c": "v9",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "USER",
+                "ssot__AiAgentApiName__c": "AAgent",
+                "ssot__AiAgentVersionApiName__c": "v3",
+            },
+            {
+                "ssot__AiAgentSessionParticipantRole__c": "AGENT",
+                "ssot__AiAgentApiName__c": "NOT_SET",
+                "ssot__AiAgentVersionApiName__c": "NOT_SET",
+            },
+        ]
+
+        _, agent, ver = fetch_dc._resolve_identity(
+            sessions, participants, _ORG_ALIAS,
+        )
+        self.assertEqual(agent, "AAgent")
+        self.assertEqual(ver, "v3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_main.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_main.py
@@ -1,0 +1,251 @@
+"""Tests for ``fetch_dc.main`` orchestration.
+
+Drives the CLI via ``argv`` patching. Mocks at three boundaries so we
+exercise the orchestration without spawning real DC/HTTP/sf-CLI work:
+
+- ``preflight_dc_access``           returns (url, token) or raises DcAccessDenied
+- ``_run_waterfall``                stubbed; mutates ctx the way the real waterfall would
+- ``assemble_dc.main_for_session``  patched to no-op
+- ``render_dc.main_for_session``    patched to no-op
+"""
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import fetch_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import IDS, write_to_disk  # type: ignore
+
+
+def _fake_waterfall(ctx: dict) -> None:
+    """Mutate ctx the way the real waterfall would: stamp identity +
+    append a few query entries. Keeps `_write_manifest` happy."""
+    ctx["org_id_15"] = IDS.ORG_ID_15
+    ctx["agent_api_name"] = IDS.AGENT_API
+    ctx["agent_version"] = IDS.AGENT_VERSION
+    ctx["session_shape"] = "complete"
+    ctx["queries"].append({
+        "name": "sessions", "wave": 1, "rows": 1,
+        "elapsed_ms": 50, "status": "ok",
+    })
+    ctx["queries"].append({
+        "name": "interactions", "wave": 1, "rows": 3,
+        "elapsed_ms": 60, "status": "ok",
+    })
+
+
+class _MainHarness:
+    """Patch DATA_ROOT + the 4 boundary functions so main() runs offline."""
+
+    def __init__(self, *, raise_dc_access_denied=None,
+                 is_tty: bool = False):
+        self.raise_dc_access_denied = raise_dc_access_denied
+        self.is_tty = is_tty
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        # Pre-create the session dir so _write_manifest's mkdir works
+        # without surprises.
+        write_to_disk(self._tmpdir)
+        if self.raise_dc_access_denied is not None:
+            preflight_mock = mock.patch.object(
+                fetch_dc, "preflight_dc_access",
+                side_effect=self.raise_dc_access_denied,
+            )
+        else:
+            preflight_mock = mock.patch.object(
+                fetch_dc, "preflight_dc_access",
+                return_value=("https://example.salesforce.com", "TOKEN"),
+            )
+        self._patches = [
+            mock.patch.object(paths, "DATA_ROOT", self._tmpdir),
+            preflight_mock,
+            mock.patch.object(fetch_dc, "_run_waterfall",
+                              side_effect=_fake_waterfall),
+            mock.patch("assemble_dc.main_for_session", return_value=0),
+            mock.patch("render_dc.main_for_session", return_value=0),
+            mock.patch.object(fetch_dc.sys.stdin, "isatty",
+                              return_value=self.is_tty),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+
+# -----------------------------------------------------------------------------
+# Happy path
+# -----------------------------------------------------------------------------
+
+
+class MainHappyPathTests(unittest.TestCase):
+
+    def test_main_returns_zero_with_no_assemble_no_render(self):
+        with _MainHarness():
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org",
+                 "--no-assemble", "--no-render"],
+            ):
+                rc = fetch_dc.main()
+        self.assertEqual(rc, 0)
+
+    def test_main_writes_manifest_under_data_root(self):
+        with _MainHarness() as h:
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org",
+                 "--no-assemble", "--no-render"],
+            ):
+                fetch_dc.main()
+            manifest_path = (
+                h._tmpdir
+                / IDS.ORG_ID_15
+                / f"{IDS.AGENT_API}__{IDS.AGENT_VERSION}"
+                / IDS.SID
+                / "dc._session_manifest.json"
+            )
+            self.assertTrue(manifest_path.is_file())
+            manifest = json.loads(manifest_path.read_text())
+        self.assertEqual(manifest["session_id"], IDS.SID)
+        self.assertEqual(manifest["session_shape"], "complete")
+
+    def test_main_invokes_assemble_and_render_by_default(self):
+        # Without --no-assemble / --no-render, both should be called once.
+        with _MainHarness():
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org"],
+            ):
+                # Re-patch the targets at call site to capture.
+                with mock.patch("assemble_dc.main_for_session") as ams:
+                    with mock.patch("render_dc.main_for_session") as rms:
+                        rc = fetch_dc.main()
+        self.assertEqual(rc, 0)
+        ams.assert_called_once_with(IDS.SID)
+        rms.assert_called_once_with(IDS.SID)
+
+    def test_main_skips_assemble_when_flag_set(self):
+        with _MainHarness():
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org",
+                 "--no-assemble"],
+            ):
+                with mock.patch("assemble_dc.main_for_session") as ams:
+                    with mock.patch("render_dc.main_for_session") as rms:
+                        rc = fetch_dc.main()
+        self.assertEqual(rc, 0)
+        ams.assert_not_called()
+        rms.assert_called_once()
+
+    def test_main_skips_render_when_flag_set(self):
+        with _MainHarness():
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org",
+                 "--no-render"],
+            ):
+                with mock.patch("assemble_dc.main_for_session") as ams:
+                    with mock.patch("render_dc.main_for_session") as rms:
+                        rc = fetch_dc.main()
+        self.assertEqual(rc, 0)
+        ams.assert_called_once()
+        rms.assert_not_called()
+
+    def test_main_verbose_flag_propagates_to_ctx(self):
+        captured_ctx = {}
+
+        def capture(ctx):
+            captured_ctx.update(ctx)
+            _fake_waterfall(ctx)
+
+        with _MainHarness():
+            # Override the waterfall mock to capture ctx
+            with mock.patch.object(fetch_dc, "_run_waterfall",
+                                   side_effect=capture):
+                with mock.patch.object(
+                    fetch_dc.sys, "argv",
+                    ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org",
+                     "--verbose", "--no-assemble", "--no-render"],
+                ):
+                    fetch_dc.main()
+        self.assertTrue(captured_ctx["verbose"])
+
+
+# -----------------------------------------------------------------------------
+# Messaging-id input
+# -----------------------------------------------------------------------------
+
+
+class MainMessagingIdTests(unittest.TestCase):
+
+    def test_messaging_id_resolves_to_uuid_via_disk(self):
+        # Fixture's session row has the messaging id wired up. Patch the
+        # resolver at the source module so fetch_dc's lazy import sees it.
+        with _MainHarness():
+            with mock.patch(
+                "resolve_session.resolve_disk_or_live",
+                return_value=IDS.SID,
+            ):
+                with mock.patch.object(
+                    fetch_dc.sys, "argv",
+                    ["fetch_dc.py",
+                     "--session", "0MwTESTMSG12345AAA",
+                     "--org", "my-org",
+                     "--no-assemble", "--no-render"],
+                ):
+                    rc = fetch_dc.main()
+        self.assertEqual(rc, 0)
+
+
+# -----------------------------------------------------------------------------
+# DcAccessDenied → routes through _handle_dc_access_denied
+# -----------------------------------------------------------------------------
+
+
+class MainDcAccessDeniedTests(unittest.TestCase):
+
+    def test_returns_exit_dc_access_denied_in_headless(self):
+        exc = fetch_dc.DcAccessDenied("401", "Unauthorized")
+        with _MainHarness(raise_dc_access_denied=exc, is_tty=False):
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org"],
+            ):
+                with mock.patch("sys.stdout", io.StringIO()):
+                    rc = fetch_dc.main()
+        self.assertEqual(rc, fetch_dc.EXIT_DC_ACCESS_DENIED)
+
+    def test_returns_exit_dc_access_denied_in_tty_choice_1(self):
+        exc = fetch_dc.DcAccessDenied("403", "Forbidden")
+        with _MainHarness(raise_dc_access_denied=exc, is_tty=True):
+            with mock.patch.object(
+                fetch_dc.sys, "argv",
+                ["fetch_dc.py", "--session", IDS.SID, "--org", "my-org"],
+            ):
+                # Interactive prompt: feed "1" via stdin.
+                with mock.patch.object(
+                    fetch_dc.sys, "stdin",
+                    io.StringIO("1\n"),
+                ):
+                    with mock.patch.object(fetch_dc, "_log"):
+                        rc = fetch_dc.main()
+        self.assertEqual(rc, fetch_dc.EXIT_DC_ACCESS_DENIED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_waterfall.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_waterfall.py
@@ -1,0 +1,229 @@
+"""Tests for ``fetch_dc`` waterfall building blocks.
+
+Covers the per-query helpers and the manifest writer. Doesn't drive the
+full 5-wave waterfall (that's exercised live and the orchestration is
+linear over the small per-query helpers tested here).
+
+- ``_classify_session_shape`` pure
+- ``_fetch``                  HTTP + storage.save side effects
+- ``_fetch_empty``            no-HTTP record-only
+- ``_write_manifest``         on-disk JSON shape
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import fetch_dc  # type: ignore
+from config import paths  # type: ignore
+from dc import DCQueryError  # type: ignore
+from .fixtures.synthetic_session import IDS  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# _classify_session_shape — pure
+# -----------------------------------------------------------------------------
+
+
+class ClassifySessionShapeTests(unittest.TestCase):
+
+    def test_session_not_found_when_no_sessions(self):
+        out = fetch_dc._classify_session_shape(
+            sessions_count=0, steps_total=0,
+            llm_step_count=0, gw_req_count=0,
+            steps_with_generation_id=0,
+        )
+        self.assertEqual(out, "session_not_found")
+
+    def test_interactions_not_materialized_yet_when_gw_present_no_steps(self):
+        out = fetch_dc._classify_session_shape(
+            sessions_count=1, steps_total=0,
+            llm_step_count=0, gw_req_count=2,
+            steps_with_generation_id=0,
+        )
+        self.assertEqual(out, "interactions_not_materialized_yet")
+
+    def test_abandoned_before_llm_when_steps_present_no_llm(self):
+        out = fetch_dc._classify_session_shape(
+            sessions_count=1, steps_total=3,
+            llm_step_count=0, gw_req_count=0,
+            steps_with_generation_id=0,
+        )
+        self.assertEqual(out, "abandoned_before_llm")
+
+    def test_planner_ran_no_gateway_logs(self):
+        out = fetch_dc._classify_session_shape(
+            sessions_count=1, steps_total=3,
+            llm_step_count=2, gw_req_count=0,
+            steps_with_generation_id=2,
+        )
+        self.assertEqual(out, "planner_ran_no_gateway_logs")
+
+    def test_complete_for_normal_session(self):
+        out = fetch_dc._classify_session_shape(
+            sessions_count=1, steps_total=3,
+            llm_step_count=1, gw_req_count=2,
+            steps_with_generation_id=1,
+        )
+        self.assertEqual(out, "complete")
+
+
+# -----------------------------------------------------------------------------
+# _fetch — HTTP success / error paths
+# -----------------------------------------------------------------------------
+
+
+def _make_ctx(tmpdir: Path) -> dict:
+    return {
+        "session_id": IDS.SID,
+        "org_alias": "my-org",
+        "instance_url": "https://example.salesforce.com",
+        "token": "TOKEN",
+        "verbose": False,
+        "queries": [],
+        "started_at": datetime.now(timezone.utc),
+        "org_id_15": IDS.ORG_ID_15,
+        "agent_api_name": IDS.AGENT_API,
+        "agent_version": IDS.AGENT_VERSION,
+    }
+
+
+class FetchHappyPathTests(unittest.TestCase):
+
+    def test_fetch_records_query_in_manifest_and_saves_rows(self):
+        rows = [{"ssot__Id__c": "x"}]
+        with TemporaryDirectory() as t:
+            with mock.patch.object(paths, "DATA_ROOT", Path(t)):
+                ctx = _make_ctx(Path(t))
+                with mock.patch.object(fetch_dc, "post", return_value=rows):
+                    out = fetch_dc._fetch(
+                        ctx, wave=1, name="sessions",
+                        where="ssot__Id__c = 'x'",
+                    )
+        self.assertEqual(out, rows)
+        self.assertEqual(len(ctx["queries"]), 1)
+        entry = ctx["queries"][0]
+        self.assertEqual(entry["name"], "sessions")
+        self.assertEqual(entry["wave"], 1)
+        self.assertEqual(entry["rows"], 1)
+        self.assertEqual(entry["status"], "ok")
+
+    def test_fetch_records_empty_status_when_zero_rows_returned(self):
+        with TemporaryDirectory() as t:
+            with mock.patch.object(paths, "DATA_ROOT", Path(t)):
+                ctx = _make_ctx(Path(t))
+                with mock.patch.object(fetch_dc, "post", return_value=[]):
+                    out = fetch_dc._fetch(
+                        ctx, wave=1, name="sessions",
+                        where="ssot__Id__c = 'x'",
+                    )
+        self.assertEqual(out, [])
+        self.assertEqual(ctx["queries"][0]["status"], "empty")
+        self.assertIn("_unavailable_reason", ctx["queries"][0])
+
+    def test_fetch_records_join_path_when_provided(self):
+        with TemporaryDirectory() as t:
+            with mock.patch.object(paths, "DATA_ROOT", Path(t)):
+                ctx = _make_ctx(Path(t))
+                with mock.patch.object(fetch_dc, "post", return_value=[{"x": 1}]):
+                    fetch_dc._fetch(
+                        ctx, wave=2, name="generations",
+                        where="generationId__c = 'x'",
+                        join_path="Step.GenerationId__c",
+                    )
+        self.assertEqual(
+            ctx["queries"][0]["join_path"], "Step.GenerationId__c",
+        )
+
+
+class FetchErrorPathTests(unittest.TestCase):
+
+    def test_fetch_records_error_status_when_post_raises(self):
+        ctx = _make_ctx(Path("/tmp"))
+        with mock.patch.object(
+            fetch_dc, "post", side_effect=DCQueryError("http=500 ISE\n  body"),
+        ):
+            out = fetch_dc._fetch(
+                ctx, wave=1, name="sessions",
+                where="ssot__Id__c = 'x'",
+            )
+        self.assertEqual(out, [])
+        entry = ctx["queries"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["rows"], 0)
+        self.assertIn("http=500 ISE", entry["_unavailable_reason"])
+
+
+# -----------------------------------------------------------------------------
+# _fetch_empty — record-only, no HTTP
+# -----------------------------------------------------------------------------
+
+
+class FetchEmptyTests(unittest.TestCase):
+
+    def test_fetch_empty_records_skipped_status_with_reason(self):
+        ctx = _make_ctx(Path("/tmp"))
+        # Should not call HTTP at all.
+        with mock.patch.object(fetch_dc, "post") as p:
+            fetch_dc._fetch_empty(
+                ctx, wave=2, name="generations",
+                reason="no parent ids harvested",
+            )
+        p.assert_not_called()
+        entry = ctx["queries"][0]
+        self.assertEqual(entry["name"], "generations")
+        self.assertEqual(entry["status"], "skipped")
+        self.assertEqual(entry["rows"], 0)
+        self.assertEqual(
+            entry["_unavailable_reason"], "no parent ids harvested",
+        )
+
+
+# -----------------------------------------------------------------------------
+# _write_manifest — JSON shape on disk
+# -----------------------------------------------------------------------------
+
+
+class WriteManifestTests(unittest.TestCase):
+
+    def test_writes_manifest_at_canonical_path(self):
+        with TemporaryDirectory() as t:
+            with mock.patch.object(paths, "DATA_ROOT", Path(t)):
+                ctx = _make_ctx(Path(t))
+                ctx["queries"] = [
+                    {"name": "sessions", "wave": 1, "rows": 1,
+                     "elapsed_ms": 50, "status": "ok"},
+                ]
+                ctx["session_shape"] = "complete"
+                ctx["harvested_ids"] = {"interactions": [IDS.IXN_TURN]}
+                fetch_dc._write_manifest(ctx)
+
+                manifest_path = (
+                    Path(t)
+                    / IDS.ORG_ID_15
+                    / f"{IDS.AGENT_API}__{IDS.AGENT_VERSION}"
+                    / IDS.SID
+                    / "dc._session_manifest.json"
+                )
+                self.assertTrue(manifest_path.is_file())
+                manifest = json.loads(manifest_path.read_text())
+            self.assertEqual(manifest["session_id"], IDS.SID)
+            self.assertEqual(manifest["org_alias"], "my-org")
+            self.assertEqual(manifest["org_id_15"], IDS.ORG_ID_15)
+            self.assertEqual(manifest["agent_api_name"], IDS.AGENT_API)
+            self.assertEqual(manifest["agent_version"], IDS.AGENT_VERSION)
+            self.assertEqual(manifest["session_shape"], "complete")
+            self.assertEqual(len(manifest["queries"]), 1)
+            self.assertIn("started_at_utc", manifest)
+            self.assertIn("finished_at_utc", manifest)
+            self.assertIn("elapsed_ms", manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_waterfall_full.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_fetch_dc_waterfall_full.py
@@ -1,0 +1,283 @@
+"""End-to-end waterfall tests for ``fetch_dc._run_waterfall``.
+
+Mocks ``dc.post`` at the network boundary; dispatches per-query fixture
+rows so the 5-wave orchestration runs to completion. Asserts on:
+
+- per-query manifest entries (rows, status, wave)
+- harvested_ids tracking across waves
+- session_shape classification
+- on-disk dc.<name>.json artifacts written by ``storage.save``
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import fetch_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import IDS, make_rows  # type: ignore
+
+
+def _build_fixture_dispatch() -> dict[str, list[dict]]:
+    """Return rows keyed by DMO name for the synthetic session fixture."""
+    return make_rows()
+
+
+def _make_post_dispatcher(rows_by_name: dict[str, list[dict]]):
+    """Return a fake ``dc.post`` that dispatches to the right fixture
+    rows by inspecting the query_name argument."""
+    def fake_post(sql: str, instance_url: str, token: str, query_name: str = ""):
+        # `_fetch` passes the template name as query_name; that's exactly
+        # what we keyed on in the fixture.
+        return list(rows_by_name.get(query_name, []))
+    return fake_post
+
+
+def _make_ctx(tmpdir: Path) -> dict:
+    """Build the same ctx shape that fetch_dc.main() builds."""
+    return {
+        "session_id": IDS.SID,
+        "org_alias": "my-org",
+        "instance_url": "https://example.salesforce.com",
+        "token": "TOKEN",
+        "verbose": False,
+        "queries": [],
+        "started_at": datetime.now(timezone.utc),
+        "org_id_15": None,
+        "agent_api_name": None,
+        "agent_version": None,
+    }
+
+
+class _WaterfallHarness:
+    """Patch DATA_ROOT + dc.post; build ctx; run the waterfall."""
+
+    def __init__(self, *, rows_overrides: dict[str, list[dict]] | None = None):
+        self.rows_overrides = rows_overrides or {}
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        self.ctx = _make_ctx(self._tmpdir)
+        rows = _build_fixture_dispatch()
+        rows.update(self.rows_overrides)
+        self._post = _make_post_dispatcher(rows)
+        self._patches = [
+            mock.patch.object(paths, "DATA_ROOT", self._tmpdir),
+            mock.patch.object(fetch_dc, "post", side_effect=self._post),
+            # Keep _log quiet during tests
+            mock.patch.object(fetch_dc, "_log"),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+    def session_dir(self) -> Path:
+        # macOS resolves /var → /private/var; resolve once so `is_file`
+        # checks work after storage.save's path composition.
+        return (
+            self._tmpdir.resolve()
+            / IDS.ORG_ID_15
+            / f"{IDS.AGENT_API}__{IDS.AGENT_VERSION}"
+            / IDS.SID
+        )
+
+
+# -----------------------------------------------------------------------------
+# Identity stamping (wave 1a)
+# -----------------------------------------------------------------------------
+
+
+class WaterfallIdentityTests(unittest.TestCase):
+
+    def test_identity_resolved_into_ctx_after_wave_1a(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+        self.assertEqual(h.ctx["org_id_15"], IDS.ORG_ID_15)
+        self.assertEqual(h.ctx["agent_api_name"], IDS.AGENT_API)
+        self.assertEqual(h.ctx["agent_version"], IDS.AGENT_VERSION)
+
+    def test_sessions_and_participants_persisted_after_identity_resolved(self):
+        # The deferred-save flush in wave 1a should write both files.
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+            # Search the entire tmp tree — avoids macOS /private/var ↔ /var
+            # resolution discrepancies between paths.session_dir() and our
+            # locally-built path.
+            written = {p.name for p in h._tmpdir.rglob("dc.*.json")}
+        self.assertIn("dc.sessions.json", written)
+        self.assertIn("dc.participants.json", written)
+
+
+# -----------------------------------------------------------------------------
+# Wave-by-wave artifact persistence
+# -----------------------------------------------------------------------------
+
+
+class WaterfallWritesArtifactsTests(unittest.TestCase):
+
+    def test_populated_dmos_emit_dc_json_artifacts(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+            files = {p.name for p in h._tmpdir.rglob("dc.*.json")}
+        # 11 DMOs are populated in the synthetic fixture; each lands as a file.
+        for name in (
+            "dc.sessions.json", "dc.interactions.json", "dc.steps.json",
+            "dc.messages.json", "dc.participants.json",
+            "dc.gateway_requests.json", "dc.gateway_responses.json",
+            "dc.generations.json", "dc.content_quality.json",
+            "dc.gateway_records.json", "dc.gateway_request_tags.json",
+        ):
+            self.assertIn(name, files, f"{name} should be on disk")
+
+    def test_zero_row_dmos_skipped_no_artifact(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+            files = {p.name for p in h._tmpdir.rglob("dc.*.json")}
+        # `tags` and friends have empty rows → no on-disk artifact.
+        self.assertNotIn("dc.tags.json", files)
+        self.assertNotIn("dc.tag_definitions.json", files)
+
+
+# -----------------------------------------------------------------------------
+# Manifest entries (one per query)
+# -----------------------------------------------------------------------------
+
+
+class WaterfallManifestTests(unittest.TestCase):
+
+    def test_24_query_entries_appended(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+        names = [q["name"] for q in h.ctx["queries"]]
+        # Exactly the 24 templates fetch_dc declares (no duplicates from
+        # tag_definitions retry: synthetic fixture's tag_definitions is
+        # empty, so retry runs once and overwrites the prior empty entry).
+        self.assertGreaterEqual(len(names), 24)
+        # Critical names appear at least once
+        for required in ("sessions", "interactions", "steps", "participants",
+                         "gateway_requests", "generations", "messages"):
+            self.assertIn(required, names)
+
+    def test_each_query_has_wave_status_rows_elapsed_ms(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+        for q in h.ctx["queries"]:
+            self.assertIn("name", q)
+            self.assertIn("wave", q)
+            self.assertIn("rows", q)
+            self.assertIn("status", q)
+            self.assertIn("elapsed_ms", q)
+            self.assertIn(q["status"], ("ok", "empty", "skipped", "error"))
+
+
+# -----------------------------------------------------------------------------
+# harvested_ids
+# -----------------------------------------------------------------------------
+
+
+class WaterfallHarvestedIdsTests(unittest.TestCase):
+
+    def test_harvested_ids_match_fixture_counts(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+            harvested = h.ctx["harvested_ids"]
+        self.assertEqual(harvested["sessions"], 1)
+        self.assertEqual(harvested["interactions"], 3)
+        self.assertEqual(harvested["steps_total"], 3)
+        self.assertEqual(harvested["gateway_request_ids"], 2)
+        # moments DMO is empty; fetch_dc falls through to the participants
+        # harvest (AGENT participant row carries IDS.AGENT_API = "DemoAgent").
+        from .fixtures.synthetic_session import IDS  # type: ignore
+        self.assertEqual(harvested["agents_observed"], [IDS.AGENT_API])
+
+    def test_steps_by_type_categorizes_correctly(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+            sbt = h.ctx["harvested_ids"]["steps_by_type"]
+        # Synthetic fixture has 1 each of TOPIC_STEP, ACTION_STEP, TRUST_GUARDRAILS_STEP
+        self.assertEqual(sbt["ACTION_STEP"], 1)
+        self.assertEqual(sbt["TOPIC_STEP"], 1)
+        self.assertEqual(sbt["TRUST_GUARDRAILS_STEP"], 1)
+        self.assertEqual(sbt["LLM_STEP"], 0)
+
+
+# -----------------------------------------------------------------------------
+# Session-shape classification
+# -----------------------------------------------------------------------------
+
+
+class WaterfallSessionShapeTests(unittest.TestCase):
+
+    def test_normal_session_classified_as_complete(self):
+        with _WaterfallHarness() as h:
+            fetch_dc._run_waterfall(h.ctx)
+        self.assertEqual(h.ctx["session_shape"], "complete")
+
+    def test_no_steps_with_gateway_requests_classified_as_lag(self):
+        # Override: empty interactions/steps/messages but keep gateway_requests.
+        rows = make_rows()
+        rows["interactions"] = []
+        rows["steps"] = []
+        rows["messages"] = []
+        with _WaterfallHarness(rows_overrides=rows) as h:
+            fetch_dc._run_waterfall(h.ctx)
+        self.assertEqual(h.ctx["session_shape"], "interactions_not_materialized_yet")
+
+    def test_steps_no_llm_no_gateway_classified_as_abandoned(self):
+        # ACTION_STEP + TOPIC_STEP exist but no LLM_STEP and no gateway_requests.
+        rows = make_rows()
+        rows["gateway_requests"] = []
+        rows["gateway_responses"] = []
+        rows["gateway_records"] = []
+        rows["gateway_request_tags"] = []
+        with _WaterfallHarness(rows_overrides=rows) as h:
+            fetch_dc._run_waterfall(h.ctx)
+        self.assertEqual(h.ctx["session_shape"], "abandoned_before_llm")
+
+
+# -----------------------------------------------------------------------------
+# Empty harvest branches (zero IDs → _fetch_empty path)
+# -----------------------------------------------------------------------------
+
+
+class WaterfallEmptyHarvestTests(unittest.TestCase):
+
+    def test_no_interactions_skips_steps_via_fetch_empty(self):
+        rows = make_rows()
+        rows["interactions"] = []
+        with _WaterfallHarness(rows_overrides=rows) as h:
+            fetch_dc._run_waterfall(h.ctx)
+        # The steps query should be in the manifest as 'skipped'.
+        steps_entries = [q for q in h.ctx["queries"] if q["name"] == "steps"]
+        self.assertEqual(len(steps_entries), 1)
+        self.assertEqual(steps_entries[0]["status"], "skipped")
+        self.assertIn("no interactions", steps_entries[0]["_unavailable_reason"])
+
+    def test_no_gateway_requests_skips_audit_chain(self):
+        rows = make_rows()
+        rows["gateway_requests"] = []
+        with _WaterfallHarness(rows_overrides=rows) as h:
+            fetch_dc._run_waterfall(h.ctx)
+        # gateway_responses + tags + records + metadata + llm all skipped
+        for name in ("gateway_responses", "gateway_request_tags",
+                     "gateway_records", "gateway_request_metadata",
+                     "gateway_request_llm"):
+            entries = [q for q in h.ctx["queries"] if q["name"] == name]
+            self.assertEqual(entries[0]["status"], "skipped",
+                             f"{name} should be skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_identity_coherence.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_identity_coherence.py
@@ -1,0 +1,327 @@
+"""Top-level vs nested identity coherence under manifest-placeholder shapes.
+
+Regression coverage for the bug where ``fetch_dc._resolve_identity`` falls
+through its strict AGENT-participant pick (fetch_dc.py:570-597) on agent
+shapes like MyAgent — leaving the manifest with
+``agent_version="v0"`` (placeholder) — while wave 5 then materializes
+``gateway_request_tags`` rows that carry the real ``v24``. The harvester
+``_build_session_identity`` correctly reads ``v24`` into
+``session.identity.agent_version``, but the top-level ``identity`` block
+was previously copied straight off the manifest and silently disagreed
+with the same JSON file's nested copy.
+
+These tests pin the promotion policy implemented by
+``_promote_identity`` / ``_reconcile_top_identity``:
+
+  - manifest "v0" + session "v24"     -> top promotes to v24
+  - manifest "v3" + session None      -> top stays v3 (manifest wins)
+  - manifest api None + session real  -> top promotes
+  - manifest "v3" + session "v5"      -> top stays v3 (manifest wins;
+                                          strict AGENT pick is intentional)
+  - manifest "v0" + session "v0"      -> top stays v0 (no real value
+                                          available; placeholder leak
+                                          remains visible to investigator)
+
+Plus a full round-trip through ``assemble_dc.assemble`` to confirm the
+top-level and nested identity records agree on a real MyAgent-shape
+session.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import (  # type: ignore
+    IDS, make_manifest, make_rows, write_to_disk,
+)
+
+
+# -----------------------------------------------------------------------------
+# Unit tests for _promote_identity (single-field policy)
+# -----------------------------------------------------------------------------
+
+
+class PromoteVersionTests(unittest.TestCase):
+    """`_promote_identity(..., kind="version")` — placeholder-only promotion."""
+
+    def test_v0_placeholder_promoted_when_session_has_real_version(self):
+        out = assemble_dc._promote_identity("v0", "v24", kind="version")
+        self.assertEqual(out, "v24")
+
+    def test_keeps_manifest_value_when_session_identity_is_none(self):
+        # Manifest already real; no reason to look elsewhere.
+        out = assemble_dc._promote_identity("v3", None, kind="version")
+        self.assertEqual(out, "v3")
+
+    def test_keeps_v0_when_session_also_returns_v0(self):
+        # No real value harvestable. Placeholder remains visible so
+        # the investigator can still see the resolution failed.
+        out = assemble_dc._promote_identity("v0", "v0", kind="version")
+        self.assertEqual(out, "v0")
+
+    def test_keeps_v0_when_session_value_is_garbage(self):
+        # Session shouldn't be able to "promote" a non-version-shaped string.
+        out = assemble_dc._promote_identity("v0", "garbage", kind="version")
+        self.assertEqual(out, "v0")
+
+    def test_keeps_v0_when_session_value_is_none(self):
+        out = assemble_dc._promote_identity("v0", None, kind="version")
+        self.assertEqual(out, "v0")
+
+    def test_no_promotion_when_both_real_but_disagree(self):
+        # Strict AGENT-row pick is intentional — manifest wins.
+        out = assemble_dc._promote_identity("v3", "v5", kind="version")
+        self.assertEqual(out, "v3")
+
+
+class PromoteApiNameTests(unittest.TestCase):
+    """`_promote_identity(..., kind="api_name")` — NOT_SET-ish promotion."""
+
+    def test_none_manifest_promoted_when_session_has_value(self):
+        out = assemble_dc._promote_identity(
+            None, "MyAgent", kind="api_name",
+        )
+        self.assertEqual(out, "MyAgent")
+
+    def test_not_set_string_promoted_when_session_has_value(self):
+        out = assemble_dc._promote_identity(
+            "NOT_SET", "MyAgent", kind="api_name",
+        )
+        self.assertEqual(out, "MyAgent")
+
+    def test_empty_manifest_promoted_when_session_has_value(self):
+        out = assemble_dc._promote_identity("", "MyAgent", kind="api_name")
+        self.assertEqual(out, "MyAgent")
+
+    def test_keeps_manifest_value_when_session_is_none(self):
+        # Symmetric of the version case — manifest wins when session
+        # has nothing to offer.
+        out = assemble_dc._promote_identity(
+            "MyAgent", None, kind="api_name",
+        )
+        self.assertEqual(out, "MyAgent")
+
+    def test_keeps_manifest_when_both_real(self):
+        out = assemble_dc._promote_identity(
+            "ManifestAgent", "SessionAgent", kind="api_name",
+        )
+        self.assertEqual(out, "ManifestAgent")
+
+
+# -----------------------------------------------------------------------------
+# Reconcile helper — composed policy across both fields + stderr note
+# -----------------------------------------------------------------------------
+
+
+class ReconcileTopIdentityTests(unittest.TestCase):
+
+    def test_reconcile_emits_stderr_note_when_version_promoted(self):
+        manifest = {"agent_api_name": "MyAgent", "agent_version": "v0"}
+        session_identity = {
+            "agent_api_name": None,
+            "agent_version": "v24",
+        }
+        with mock.patch("sys.stderr") as fake_stderr:
+            top = assemble_dc._reconcile_top_identity(
+                manifest, session_identity, "00DXX0000000ABC",
+            )
+        self.assertEqual(top["agent_version"], "v24")
+        self.assertEqual(top["agent_api_name"], "MyAgent")
+        self.assertEqual(top["org_id_15"], "00DXX0000000ABC")
+        # The stderr note format is part of the contract — at least
+        # one print call mentioning "promoted" must fire.
+        emitted = [
+            call.args[0] for call in fake_stderr.write.call_args_list
+            if call.args
+        ]
+        self.assertTrue(
+            any("promoted" in str(s) for s in emitted),
+            f"expected promotion note on stderr; got writes: {emitted}",
+        )
+
+    def test_reconcile_silent_when_no_promotion_needed(self):
+        manifest = {"agent_api_name": "DemoAgent", "agent_version": "v5"}
+        session_identity = {
+            "agent_api_name": "DemoAgent",
+            "agent_version": "v5",
+        }
+        with mock.patch("sys.stderr") as fake_stderr:
+            top = assemble_dc._reconcile_top_identity(
+                manifest, session_identity, "00DXX0000000ABC",
+            )
+        self.assertEqual(top["agent_version"], "v5")
+        emitted = [
+            call.args[0] for call in fake_stderr.write.call_args_list
+            if call.args
+        ]
+        self.assertFalse(
+            any("promoted" in str(s) for s in emitted),
+            f"unexpected promotion note: {emitted}",
+        )
+
+
+# -----------------------------------------------------------------------------
+# Full-fixture round-trip — MyAgent-shape session through assemble()
+# -----------------------------------------------------------------------------
+
+
+def _serviceagent2_shape_disk_writer(tmp_root: Path) -> Path:
+    """Materialize a MyAgent-shape session under tmp_root.
+
+    Mutates the synthetic fixture so that:
+
+      - manifest carries the placeholder ``agent_version="v0"`` (mirrors
+        what ``fetch_dc._resolve_identity``'s fallback stamps).
+      - the AGENT participant row has its ``ssot__AiAgentVersionApiName__c``
+        cleared to NOT_SET (so ``_build_session_identity`` doesn't pick up
+        a version from there).
+      - ``gateway_request_tags`` carries an ``agent_version_api_name=v24``
+        tag against the declared GW request, so the harvester finds the
+        real value.
+
+    The session dir lives under ``<org>/<api_name>__v0/<sid>/`` to match the
+    placeholder-stamped layout fetch_dc actually writes on this path.
+    """
+    rows = make_rows()
+
+    # AGENT row: clear version so _build_session_identity has no hint
+    # via that path; the harvest must come from gateway_request_tags.
+    for p in rows["participants"]:
+        if p.get("ssot__AiAgentSessionParticipantRole__c") == "AGENT":
+            p["ssot__AiAgentVersionApiName__c"] = "NOT_SET"
+
+    # Add the agent_version_api_name tag against the declared GW request.
+    rows["gateway_request_tags"].append({
+        "id__c": "tag-agent-version",
+        "parent__c": IDS.GW_REQ_DECLARED,
+        "tag__c": "agent_version_api_name",
+        "tagValue__c": '"v24"',  # quoted form mirrors live shape
+    })
+    # Plus agent_developer_name so session.identity.agent_api_name
+    # also gets a real value to test the api_name path.
+    rows["gateway_request_tags"].append({
+        "id__c": "tag-agent-dev",
+        "parent__c": IDS.GW_REQ_DECLARED,
+        "tag__c": "agent_developer_name",
+        "tagValue__c": '"MyAgent"',
+    })
+
+    # Manifest: placeholder version, real api_name (matches the
+    # MyAgent fallback's actual output — it stamps api_name from
+    # any participant row but version is forced to "v0").
+    manifest = make_manifest()
+    manifest["agent_api_name"] = "MyAgent"
+    manifest["agent_version"] = "v0"
+    manifest["org_id_15"] = IDS.ORG_ID_15
+
+    # Layout: <org>/<api_name>__v0/<sid>/ — the placeholder-shaped dir.
+    sdir = tmp_root / IDS.ORG_ID_15 / "MyAgent__v0" / IDS.SID
+    sdir.mkdir(parents=True, exist_ok=True)
+
+    (sdir / "dc._session_manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+    for name, rs in rows.items():
+        if rs:
+            (sdir / f"dc.{name}.json").write_text(
+                json.dumps(rs, indent=2) + "\n"
+            )
+
+    # Breadcrumb for _find_session_dir's primary path.
+    link_dir = tmp_root / IDS.ORG_ID_15 / "_sessions"
+    link_dir.mkdir(parents=True, exist_ok=True)
+    (link_dir / f"{IDS.SID}.link").write_text(
+        f"../MyAgent__v0/{IDS.SID}\n"
+    )
+    return sdir
+
+
+class AssembleEndToEndIdentityCoherenceTests(unittest.TestCase):
+    """The bug repro — top-level vs nested identity must agree after fix."""
+
+    def test_top_identity_promoted_when_manifest_has_v0_and_tags_have_v24(self):
+        with TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            _serviceagent2_shape_disk_writer(tmp_root)
+            with mock.patch.object(paths, "DATA_ROOT", tmp_root):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+        # The harvester (_build_session_identity) reads v24 from tags.
+        self.assertEqual(tree["session"]["identity"]["agent_version"], "v24")
+        # The top-level — previously v0 — must now agree.
+        self.assertEqual(tree["identity"]["agent_version"], "v24")
+
+    def test_top_and_session_identity_agree_on_agent_version(self):
+        with TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            _serviceagent2_shape_disk_writer(tmp_root)
+            with mock.patch.object(paths, "DATA_ROOT", tmp_root):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+        # The whole point of the fix.
+        self.assertEqual(
+            tree["identity"]["agent_version"],
+            tree["session"]["identity"]["agent_version"],
+        )
+
+    def test_api_name_top_level_keeps_manifest_when_session_returns_null(self):
+        # Mirror the live live-verification observation: top-level
+        # api_name is "MyAgent" (from manifest), session.identity
+        # api_name is None because no agent_developer_name tag fired.
+        # Strip the agent_developer_name tag we added in the helper.
+        with TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            _serviceagent2_shape_disk_writer(tmp_root)
+            sdir = tmp_root / IDS.ORG_ID_15 / "MyAgent__v0" / IDS.SID
+            tags_path = sdir / "dc.gateway_request_tags.json"
+            tags = json.loads(tags_path.read_text())
+            tags = [t for t in tags if t.get("tag__c") != "agent_developer_name"]
+            tags_path.write_text(json.dumps(tags, indent=2) + "\n")
+
+            with mock.patch.object(paths, "DATA_ROOT", tmp_root):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+        # session.identity.agent_api_name None — no harvestable value.
+        self.assertIsNone(tree["session"]["identity"]["agent_api_name"])
+        # Top-level keeps manifest's "MyAgent" — promotion does NOT
+        # erase a real manifest value when session has nothing to offer.
+        self.assertEqual(tree["identity"]["agent_api_name"], "MyAgent")
+
+
+# -----------------------------------------------------------------------------
+# Sanity: the existing happy-path fixture still produces matching identity
+# (regression guard against the fix mutating the simple case).
+# -----------------------------------------------------------------------------
+
+
+class HappyPathStillCoherentTests(unittest.TestCase):
+
+    def test_happy_path_unchanged(self):
+        # The synthetic fixture's gateway_request_tags don't include
+        # `agent_version_api_name`, so session.identity.agent_version is
+        # None on this path. The fix's policy preserves the manifest
+        # value ("v5") in that case — verifying the no-promote branch
+        # doesn't accidentally null out the top-level when the harvest
+        # layer has nothing to offer.
+        with TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            write_to_disk(tmp_root)
+            with mock.patch.object(paths, "DATA_ROOT", tmp_root):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+        self.assertEqual(tree["identity"]["agent_version"], IDS.AGENT_VERSION)
+        self.assertEqual(tree["identity"]["agent_api_name"], IDS.AGENT_API)
+        # session.identity may be None here (no agent_version_api_name tag);
+        # the top-level keeps the manifest's real value, which is the point.
+        self.assertIn(
+            tree["session"]["identity"]["agent_version"],
+            (None, IDS.AGENT_VERSION),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_branches.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_branches.py
@@ -1,0 +1,256 @@
+"""Additional ``render_dc`` tests targeting branches not covered by
+``test_render_dc_integration.py``:
+
+- ``main_for_session``     reads tree + manifest from disk; emits markdown
+- ``main``                  argparse → main_for_session
+- ``_parse_finish_reason``  HTML-escaped JSON parsing
+- ``_decoded_line``         tool-call JSON detection
+- mermaid sequence diagram  (requires ≥2 ACTION_STEPs OR an error_text)
+- mermaid topic flowchart   (requires repeating topics across turns)
+- schema-version refusal    on unsupported _schema_version
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+import render_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import IDS, write_to_disk  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# main_for_session — disk-backed entry point
+# -----------------------------------------------------------------------------
+
+
+class MainForSessionTests(unittest.TestCase):
+
+    def test_reads_tree_writes_summary_md(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            sdir = write_to_disk(tmp)
+            with mock.patch.object(paths, "DATA_ROOT", tmp):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+                (sdir / "dc._session_tree.json").write_text(
+                    json.dumps(tree, default=str)
+                )
+                rc = render_dc.main_for_session(IDS.SID)
+                self.assertEqual(rc, 0)
+                summary_path = sdir / "dc._session_summary.md"
+                self.assertTrue(summary_path.is_file())
+                self.assertGreater(len(summary_path.read_text()), 1000)
+
+    def test_raises_when_tree_missing(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            write_to_disk(tmp)  # creates session dir but not tree
+            with mock.patch.object(paths, "DATA_ROOT", tmp):
+                with self.assertRaises(SystemExit) as ctx:
+                    render_dc.main_for_session(IDS.SID)
+        self.assertIn("tree not found", str(ctx.exception))
+
+    def test_tolerates_missing_manifest_with_warning(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            sdir = write_to_disk(tmp)
+            with mock.patch.object(paths, "DATA_ROOT", tmp):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+                (sdir / "dc._session_tree.json").write_text(
+                    json.dumps(tree, default=str)
+                )
+                # Wipe the manifest. main_for_session should still succeed
+                # (manifest is optional; missing → no manifest-driven sections).
+                (sdir / "dc._session_manifest.json").unlink()
+                rc = render_dc.main_for_session(IDS.SID)
+                self.assertEqual(rc, 0)
+
+
+# -----------------------------------------------------------------------------
+# main — argparse + resolve
+# -----------------------------------------------------------------------------
+
+
+class MainTests(unittest.TestCase):
+
+    def test_main_invokes_main_for_session_with_resolved_sid(self):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            sdir = write_to_disk(tmp)
+            with mock.patch.object(paths, "DATA_ROOT", tmp):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+                (sdir / "dc._session_tree.json").write_text(
+                    json.dumps(tree, default=str)
+                )
+                with mock.patch.object(
+                    render_dc.sys, "argv",
+                    ["render_dc.py", "--session", IDS.SID],
+                ):
+                    rc = render_dc.main()
+        self.assertEqual(rc, 0)
+
+
+# -----------------------------------------------------------------------------
+# _parse_finish_reason — HTML-escaped JSON
+# -----------------------------------------------------------------------------
+
+
+class ParseFinishReasonTests(unittest.TestCase):
+
+    def test_extracts_stop_from_double_escaped_json(self):
+        # Real wire format: `{&quot;finish_reason&quot;:&quot;\"stop\"&quot;}`
+        params = '{&quot;finish_reason&quot;:&quot;\\"stop\\"&quot;}'
+        self.assertEqual(render_dc._parse_finish_reason(params), "stop")
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(render_dc._parse_finish_reason(None))
+        self.assertIsNone(render_dc._parse_finish_reason(""))
+
+    def test_returns_none_for_unparseable_json(self):
+        self.assertIsNone(render_dc._parse_finish_reason("<<<not json>>>"))
+
+    def test_returns_none_when_finish_reason_not_string(self):
+        params = '{&quot;finish_reason&quot;: 42}'
+        self.assertIsNone(render_dc._parse_finish_reason(params))
+
+
+# -----------------------------------------------------------------------------
+# _decoded_line — tool-call JSON detection
+# -----------------------------------------------------------------------------
+
+
+class DecodedLineTests(unittest.TestCase):
+
+    def test_returns_dash_for_empty(self):
+        self.assertEqual(render_dc._decoded_line(None), "—")
+        self.assertEqual(render_dc._decoded_line(""), "—")
+
+    def test_renders_quoted_truncated_text_for_plain_string(self):
+        out = render_dc._decoded_line("Hello world")
+        self.assertEqual(out, '"Hello world"')
+
+    def test_summarizes_tool_call_json(self):
+        # Real wire shape: HTML-escaped JSON with toolInvocations array.
+        body = (
+            '{"toolInvocations":[{'
+            '"function":{"name":"search_orders",'
+            '"arguments":"{\\"query\\":\\"refund\\"}"}}],'
+            '"content":"I will search for orders."}'
+        )
+        out = render_dc._decoded_line(body)
+        self.assertIn("1 tool call", out)
+        self.assertIn("search_orders", out)
+        self.assertIn("query=", out)
+
+
+# -----------------------------------------------------------------------------
+# Multi-turn fixture for mermaid branches
+# -----------------------------------------------------------------------------
+
+
+def _add_extra_turn_to_tree(tree: dict) -> None:
+    """Mutate the assembled tree to have a 2nd TURN with a topic that
+    repeats — triggers both the sequence diagram and the topic flowchart.
+    """
+    # Tag the existing turn with a topic
+    sess = tree["session"]
+    for iv in sess["interactions"]:
+        if iv["type"] == "TURN":
+            iv["topic"] = "Refunds"
+            # Inject a 2nd action step so sequence diagram passes its
+            # has_error/len(actions)>=2 gate.
+            iv["steps"].append({
+                "id": "step-extra-action",
+                "type": "ACTION_STEP",
+                "name": "ExtraAction",
+                "start_ts": "2026-04-22T10:00:42.000Z",
+                "end_ts":   "2026-04-22T10:00:48.000Z",
+                "error_text": None,
+                "generation": None,
+                "gateway_request": None,
+            })
+            break
+    # Append a 2nd TURN that uses the same topic — triggers flowchart edges.
+    sess["interactions"].append({
+        "id": "ixn-turn-002b",
+        "type": "TURN",
+        "topic": "Refunds",
+        "trace_id": "trace-2nd",
+        "start_ts": "2026-04-22T10:01:05.000Z",
+        "end_ts":   "2026-04-22T10:01:25.000Z",
+        "steps": [
+            {"id": "step-2a", "type": "ACTION_STEP",
+             "name": "ActionA",
+             "start_ts": "2026-04-22T10:01:08.000Z",
+             "end_ts":   "2026-04-22T10:01:12.000Z",
+             "error_text": None,
+             "generation": None,
+             "gateway_request": None},
+            {"id": "step-2b", "type": "ACTION_STEP",
+             "name": "ActionB",
+             "start_ts": "2026-04-22T10:01:13.000Z",
+             "end_ts":   "2026-04-22T10:01:18.000Z",
+             "error_text": "Action B failed: timeout",
+             "generation": None,
+             "gateway_request": None},
+        ],
+        "messages": [
+            {"role": "USER", "text": "I want to escalate.", "ts": None},
+            {"role": "AGENT", "text": "Connecting you to a human.", "ts": None},
+        ],
+        "tag_associations": [], "telemetry_spans": [],
+        "timestamp_bound_gateway_calls": [],
+    })
+
+
+class MultiTurnRenderTests(unittest.TestCase):
+
+    def _assemble_and_render(self, tree_mutator):
+        with TemporaryDirectory() as t:
+            tmp = Path(t)
+            sdir = write_to_disk(tmp)
+            with mock.patch.object(paths, "DATA_ROOT", tmp):
+                tree, _ = assemble_dc.assemble(IDS.SID)
+                tree_mutator(tree)
+                manifest = json.loads(
+                    (sdir / "dc._session_manifest.json").read_text()
+                )
+                return render_dc.render(tree, manifest=manifest, session_dir=sdir)
+
+    def test_sequence_diagram_emitted_when_turn_has_two_actions(self):
+        md = self._assemble_and_render(_add_extra_turn_to_tree)
+        self.assertIn("sequenceDiagram", md)
+        self.assertIn("participant U as USER", md)
+        self.assertIn("participant P as Planner", md)
+
+    def test_topic_flowchart_emitted_when_topics_repeat(self):
+        md = self._assemble_and_render(_add_extra_turn_to_tree)
+        self.assertIn("flowchart LR", md)
+        self.assertIn("Refunds", md)
+
+
+# -----------------------------------------------------------------------------
+# Schema-version guard
+# -----------------------------------------------------------------------------
+
+
+class SchemaVersionGuardTests(unittest.TestCase):
+
+    def test_render_refuses_unsupported_schema_version(self):
+        # _assert_schema_version reads session._schema_version (per impl).
+        bad_tree = {
+            "session": {"id": IDS.SID, "interactions": [], "_schema_version": 999},
+        }
+        with self.assertRaises(SystemExit) as ctx:
+            render_dc.render(bad_tree)
+        self.assertIn("unsupported tree _schema_version", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_gateway_direct.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_gateway_direct.py
@@ -1,0 +1,130 @@
+"""Tests for ``render_dc._render_gateway_direct``.
+
+Feeds a gateway-direct tree (built by ``_assemble_gateway_direct``)
+through the public ``render()`` entry point and asserts on the emitted
+markdown. The intent is to pin the section contract without coupling to
+exact whitespace:
+
+  - lag banner appears
+  - gateway chain table has the expected header
+  - one H4 per gateway_request_id in per-call detail
+  - per-call detail includes a fenced code block for the prompt
+  - Interaction-dependent sections are ABSENT (Hierarchical trace,
+    Per-turn summary, Transcript, Session counts)
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+from assemble_dc import _assemble_gateway_direct  # type: ignore
+from render_dc import render  # type: ignore
+
+from .test_assemble_dc_gateway_direct import (
+    _SID,
+    _make_manifest,
+    _make_rows,
+)
+
+
+class RenderGatewayDirectTests(unittest.TestCase):
+
+    def setUp(self):
+        rows = _make_rows()
+        manifest = _make_manifest()
+        self.tree = _assemble_gateway_direct(_SID, rows, manifest, parse_warnings=[])
+        # Opt into prompt rendering — these tests exercise the *content* of
+        # the per-call detail block, not the default-gating contract. The
+        # default-gating tests live in test_render_dc_show_prompts_gating.py.
+        self.md = render(self.tree, manifest, show_prompts=True)
+
+    def test_starts_with_session_heading(self):
+        self.assertTrue(self.md.startswith(f"# Session {_SID}"))
+
+    def test_lag_banner_present(self):
+        self.assertIn("STDM Interaction/Step/Message DMOs have not yet "
+                      "materialized", self.md)
+        self.assertIn("Re-run in 24–72h", self.md)
+
+    def test_gateway_chain_table_header(self):
+        self.assertIn("| Model | Provider", self.md)
+        self.assertIn("Prompt tok", self.md)
+        self.assertIn("Response ts", self.md)
+
+    def test_h4_per_gateway_call(self):
+        """3 fixture gateway_requests → 3 `#### LLM call N` headings."""
+        h4_count = self.md.count("#### LLM call ")
+        self.assertGreaterEqual(h4_count, 3)
+
+    def test_prompt_fenced_code_block(self):
+        """Per-call detail wraps the prompt in a fenced code block."""
+        self.assertIn("```", self.md)
+        self.assertIn("This is the prompt body for gw-1.", self.md)
+
+    def test_no_hierarchical_trace_section(self):
+        self.assertNotIn("Hierarchical trace", self.md)
+        self.assertNotIn("Complete hierarchical trace", self.md)
+
+    def test_no_per_turn_summary_section(self):
+        self.assertNotIn("Per-turn summary", self.md)
+
+    def test_no_transcript_section(self):
+        self.assertNotIn("## Transcript", self.md)
+
+    def test_session_identity_section_present(self):
+        self.assertIn("## Session identity", self.md)
+
+    def test_prompt_with_triple_backticks_uses_longer_fence(self):
+        """Prompts containing ``` must get a 4+-backtick fence.
+
+        LLM prompt templates commonly embed triple-backtick tool-use
+        examples. A hardcoded ``` fence would close early and corrupt
+        every section after the first such prompt.
+        """
+        rows = _make_rows()
+        rows["gateway_requests"][0]["prompt__c"] = (
+            "See this example:\n"
+            "```python\n"
+            "print('hi')\n"
+            "```\n"
+            "End of example."
+        )
+        manifest = _make_manifest()
+        tree = _assemble_gateway_direct(_SID, rows, manifest, parse_warnings=[])
+        md = render(tree, manifest, show_prompts=True)
+        self.assertIn("````", md)  # 4-backtick fence
+        self.assertIn("print('hi')", md)
+        # The inner triple-backticks survive intact.
+        self.assertIn("```python", md)
+
+    def test_prompt_with_four_backticks_uses_five_backtick_fence(self):
+        """Fence length scales with the longest inner run of backticks."""
+        rows = _make_rows()
+        rows["gateway_requests"][0]["prompt__c"] = (
+            "Edge case:\n````\nnested\n````\nDone."
+        )
+        manifest = _make_manifest()
+        tree = _assemble_gateway_direct(_SID, rows, manifest, parse_warnings=[])
+        md = render(tree, manifest, show_prompts=True)
+        self.assertIn("`````", md)  # 5-backtick fence
+
+    def test_prompt_truncation_marker_for_oversized_prompt(self):
+        """Display-only 64 KB cap: prompts over the limit carry a truncation marker.
+
+        Raw JSON on disk is untouched — the cap only applies to markdown.
+        """
+        rows = _make_rows()
+        # Inflate the first prompt to 80 KB of ASCII.
+        rows["gateway_requests"][0]["prompt__c"] = "x" * 80_000
+        manifest = _make_manifest()
+        tree = _assemble_gateway_direct(_SID, rows, manifest, parse_warnings=[])
+        md = render(tree, manifest, show_prompts=True)
+        self.assertIn("[truncated; full prompt in dc.gateway_requests.json]", md)
+        # The on-tree prompt_text is still the full 80 KB — the cap is render-only.
+        self.assertEqual(len(tree["session"]["gateway_chain"][0]["prompt_text"]),
+                         80_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_helpers.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_helpers.py
@@ -1,0 +1,291 @@
+"""Tests for ``render_dc`` pure-function helpers.
+
+The renderer is large (863 stmts); covering its end-to-end markdown
+output requires a complex tree fixture. These tests target the small,
+pure helpers — they're cheap to test and account for ~150 stmts of the
+gap.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import render_dc  # type: ignore
+
+
+# -----------------------------------------------------------------------------
+# _parse_iso
+# -----------------------------------------------------------------------------
+
+
+class ParseIsoTests(unittest.TestCase):
+
+    def test_returns_none_for_falsy_input(self):
+        self.assertIsNone(render_dc._parse_iso(None))
+        self.assertIsNone(render_dc._parse_iso(""))
+
+    def test_parses_z_terminated(self):
+        self.assertEqual(
+            render_dc._parse_iso("2026-04-22T10:00:00Z"),
+            datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_returns_none_for_unparseable(self):
+        self.assertIsNone(render_dc._parse_iso("not-a-timestamp"))
+
+
+# -----------------------------------------------------------------------------
+# _fmt_offset
+# -----------------------------------------------------------------------------
+
+
+class FmtOffsetTests(unittest.TestCase):
+
+    def test_returns_dash_when_timestamp_or_start_missing(self):
+        anchor = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(render_dc._fmt_offset(None, anchor), "—")
+        self.assertEqual(render_dc._fmt_offset("2026-04-22T10:00:00Z", None), "—")
+
+    def test_formats_offset_with_3_decimals(self):
+        anchor = datetime(2026, 4, 22, 10, 0, 0, tzinfo=timezone.utc)
+        out = render_dc._fmt_offset("2026-04-22T10:00:01.234Z", anchor)
+        self.assertEqual(out, "+1.234s")
+
+
+# -----------------------------------------------------------------------------
+# _fmt_duration_ms
+# -----------------------------------------------------------------------------
+
+
+class FmtDurationMsTests(unittest.TestCase):
+
+    def test_dash_when_either_side_missing(self):
+        self.assertEqual(render_dc._fmt_duration_ms(None, "2026-04-22T10:00:00Z"), "—")
+        self.assertEqual(render_dc._fmt_duration_ms("2026-04-22T10:00:00Z", None), "—")
+
+    def test_returns_int_ms_with_unit(self):
+        out = render_dc._fmt_duration_ms(
+            "2026-04-22T10:00:00.000Z", "2026-04-22T10:00:00.123Z",
+        )
+        self.assertEqual(out, "123ms")
+
+
+# -----------------------------------------------------------------------------
+# _decode + _truncate
+# -----------------------------------------------------------------------------
+
+
+class DecodeTruncateTests(unittest.TestCase):
+
+    def test_decode_unescapes_html_and_collapses_newlines(self):
+        self.assertEqual(render_dc._decode("&quot;hi&quot;\nthere"), '"hi" there')
+
+    def test_decode_returns_empty_for_falsy(self):
+        self.assertEqual(render_dc._decode(None), "")
+        self.assertEqual(render_dc._decode(""), "")
+
+    def test_truncate_pads_with_ellipsis_when_over_n(self):
+        long = "a" * 100
+        out = render_dc._truncate(long, n=10)
+        self.assertEqual(len(out), 10)
+        self.assertTrue(out.endswith("…"))
+
+    def test_truncate_returns_input_when_under_or_equal_n(self):
+        self.assertEqual(render_dc._truncate("short", n=10), "short")
+
+    def test_truncate_returns_dash_for_falsy(self):
+        self.assertEqual(render_dc._truncate(None), "—")
+        self.assertEqual(render_dc._truncate(""), "—")
+
+
+# -----------------------------------------------------------------------------
+# _short
+# -----------------------------------------------------------------------------
+
+
+class ShortTests(unittest.TestCase):
+
+    def test_returns_dash_for_falsy(self):
+        self.assertEqual(render_dc._short(None), "—")
+        self.assertEqual(render_dc._short(""), "—")
+
+    def test_truncates_long_uuid_with_ellipsis(self):
+        out = render_dc._short("019dface-0000-7000-8000-000000000001", keep=8)
+        self.assertEqual(out, "019dface…")
+
+    def test_returns_input_when_short(self):
+        self.assertEqual(render_dc._short("abc"), "abc")
+
+
+# -----------------------------------------------------------------------------
+# _fmt_total_duration — h / m / s rollover
+# -----------------------------------------------------------------------------
+
+
+class FmtTotalDurationTests(unittest.TestCase):
+
+    def test_returns_none_when_either_side_missing(self):
+        self.assertIsNone(render_dc._fmt_total_duration(None, "2026-04-22T10:00:00Z"))
+
+    def test_seconds_only(self):
+        self.assertEqual(
+            render_dc._fmt_total_duration(
+                "2026-04-22T10:00:00.000Z", "2026-04-22T10:00:42.500Z",
+            ),
+            "42.500s",
+        )
+
+    def test_minutes_and_seconds(self):
+        self.assertEqual(
+            render_dc._fmt_total_duration(
+                "2026-04-22T10:00:00Z", "2026-04-22T10:02:30Z",
+            ),
+            "2m 30.000s",
+        )
+
+    def test_hours_minutes_seconds(self):
+        out = render_dc._fmt_total_duration(
+            "2026-04-22T10:00:00Z", "2026-04-22T11:30:45Z",
+        )
+        self.assertEqual(out, "1h 30m 45.000s")
+
+
+# -----------------------------------------------------------------------------
+# _derive_session_end
+# -----------------------------------------------------------------------------
+
+
+class DeriveSessionEndTests(unittest.TestCase):
+
+    def test_returns_session_end_ts_verbatim_when_present(self):
+        end, source = render_dc._derive_session_end(
+            {"end_ts": "2026-04-22T11:00:00Z", "interactions": []},
+        )
+        self.assertEqual(end, "2026-04-22T11:00:00Z")
+        self.assertIsNone(source)
+
+    def test_uses_session_end_interaction_start_ts(self):
+        sess = {
+            "end_ts": None,
+            "interactions": [
+                {"type": "TURN", "start_ts": "10:00", "end_ts": "10:01"},
+                {"type": "SESSION_END", "start_ts": "11:00:00Z"},
+            ],
+        }
+        end, source = render_dc._derive_session_end(sess)
+        self.assertEqual(end, "11:00:00Z")
+        self.assertEqual(source, "from SESSION_END interaction")
+
+    def test_falls_back_to_last_turn_end_ts(self):
+        sess = {
+            "end_ts": None,
+            "interactions": [
+                {"type": "TURN", "start_ts": "10:00", "end_ts": "10:01"},
+                {"type": "TURN", "start_ts": "10:02", "end_ts": "10:03"},
+            ],
+        }
+        end, source = render_dc._derive_session_end(sess)
+        self.assertEqual(end, "10:03")
+        self.assertEqual(source, "session still open (last TURN)")
+
+    def test_returns_none_pair_when_no_data(self):
+        end, source = render_dc._derive_session_end({"interactions": []})
+        self.assertIsNone(end)
+        self.assertIsNone(source)
+
+
+# -----------------------------------------------------------------------------
+# _compose_agent_cell
+# -----------------------------------------------------------------------------
+
+
+class ComposeAgentCellTests(unittest.TestCase):
+
+    def test_full_identity_concatenated(self):
+        out = render_dc._compose_agent_cell({
+            "agent_api_name": "MyAgent",
+            "agent_version": "v3",
+            "agent_label": "My Agent",
+            "agent_type": "Internal",
+        })
+        self.assertEqual(out, "MyAgent v3 — My Agent (Internal)")
+
+    def test_only_api_name(self):
+        out = render_dc._compose_agent_cell({"agent_api_name": "MyAgent"})
+        self.assertEqual(out, "MyAgent")
+
+    def test_only_label(self):
+        out = render_dc._compose_agent_cell({"agent_label": "Display Only"})
+        self.assertEqual(out, "Display Only")
+
+    def test_returns_none_for_empty_identity(self):
+        self.assertIsNone(render_dc._compose_agent_cell({}))
+
+
+# -----------------------------------------------------------------------------
+# _section_session_bootstrap — channel-aware NOT_SET wording
+# -----------------------------------------------------------------------------
+
+
+class SectionSessionBootstrapNotSetWordingTests(unittest.TestCase):
+    """`VariableText__c == NOT_SET` is a "no bootstrap variables" signal,
+    not a messaging-channel signal. Several non-messaging shapes (E&O
+    headless API, Atlas planner, generic API/integration) legitimately
+    produce NOT_SET — the rendered line must not call those "production
+    messaging path".
+    """
+
+    def _identity_with_no_bootstrap(self) -> dict:
+        # Sentinel: bootstrap_variables key is present and explicitly None
+        # (the assembler stamps None when VariableText__c is NOT_SET).
+        return {"bootstrap_variables": None}
+
+    def test_messaging_channel_keeps_messaging_path_addendum(self):
+        out = "\n".join(render_dc._section_session_bootstrap(
+            self._identity_with_no_bootstrap(),
+            channel="SCRT2 - EmbeddedMessaging",
+        ))
+        self.assertIn("no bootstrap variables", out)
+        self.assertIn("production messaging path", out)
+        # Alias.
+        out2 = "\n".join(render_dc._section_session_bootstrap(
+            self._identity_with_no_bootstrap(),
+            channel="Messaging",
+        ))
+        self.assertIn("production messaging path", out2)
+
+    def test_non_messaging_channel_omits_messaging_path(self):
+        # E&O is the wheelz that surfaced this bug — Atlas-planner
+        # session on the "E & O" channel was being mislabeled
+        # "production messaging path".
+        out = "\n".join(render_dc._section_session_bootstrap(
+            self._identity_with_no_bootstrap(),
+            channel="E & O",
+        ))
+        self.assertIn("no bootstrap variables", out)
+        self.assertNotIn("production messaging path", out)
+        self.assertNotIn("messaging", out.lower())
+
+    def test_null_channel_uses_neutral_wording(self):
+        # No channel info at all — must not assume messaging.
+        out = "\n".join(render_dc._section_session_bootstrap(
+            self._identity_with_no_bootstrap(),
+            channel=None,
+        ))
+        self.assertIn("no bootstrap variables", out)
+        self.assertNotIn("production messaging path", out)
+
+    def test_default_channel_kwarg_is_neutral(self):
+        # Backward-compat: callers that don't pass channel get the
+        # neutral wording, never the messaging-path label.
+        out = "\n".join(render_dc._section_session_bootstrap(
+            self._identity_with_no_bootstrap(),
+        ))
+        self.assertIn("no bootstrap variables", out)
+        self.assertNotIn("production messaging path", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_integration.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_integration.py
@@ -1,0 +1,220 @@
+"""End-to-end integration tests for ``render_dc.render``.
+
+Drives the full renderer against the synthetic session fixture (assembled
+through ``assemble_dc.assemble`` first). Asserts on section presence,
+substring content of identity / transcript / hierarchical-trace / id-ref
+sections, and graceful degradation paths (no session_dir, gateway-direct
+shape, minimal tree).
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+import render_dc  # type: ignore
+from config import paths  # type: ignore
+from .fixtures.synthetic_session import (  # type: ignore
+    IDS, write_to_disk,
+)
+
+
+class _RenderHarness:
+    """Materialize fixture, assemble, render."""
+
+    def __init__(self, *, with_session_dir: bool = True,
+                 mutate_files=None):
+        self.with_session_dir = with_session_dir
+        self.mutate_files = mutate_files
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        sdir = write_to_disk(self._tmpdir)
+        if self.mutate_files:
+            self.mutate_files(sdir)
+        self._patch = mock.patch.object(paths, "DATA_ROOT", self._tmpdir)
+        self._patch.start()
+        self.tree, self.sdir = assemble_dc.assemble(IDS.SID)
+        self.manifest = json.loads(
+            (self.sdir / "dc._session_manifest.json").read_text()
+        )
+        self.md = render_dc.render(
+            self.tree,
+            manifest=self.manifest,
+            session_dir=self.sdir if self.with_session_dir else None,
+        )
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+
+# -----------------------------------------------------------------------------
+# Top-level shape — sections present
+# -----------------------------------------------------------------------------
+
+
+class RenderSectionsPresentTests(unittest.TestCase):
+
+    def test_renders_session_identity_section(self):
+        with _RenderHarness() as h:
+            self.assertIn("## Session identity", h.md)
+
+    def test_renders_id_reference_section(self):
+        with _RenderHarness() as h:
+            self.assertIn("## ID reference", h.md)
+
+    def test_renders_hierarchical_trace_section(self):
+        with _RenderHarness() as h:
+            self.assertIn("## Complete hierarchical trace", h.md)
+
+    def test_renders_per_turn_summary_section(self):
+        with _RenderHarness() as h:
+            self.assertIn("## Per-turn summary", h.md)
+
+    def test_renders_transcript_section(self):
+        with _RenderHarness() as h:
+            self.assertIn("## Transcript", h.md)
+
+
+# -----------------------------------------------------------------------------
+# Identity content
+# -----------------------------------------------------------------------------
+
+
+class RenderIdentityTests(unittest.TestCase):
+
+    def test_identity_shows_session_id(self):
+        with _RenderHarness() as h:
+            self.assertIn(IDS.SID, h.md)
+
+    def test_identity_shows_messaging_session_id(self):
+        with _RenderHarness() as h:
+            self.assertIn("0MwTESTMSG12345AAA", h.md)
+
+    def test_identity_shows_total_duration_in_human_form(self):
+        with _RenderHarness() as h:
+            # Session is 90 seconds → "1m 30.000s"
+            self.assertIn("1m 30.000s", h.md)
+
+    def test_identity_shows_channel_and_end_type(self):
+        with _RenderHarness() as h:
+            self.assertIn("SCRT2 - EmbeddedMessaging", h.md)
+            self.assertIn("USER_ENDED", h.md)
+
+    def test_identity_marks_session_end_as_materialized(self):
+        with _RenderHarness() as h:
+            self.assertIn("✓ materialized", h.md)
+
+
+# -----------------------------------------------------------------------------
+# ID reference
+# -----------------------------------------------------------------------------
+
+
+class RenderIdReferenceTests(unittest.TestCase):
+
+    def test_id_ref_lists_all_three_interactions(self):
+        with _RenderHarness() as h:
+            self.assertIn(IDS.IXN_START, h.md)
+            self.assertIn(IDS.IXN_TURN, h.md)
+            self.assertIn(IDS.IXN_END, h.md)
+
+    def test_id_ref_lists_both_participants_with_roles(self):
+        with _RenderHarness() as h:
+            self.assertIn(IDS.PART_AGENT, h.md)
+            self.assertIn(IDS.PART_USER, h.md)
+            self.assertIn("role=AGENT", h.md)
+            self.assertIn("role=USER", h.md)
+
+    def test_id_ref_lists_all_three_steps(self):
+        with _RenderHarness() as h:
+            self.assertIn("TopicSelection", h.md)
+            self.assertIn("PrimaryAction", h.md)
+            self.assertIn("FinalGuard", h.md)
+
+    def test_id_ref_lists_both_gateway_requests_with_binding_method(self):
+        with _RenderHarness() as h:
+            self.assertIn(IDS.GW_REQ_DECLARED, h.md)
+            self.assertIn(IDS.GW_REQ_WINDOW, h.md)
+            self.assertIn("binding=declared", h.md)
+            self.assertIn("binding=timestamp_window", h.md)
+
+    def test_id_ref_includes_extracted_trace_id(self):
+        with _RenderHarness() as h:
+            # Trace_id was pulled from HTML-escaped AttributeText; once
+            # decoded it must appear verbatim in the id-ref section.
+            self.assertIn(IDS.TRACE_ID, h.md)
+
+
+# -----------------------------------------------------------------------------
+# Transcript
+# -----------------------------------------------------------------------------
+
+
+class RenderTranscriptTests(unittest.TestCase):
+
+    def test_transcript_includes_user_message(self):
+        with _RenderHarness() as h:
+            self.assertIn("How do I refund my order?", h.md)
+
+    def test_transcript_includes_agent_message(self):
+        with _RenderHarness() as h:
+            self.assertIn("I'll help you with the refund process.", h.md)
+
+
+# -----------------------------------------------------------------------------
+# Graceful degradation paths
+# -----------------------------------------------------------------------------
+
+
+class RenderDegradationTests(unittest.TestCase):
+
+    def test_renders_without_session_dir(self):
+        # No session_dir → no latency-rollup section, but the rest of
+        # the render should succeed and contain the standard sections.
+        with _RenderHarness(with_session_dir=False) as h:
+            self.assertIn("## Session identity", h.md)
+            self.assertIn("## Complete hierarchical trace", h.md)
+
+    def test_minimal_tree_short_circuits_to_short_markdown(self):
+        def empty_sessions(sdir: Path) -> None:
+            (sdir / "dc.sessions.json").write_text("[]")
+
+        with _RenderHarness(mutate_files=empty_sessions) as h:
+            # session_not_found minimal tree still produces something
+            # readable that contains the SID.
+            self.assertIn(IDS.SID, h.md)
+            # Doesn't produce the full 9-section layout — verify by
+            # absence of a section that requires interactions.
+            self.assertNotIn("## Complete hierarchical trace", h.md)
+
+
+# -----------------------------------------------------------------------------
+# Output is non-empty markdown
+# -----------------------------------------------------------------------------
+
+
+class RenderOutputBasicsTests(unittest.TestCase):
+
+    def test_output_starts_with_h1_header(self):
+        with _RenderHarness() as h:
+            first_line = h.md.splitlines()[0]
+            self.assertTrue(first_line.startswith("# Session "))
+
+    def test_output_is_substantial(self):
+        # A real session produces several KB; a hand-built fixture with
+        # 1 turn + 3 steps + 2 gateway calls should produce ≥ 2 KB.
+        with _RenderHarness() as h:
+            self.assertGreater(len(h.md), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_planner_llm_calls.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_planner_llm_calls.py
@@ -1,0 +1,284 @@
+"""Tests for the opt-in Planner LLM calls section in render_dc.
+
+The full-tree branch of `render_dc.render()` by default surfaces only a
+one-line `decoded:` summary on each generation. The `--show-prompts` flag
+(CLI) / `show_prompts=True` (programmatic) opts in to a section that
+emits the full prompt + response per LLM call.
+
+Coverage:
+  - assemble_dc: hierarchical-tree gw view carries `prompt_text` + `prompt_template_dev_name`
+  - render_dc: section omitted by default
+  - render_dc: section emitted with show_prompts=True
+  - render_dc: section walks all interactions[].steps[] and renders one block per gateway_request
+  - render_dc: 64 KB byte-cap on prompt display still applies (regression guard)
+  - render_dc: empty/missing prompt → renders `(empty)` not crash
+  - render_dc: response_text is HTML-unescaped before display
+  - render_dc: gateway-direct branch unchanged (still emits Per-call detail)
+
+Test isolation: synthesizes a session tree in memory (no on-disk DC fetch),
+calls `render(...)` directly, and asserts on the produced markdown.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import assemble_dc  # type: ignore
+import render_dc  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: minimal full-tree shape that render() will accept
+# ---------------------------------------------------------------------------
+
+def _full_tree(*, with_prompt_text: bool = True,
+               with_response_text: bool = True,
+               num_calls: int = 2) -> dict:
+    """Build a synthetic full-tree dict with `num_calls` gateway requests."""
+    steps = []
+    for i in range(num_calls):
+        gw = {
+            "gateway_request_id": f"gw-id-{i}",
+            "model": "gpt-4.1-2025-04-14",
+            "provider": "salesforce",
+            "prompt_template_dev_name": "Atlas__AgentGraphReasoningPrompt",
+            "prompt_tokens": 100 + i,
+            "completion_tokens": 50,
+            "total_tokens": 150 + i,
+            "prompt_text": (
+                f"role: user\nMessage {i}\nrole: assistant\nResponse {i}"
+                if with_prompt_text else None
+            ),
+            "response": {"finish_reason": "stop"},
+        }
+        gen = {
+            "generation_id": f"gen-{i}",
+            "response_text": (
+                f'{{"content":"","toolInvocations":[{{"id":"call_{i}",'
+                f'"function":{{"name":"some_tool","arguments":"{{}}"}}}}]}}'
+                if with_response_text else None
+            ),
+        }
+        steps.append({
+            "id": f"step-{i}",
+            "type": "LLM_STEP",
+            "gateway_request": gw,
+            "generation": gen,
+        })
+    return {
+        "session": {
+            "_schema_version": 1,
+            "id": "fixture-session-uuid-0000",
+            "start_ts": "2026-05-14T10:00:00.000Z",
+            "end_ts": "2026-05-14T10:00:30.000Z",
+            "identity": {},
+            "interactions": [{
+                "id": "interaction-0000",
+                "type": "TURN",
+                "steps": steps,
+            }],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Assembler: _build_gw_view now carries prompt_text + prompt_template_dev_name
+# ---------------------------------------------------------------------------
+
+class BuildGwViewCarriesPromptTests(unittest.TestCase):
+    """Hierarchical view propagates prompt__c so renderer can use it."""
+
+    def _idx_dispatch(self):
+        from assemble_dc import Indexes, PolymorphicSplits
+        idx = Indexes(
+            interactions_by_id={}, participants_by_id={},
+            generations_by_id={}, gw_req_by_id={},
+            gw_resp_by_resp_id={}, feedback_by_id={},
+            gw_resp_by_req_id={}, steps_by_interaction={},
+            messages_by_interaction={}, gw_tags_by_parent={},
+            gw_md_by_parent={}, gw_llm_by_parent={},
+            quality_by_parent={}, quality_by_id={},
+            feedback_by_gen={}, feedback_details_by_parent={},
+            participant_role_by_id={},
+        )
+        dispatch = PolymorphicSplits(
+            categories_by_generation={}, categories_by_quality={},
+            gw_records_by_gw_req={}, gw_records_by_feedback={},
+            tag_assoc_session=[], tag_assoc_by_interaction={},
+            tag_assoc_by_moment={},
+        )
+        return idx, dispatch
+
+    def test_prompt_text_propagated(self):
+        idx, dispatch = self._idx_dispatch()
+        gw_req = {
+            "gatewayRequestId__c": "gw-fixture-0000",
+            "feature__c": "plannerservice",
+            "model__c": "gpt-4.1",
+            "provider__c": "salesforce",
+            "promptTemplateDevName__c": "Atlas__AgentGraphReasoningPrompt",
+            "promptTokens__c": 874.0,
+            "completionTokens__c": 1.0,
+            "totalTokens__c": 875.0,
+            "prompt__c": "role: user\nHello\nrole: assistant\nHi",
+        }
+        view = assemble_dc._build_gw_view(
+            gw_req, "declared", idx=idx, dispatch=dispatch,
+        )
+        self.assertEqual(view["prompt_text"],
+                         "role: user\nHello\nrole: assistant\nHi")
+        self.assertEqual(view["prompt_template_dev_name"],
+                         "Atlas__AgentGraphReasoningPrompt")
+
+    def test_missing_prompt_propagates_as_none(self):
+        """No prompt__c on the source row → view.prompt_text is None, no crash."""
+        idx, dispatch = self._idx_dispatch()
+        gw_req = {"gatewayRequestId__c": "gw-no-prompt"}
+        view = assemble_dc._build_gw_view(
+            gw_req, "declared", idx=idx, dispatch=dispatch,
+        )
+        self.assertIsNone(view["prompt_text"])
+
+
+# ---------------------------------------------------------------------------
+# Renderer: opt-in section
+# ---------------------------------------------------------------------------
+
+class RenderShowPromptsOffByDefaultTests(unittest.TestCase):
+
+    def test_section_absent_by_default(self):
+        tree = _full_tree()
+        md = render_dc.render(tree)
+        self.assertNotIn("Planner LLM calls", md)
+        self.assertNotIn("**Prompt** (full input sent to the model)", md)
+
+    def test_section_present_with_flag(self):
+        tree = _full_tree()
+        md = render_dc.render(tree, show_prompts=True)
+        self.assertIn("## Planner LLM calls", md)
+        self.assertIn("**Prompt**", md)
+
+
+class RenderShowPromptsContentsTests(unittest.TestCase):
+
+    def test_section_renders_one_block_per_call(self):
+        tree = _full_tree(num_calls=3)
+        md = render_dc.render(tree, show_prompts=True)
+        # Three "#### LLM call N" headers — one per gateway_request.
+        self.assertEqual(md.count("#### LLM call 1 — "), 1)
+        self.assertEqual(md.count("#### LLM call 2 — "), 1)
+        self.assertEqual(md.count("#### LLM call 3 — "), 1)
+        # Both blocks (prompt + response) per call → 3 of each.
+        self.assertEqual(md.count("**Prompt**"), 3)
+        self.assertEqual(md.count("**Response**"), 3)
+
+    def test_prompt_text_appears_verbatim(self):
+        tree = _full_tree(num_calls=1)
+        md = render_dc.render(tree, show_prompts=True)
+        self.assertIn("role: user\nMessage 0\nrole: assistant\nResponse 0", md)
+
+    def test_response_text_html_unescaped(self):
+        """Generation.response_text may have &quot; from the wire format —
+        renderer must HTML-unescape before fenced-block insertion."""
+        tree = _full_tree(num_calls=1)
+        # Replace the response with HTML-escaped content.
+        tree["session"]["interactions"][0]["steps"][0]["generation"]["response_text"] = (
+            '{&quot;content&quot;:&quot;Hello&quot;}'
+        )
+        md = render_dc.render(tree, show_prompts=True)
+        self.assertIn('{"content":"Hello"}', md)
+        self.assertNotIn("&quot;", md)
+
+    def test_empty_prompt_renders_empty_marker_not_crash(self):
+        """Missing prompt + response → block emits `(empty)` cleanly."""
+        tree = _full_tree(with_prompt_text=False, with_response_text=False,
+                          num_calls=1)
+        md = render_dc.render(tree, show_prompts=True)
+        # Both blocks present, but the body is `(empty)`.
+        self.assertIn("**Prompt**", md)
+        self.assertIn("(empty)", md)
+
+    def test_section_empty_when_no_steps_have_gateway_request(self):
+        """Steps without gateway_request → no section emitted at all."""
+        tree = _full_tree(num_calls=1)
+        # Strip the gateway_request off the only step.
+        tree["session"]["interactions"][0]["steps"][0].pop("gateway_request")
+        md = render_dc.render(tree, show_prompts=True)
+        self.assertNotIn("## Planner LLM calls", md)
+
+
+class RenderPromptDisplayCapTests(unittest.TestCase):
+    """Regression guard: the 64 KB byte-cap from the gateway-direct path
+    still applies on the new full-tree path."""
+
+    def test_oversize_prompt_truncated(self):
+        tree = _full_tree(num_calls=1)
+        # 100 KB of ASCII — well over the 64 KB cap.
+        oversize = "x" * (100 * 1024)
+        tree["session"]["interactions"][0]["steps"][0][
+            "gateway_request"]["prompt_text"] = oversize
+        md = render_dc.render(tree, show_prompts=True)
+        # Truncation marker present.
+        self.assertIn("…[truncated; full prompt in dc.gateway_requests.json]",
+                      md)
+        # Body capped — not the full 100 KB.
+        self.assertLess(md.count("x"), 100 * 1024)
+
+
+class RenderGatewayDirectUnchangedTests(unittest.TestCase):
+    """The gateway-direct branch (STDM-not-yet-materialized) keeps emitting
+    its Per-call detail section header + per-call summary line by default.
+    The full prompt body is gated behind ``show_prompts=True`` to match the
+    documented contract for ``dc._session_summary.md`` (default summary
+    omits prompts; ``--show-prompts`` opts in).
+    """
+
+    def _gateway_direct_tree(self):
+        return {
+            "_source": "gateway_direct",
+            "session": {
+                "_schema_version": 1,
+                "id": "fixture-session-uuid-0000",
+                "start_ts": "2026-05-14T10:00:00.000Z",
+                "end_ts": "2026-05-14T10:00:30.000Z",
+                "identity": {},
+                "gateway_chain": [{
+                    "gateway_request_id": "gw-direct-0",
+                    "model": "gpt-4.1",
+                    "provider": "salesforce",
+                    "prompt_template_dev_name": "Atlas__X",
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                    "prompt_text": "Some prompt",
+                    "response": {"finish_reason": "stop"},
+                }],
+            },
+        }
+
+    def test_gateway_direct_per_call_section_header_still_emitted(self):
+        """Default render keeps the Per-call detail header + summary line."""
+        md = render_dc.render(self._gateway_direct_tree())
+        # gateway-direct path's own header is "## Per-call detail".
+        self.assertIn("## Per-call detail", md)
+        # Per-call summary line (model/provider/tokens) still emits.
+        self.assertIn("model=gpt-4.1", md)
+        # Prompt body suppressed by default (matches doc contract).
+        self.assertNotIn("Some prompt", md)
+        self.assertNotIn("**Prompt**", md)
+        # gateway-direct never has response_text → no Response block.
+        self.assertNotIn("**Response**", md)
+
+    def test_gateway_direct_per_call_detail_with_show_prompts(self):
+        """Opt-in render exposes the full prompt body in the per-call block."""
+        md = render_dc.render(self._gateway_direct_tree(), show_prompts=True)
+        self.assertIn("## Per-call detail", md)
+        self.assertIn("**Prompt**", md)
+        self.assertIn("Some prompt", md)
+        # Response block still suppressed — gateway-direct never carries it.
+        self.assertNotIn("**Response**", md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_show_prompts_gating.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_render_dc_show_prompts_gating.py
@@ -1,0 +1,215 @@
+"""Default-gating contract for the ``--show-prompts`` flag in render_dc.
+
+Both render branches — gateway-direct (STDM lag) and full-tree (post-STDM
+materialization) — must suppress the full prompt block by default and only
+emit it when the caller opts in via ``show_prompts=True`` (CLI:
+``--show-prompts``).
+
+This pins the doc contract from ``SKILL.md``:
+
+    The default ``dc._session_summary.md`` does NOT include the input
+    prompt or the model's full response — only a one-line ``decoded:``
+    summary on each generation. When the user asks for the actual prompt
+    sent to the model … re-render with the ``--show-prompts`` flag.
+
+A regression on the gateway-direct branch (renderer dropped the
+parameter on the ``--show-prompts`` plumbing path) leaked the full prompt
+on every fresh-session render. These tests guard both branches and the
+``_render_call_detail_block`` helper directly so the two flags
+(``show_prompts`` / ``show_response_text``) gate independently.
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import render_dc  # type: ignore
+
+
+# Distinct sentinel strings so test failures point at the exact branch
+# that leaked. ``role: user`` is included because the live render uses
+# that exact substring on real prompts and `grep` searches in the
+# investigation runbook key off it.
+_GATEWAY_DIRECT_PROMPT_MARKER = "ROLE-USER-GATEWAY-DIRECT-MARKER"
+_FULL_TREE_PROMPT_MARKER = "ROLE-USER-FULL-TREE-MARKER"
+_FULL_TREE_RESPONSE_MARKER = "ROLE-ASSISTANT-FULL-TREE-MARKER"
+
+
+def _gateway_direct_tree_with_marker() -> dict:
+    """Synthetic gateway-direct tree carrying a unique prompt marker."""
+    return {
+        "_source": "gateway_direct",
+        "session": {
+            "_schema_version": 1,
+            "id": "fixture-gd-session-0000",
+            "start_ts": "2026-05-26T10:00:00.000Z",
+            "end_ts": "2026-05-26T10:00:30.000Z",
+            "identity": {},
+            "gateway_chain": [{
+                "gateway_request_id": "gw-gd-0",
+                "model": "gpt-4.1",
+                "provider": "salesforce",
+                "prompt_template_dev_name": "Atlas__X",
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "prompt_text": _GATEWAY_DIRECT_PROMPT_MARKER,
+                "response": {"finish_reason": "stop"},
+            }],
+        },
+    }
+
+
+def _full_tree_with_marker() -> dict:
+    """Synthetic full-tree session with one LLM call, unique markers."""
+    return {
+        "session": {
+            "_schema_version": 1,
+            "id": "fixture-ft-session-0000",
+            "start_ts": "2026-05-26T10:00:00.000Z",
+            "end_ts": "2026-05-26T10:00:30.000Z",
+            "identity": {},
+            "interactions": [{
+                "id": "interaction-0000",
+                "type": "TURN",
+                "steps": [{
+                    "id": "step-0",
+                    "type": "LLM_STEP",
+                    "gateway_request": {
+                        "gateway_request_id": "gw-ft-0",
+                        "model": "gpt-4.1",
+                        "provider": "salesforce",
+                        "prompt_template_dev_name": "Atlas__X",
+                        "prompt_tokens": 100,
+                        "completion_tokens": 50,
+                        "total_tokens": 150,
+                        "prompt_text": _FULL_TREE_PROMPT_MARKER,
+                        "response": {"finish_reason": "stop"},
+                    },
+                    "generation": {
+                        "generation_id": "gen-0",
+                        "response_text": _FULL_TREE_RESPONSE_MARKER,
+                    },
+                }],
+            }],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gateway-direct branch (the leaky branch this fix targets)
+# ---------------------------------------------------------------------------
+
+
+class GatewayDirectBranchGatingTests(unittest.TestCase):
+
+    def test_gateway_direct_no_prompt_block_by_default(self):
+        """Default render: no **Prompt** heading, no prompt body bytes."""
+        md = render_dc.render(_gateway_direct_tree_with_marker())
+        self.assertNotIn(_GATEWAY_DIRECT_PROMPT_MARKER, md)
+        self.assertNotIn("**Prompt**", md)
+        # The Per-call detail section header itself stays — only the
+        # body is gated.
+        self.assertIn("## Per-call detail", md)
+
+    def test_gateway_direct_emits_prompt_block_when_show_prompts_true(self):
+        """Opt-in render: prompt body + heading both surface."""
+        md = render_dc.render(_gateway_direct_tree_with_marker(),
+                              show_prompts=True)
+        self.assertIn(_GATEWAY_DIRECT_PROMPT_MARKER, md)
+        self.assertIn("**Prompt**", md)
+
+
+# ---------------------------------------------------------------------------
+# Full-tree branch (regression guard — already correctly gated, lock it in)
+# ---------------------------------------------------------------------------
+
+
+class FullTreeBranchGatingTests(unittest.TestCase):
+
+    def test_full_tree_no_prompt_block_by_default_regression(self):
+        """Full-tree default: no Planner LLM calls section, no prompt body."""
+        md = render_dc.render(_full_tree_with_marker())
+        self.assertNotIn(_FULL_TREE_PROMPT_MARKER, md)
+        self.assertNotIn("**Prompt**", md)
+        self.assertNotIn("## Planner LLM calls", md)
+
+    def test_full_tree_emits_prompt_block_when_show_prompts_true_regression(self):
+        """Full-tree opt-in: section header + prompt + response all surface."""
+        md = render_dc.render(_full_tree_with_marker(), show_prompts=True)
+        self.assertIn("## Planner LLM calls", md)
+        self.assertIn("**Prompt**", md)
+        self.assertIn(_FULL_TREE_PROMPT_MARKER, md)
+        self.assertIn("**Response**", md)
+        self.assertIn(_FULL_TREE_RESPONSE_MARKER, md)
+
+
+# ---------------------------------------------------------------------------
+# Helper: independent gating of prompt vs response block
+# ---------------------------------------------------------------------------
+
+
+class RenderCallDetailBlockHelperTests(unittest.TestCase):
+    """``_render_call_detail_block`` must gate prompt and response
+    independently. The gateway-direct path uses
+    ``show_prompts=False, show_response_text=False`` by default, while
+    the full-tree path post-fix uses
+    ``show_prompts=True, show_response_text=True`` once the section
+    guard has cleared. Mixed combinations must work too."""
+
+    def _call(self):
+        return {
+            "gateway_request_id": "gw-helper-0",
+            "model": "gpt-4.1",
+            "provider": "salesforce",
+            "prompt_template_dev_name": "Atlas__X",
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "prompt_text": "PROMPT-MARKER",
+            "response": {"finish_reason": "stop"},
+            "response_text": "RESPONSE-MARKER",
+        }
+
+    def test_response_only(self):
+        """show_prompts=False + show_response_text=True → response only."""
+        block = "\n".join(render_dc._render_call_detail_block(
+            self._call(), 1, show_prompts=False, show_response_text=True))
+        self.assertNotIn("**Prompt**", block)
+        self.assertNotIn("PROMPT-MARKER", block)
+        self.assertIn("**Response**", block)
+        self.assertIn("RESPONSE-MARKER", block)
+
+    def test_prompt_only(self):
+        """show_prompts=True + show_response_text=False → prompt only."""
+        block = "\n".join(render_dc._render_call_detail_block(
+            self._call(), 1, show_prompts=True, show_response_text=False))
+        self.assertIn("**Prompt**", block)
+        self.assertIn("PROMPT-MARKER", block)
+        self.assertNotIn("**Response**", block)
+        self.assertNotIn("RESPONSE-MARKER", block)
+
+    def test_neither(self):
+        """Both flags off → summary line only, no fenced blocks."""
+        block = "\n".join(render_dc._render_call_detail_block(
+            self._call(), 1))
+        self.assertNotIn("**Prompt**", block)
+        self.assertNotIn("**Response**", block)
+        self.assertNotIn("PROMPT-MARKER", block)
+        self.assertNotIn("RESPONSE-MARKER", block)
+        # Summary line still emits.
+        self.assertIn("model=gpt-4.1", block)
+
+    def test_both(self):
+        """Both flags on → both blocks present."""
+        block = "\n".join(render_dc._render_call_detail_block(
+            self._call(), 1, show_prompts=True, show_response_text=True))
+        self.assertIn("**Prompt**", block)
+        self.assertIn("PROMPT-MARKER", block)
+        self.assertIn("**Response**", block)
+        self.assertIn("RESPONSE-MARKER", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_resolve_from_disk.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_resolve_from_disk.py
@@ -1,0 +1,100 @@
+"""Tests for ``resolve_session.resolve_from_disk``.
+
+The function walks ``DATA_ROOT`` for ``dc.sessions.json`` files and
+returns the AI-agent session UUID whose row has a matching
+``ssot__RelatedMessagingSessionId__c``. Must work across:
+
+  - the nested layout (``<org>/<agent>__<ver>/<uuid>/``),
+  - historic flat layout (``<uuid>/``),
+  - user-created archive suffix dirs (skip — stale duplicate rows),
+  - distinct-UUID multi-match (SystemExit),
+  - UUID pass-through (no-op).
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import resolve_session  # type: ignore
+
+
+_UUID_A = "019dface-0000-7000-8000-000000000001"
+_UUID_B = "019dface-0000-7000-8000-000000000002"
+_MSG_ID = "0MwTESTMSG67890BBB"
+
+
+def _write_sessions_row(session_dir: Path, uuid: str, msg_id: str) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "dc.sessions.json").write_text(json.dumps([{
+        "ssot__Id__c": uuid,
+        "ssot__RelatedMessagingSessionId__c": msg_id,
+    }]))
+
+
+class ResolveFromDiskTests(unittest.TestCase):
+
+    def test_nested_layout_finds_uuid(self):
+        """``<org>/<agent>/<uuid>/dc.sessions.json`` — the current layout
+        produced by ``storage.save``. Must find the messaging id."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_sessions_row(
+                root / "00D000000000000" / "DemoAgent__v5" / _UUID_A,
+                _UUID_A, _MSG_ID,
+            )
+            with mock.patch.object(resolve_session, "DATA_ROOT", root):
+                self.assertEqual(resolve_session.resolve_from_disk(_MSG_ID), _UUID_A)
+
+    def test_flat_layout_still_finds_uuid(self):
+        """Historic ``<uuid>/dc.sessions.json`` layout — same rglob walk
+        catches it. Regression guard for backwards compatibility."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_sessions_row(root / _UUID_A, _UUID_A, _MSG_ID)
+            with mock.patch.object(resolve_session, "DATA_ROOT", root):
+                self.assertEqual(resolve_session.resolve_from_disk(_MSG_ID), _UUID_A)
+
+    def test_archive_suffix_dirs_are_skipped(self):
+        """Primary ``<uuid>/`` + duplicate ``<uuid> - archive 1/`` hold
+        identical rows. The archive copy must not trigger a multi-match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org_agent = root / "00D000000000000" / "DemoAgent__v5"
+            _write_sessions_row(org_agent / _UUID_A, _UUID_A, _MSG_ID)
+            _write_sessions_row(
+                org_agent / f"{_UUID_A} - archive 1", _UUID_A, _MSG_ID,
+            )
+            with mock.patch.object(resolve_session, "DATA_ROOT", root):
+                self.assertEqual(resolve_session.resolve_from_disk(_MSG_ID), _UUID_A)
+
+    def test_distinct_uuids_with_same_msg_id_raise(self):
+        """Two DISTINCT uuid dirs carrying the same messaging id is the
+        real ambiguity case — SystemExit with both uuids listed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org_agent = root / "00D000000000000" / "DemoAgent__v5"
+            _write_sessions_row(org_agent / _UUID_A, _UUID_A, _MSG_ID)
+            _write_sessions_row(org_agent / _UUID_B, _UUID_B, _MSG_ID)
+            with mock.patch.object(resolve_session, "DATA_ROOT", root):
+                with self.assertRaises(SystemExit) as cm:
+                    resolve_session.resolve_from_disk(_MSG_ID)
+                msg = str(cm.exception)
+                self.assertIn(_UUID_A, msg)
+                self.assertIn(_UUID_B, msg)
+                self.assertIn("matches 2", msg)
+
+    def test_uuid_input_passes_through(self):
+        """UUID input is returned as-is without scanning. The caller
+        validates disk presence downstream."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(resolve_session, "DATA_ROOT", Path(tmp)):
+                self.assertEqual(resolve_session.resolve_from_disk(_UUID_A), _UUID_A)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_resolve_session_main.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_resolve_session_main.py
@@ -1,0 +1,149 @@
+"""Tests for ``resolve_session.main`` CLI.
+
+Argparse-driven — exercises every branch:
+- UUID pass-through
+- --disk-only hit / miss
+- live path with --org
+- disk-first fallback when no --org
+- not-found-no-org error
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+import resolve_session  # type: ignore
+from .fixtures.synthetic_session import IDS, write_to_disk  # type: ignore
+
+
+class _MainHarness:
+    """Patch sys.argv + stdout/stderr; optionally plant the synthetic
+    fixture under DATA_ROOT for disk-resolution tests."""
+
+    def __init__(self, *, argv: list[str], plant_fixture: bool = False):
+        self.argv = argv
+        self.plant_fixture = plant_fixture
+
+    def __enter__(self):
+        self._tmp = TemporaryDirectory()
+        self._tmpdir = Path(self._tmp.name)
+        if self.plant_fixture:
+            write_to_disk(self._tmpdir)
+        self._patches = [
+            mock.patch.object(resolve_session.sys, "argv",
+                              ["resolve_session.py", *self.argv]),
+            mock.patch.object(resolve_session, "DATA_ROOT", self._tmpdir),
+        ]
+        for p in self._patches:
+            p.start()
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
+        self._stdout_patch = mock.patch("sys.stdout", self.stdout)
+        self._stderr_patch = mock.patch("sys.stderr", self.stderr)
+        self._stdout_patch.start()
+        self._stderr_patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stderr_patch.stop()
+        self._stdout_patch.stop()
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+
+# -----------------------------------------------------------------------------
+# UUID pass-through
+# -----------------------------------------------------------------------------
+
+
+class UuidPassThroughTests(unittest.TestCase):
+
+    def test_uuid_input_prints_unchanged_returns_zero(self):
+        with _MainHarness(argv=["--id", IDS.SID]) as h:
+            rc = resolve_session.main()
+        self.assertEqual(rc, 0)
+        self.assertIn(IDS.SID, h.stdout.getvalue())
+
+
+# -----------------------------------------------------------------------------
+# --disk-only branch
+# -----------------------------------------------------------------------------
+
+
+class DiskOnlyBranchTests(unittest.TestCase):
+
+    def test_disk_only_hit_prints_uuid(self):
+        with _MainHarness(
+            argv=["--id", "0MwTESTMSG12345AAA", "--disk-only"],
+            plant_fixture=True,
+        ) as h:
+            rc = resolve_session.main()
+        self.assertEqual(rc, 0)
+        self.assertIn(IDS.SID, h.stdout.getvalue())
+
+    def test_disk_only_miss_returns_one(self):
+        with _MainHarness(
+            argv=["--id", "0Mw000000000000", "--disk-only"],
+            plant_fixture=True,
+        ) as h:
+            rc = resolve_session.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("no local session dir matches", h.stderr.getvalue())
+
+
+# -----------------------------------------------------------------------------
+# Live path with --org
+# -----------------------------------------------------------------------------
+
+
+class LiveOrgPathTests(unittest.TestCase):
+
+    def test_live_path_returns_uuid_from_resolver(self):
+        with _MainHarness(
+            argv=["--id", "0MwTESTMSG12345AAA", "--org", "my-org"],
+        ) as h:
+            with mock.patch.object(
+                resolve_session, "resolve", return_value="resolved-uuid",
+            ) as r:
+                rc = resolve_session.main()
+            r.assert_called_once_with("0MwTESTMSG12345AAA", org="my-org")
+        self.assertEqual(rc, 0)
+        self.assertIn("resolved-uuid", h.stdout.getvalue())
+
+
+# -----------------------------------------------------------------------------
+# Disk-first convenience fallback
+# -----------------------------------------------------------------------------
+
+
+class DiskFirstFallbackTests(unittest.TestCase):
+
+    def test_disk_hit_when_no_org_supplied(self):
+        # No --org but disk resolution succeeds via fixture.
+        with _MainHarness(
+            argv=["--id", "0MwTESTMSG12345AAA"],
+            plant_fixture=True,
+        ) as h:
+            rc = resolve_session.main()
+        self.assertEqual(rc, 0)
+        self.assertIn(IDS.SID, h.stdout.getvalue())
+
+    def test_disk_miss_no_org_returns_two_with_hint(self):
+        # No --org AND disk miss → exit 2 + helpful stderr.
+        with _MainHarness(
+            argv=["--id", "0Mw000000000000"],
+        ) as h:
+            rc = resolve_session.main()
+        self.assertEqual(rc, 2)
+        self.assertIn("not found on disk", h.stderr.getvalue())
+        self.assertIn("--org <alias> required", h.stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_session_shape.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_session_shape.py
@@ -1,0 +1,95 @@
+"""Tests for ``fetch_dc._classify_session_shape``.
+
+Covers all 5 shapes with a parameterized table:
+
+  - session_not_found                 — sessions.json returned 0 rows
+  - interactions_not_materialized_yet — gw_reqs > 0 AND steps == 0 (STDM lag)
+  - abandoned_before_llm              — steps > 0, LLM_STEP == 0, gw_reqs == 0
+  - planner_ran_no_gateway_logs       — LLM_STEP > 0 with generation ids, gw_reqs == 0
+  - complete                          — the happy path
+
+Order matters — the gateway-direct rule sits BEFORE abandoned_before_llm
+because ``gw_req_count > 0`` is a stronger positive signal than
+``steps_total > 0``. Verified here by including a case with both signals
+disjointly (steps==0 on the gateway-direct path).
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+from fetch_dc import _classify_session_shape  # type: ignore
+
+
+_CASES = [
+    # (label, kwargs, expected)
+    (
+        "session_not_found when sessions.json is empty",
+        dict(sessions_count=0, steps_total=0, llm_step_count=0,
+             steps_with_generation_id=0, gw_req_count=0),
+        "session_not_found",
+    ),
+    (
+        "session_not_found wins even when gw_reqs > 0 (sessions gate runs first)",
+        dict(sessions_count=0, steps_total=0, llm_step_count=0,
+             steps_with_generation_id=0, gw_req_count=5),
+        "session_not_found",
+    ),
+    (
+        "interactions_not_materialized_yet — fresh session, gateway populated, STDM lagging",
+        dict(sessions_count=1, steps_total=0, llm_step_count=0,
+             steps_with_generation_id=0, gw_req_count=3),
+        "interactions_not_materialized_yet",
+    ),
+    (
+        "abandoned_before_llm — steps created but no LLM step, no gateway calls",
+        dict(sessions_count=1, steps_total=2, llm_step_count=0,
+             steps_with_generation_id=0, gw_req_count=0),
+        "abandoned_before_llm",
+    ),
+    (
+        "planner_ran_no_gateway_logs — LLM steps + gen ids but gateway empty",
+        dict(sessions_count=1, steps_total=3, llm_step_count=2,
+             steps_with_generation_id=2, gw_req_count=0),
+        "planner_ran_no_gateway_logs",
+    ),
+    (
+        "complete — the normal bucket",
+        dict(sessions_count=1, steps_total=5, llm_step_count=3,
+             steps_with_generation_id=3, gw_req_count=4),
+        "complete",
+    ),
+]
+
+
+class ClassifySessionShapeTests(unittest.TestCase):
+    """Parametric truth-table for the 5-way enum."""
+
+    def test_all_shapes(self):
+        for label, kwargs, expected in _CASES:
+            with self.subTest(label=label):
+                self.assertEqual(_classify_session_shape(**kwargs), expected)
+
+    def test_gateway_direct_precedes_abandoned(self):
+        """Regression guard: the new rule must fire before abandoned_before_llm.
+
+        If someone reorders the checks, a session with gw_reqs > 0 AND
+        steps > 0 AND LLM_STEP == 0 (edge case — happens when Step rows
+        land while Interaction parent rows are still lagging) could fall
+        through incorrectly. Today the rules' inputs are disjoint
+        (gateway-direct needs steps==0), so the guard case uses steps==0
+        to exercise the ordering directly.
+        """
+        shape = _classify_session_shape(
+            sessions_count=1,
+            steps_total=0,
+            llm_step_count=0,
+            steps_with_generation_id=0,
+            gw_req_count=1,
+        )
+        self.assertEqual(shape, "interactions_not_materialized_yet")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/scripts/tests/test_session_shape_dropped_by_stdm.py
+++ b/skills/investigating-agentforce-d360/scripts/tests/test_session_shape_dropped_by_stdm.py
@@ -1,0 +1,85 @@
+"""Tests for the `gateway_requests_dropped_by_stdm` session_shape enum value.
+
+This is the case where LLM_STEPs ran but neither gateway_requests nor
+generations wrote (frequently observed on Atlas-routed sessions where
+the STDM exporter dropped writes).
+"""
+from __future__ import annotations
+
+import unittest
+
+from . import _bootstrap  # noqa: F401  — sys.path setup
+
+from fetch_dc import _classify_session_shape  # type: ignore
+
+
+class ClassifySessionShapeTests(unittest.TestCase):
+    """All 6 shapes plus disambiguation between the two zero-gw shapes."""
+
+    def test_session_not_found_when_zero_sessions(self):
+        out = _classify_session_shape(
+            sessions_count=0, steps_total=0, llm_step_count=0,
+            steps_with_generation_id=0, gw_req_count=0,
+        )
+        self.assertEqual(out, "session_not_found")
+
+    def test_interactions_not_materialized_when_gw_present_steps_empty(self):
+        out = _classify_session_shape(
+            sessions_count=1, steps_total=0, llm_step_count=0,
+            steps_with_generation_id=0, gw_req_count=5,
+        )
+        self.assertEqual(out, "interactions_not_materialized_yet")
+
+    def test_abandoned_before_llm_when_steps_present_no_llm(self):
+        out = _classify_session_shape(
+            sessions_count=1, steps_total=3, llm_step_count=0,
+            steps_with_generation_id=0, gw_req_count=0,
+        )
+        self.assertEqual(out, "abandoned_before_llm")
+
+    def test_gateway_requests_dropped_by_stdm_when_llm_steps_no_gens_no_gw(self):
+        """LLM_STEPs ran, but neither generations nor gateway_requests
+        wrote. STDM exporter dropped both — frequently observed on
+        Atlas-routed sessions."""
+        out = _classify_session_shape(
+            sessions_count=1, steps_total=10, llm_step_count=4,
+            steps_with_generation_id=0, gw_req_count=0,
+        )
+        self.assertEqual(out, "gateway_requests_dropped_by_stdm")
+
+    def test_planner_ran_no_gateway_logs_when_gens_present_gw_absent(self):
+        """Distinct from the new STDM-drop shape: generations DID write,
+        gateway_requests didn't. Narrower defect."""
+        out = _classify_session_shape(
+            sessions_count=1, steps_total=10, llm_step_count=4,
+            steps_with_generation_id=4, gw_req_count=0,
+        )
+        self.assertEqual(out, "planner_ran_no_gateway_logs")
+
+    def test_complete_when_everything_present(self):
+        out = _classify_session_shape(
+            sessions_count=1, steps_total=10, llm_step_count=4,
+            steps_with_generation_id=4, gw_req_count=4,
+        )
+        self.assertEqual(out, "complete")
+
+    def test_new_shape_takes_priority_over_planner_ran_no_gateway_logs(self):
+        """When steps_with_generation_id == 0 (and other guards align),
+        the new gateway_requests_dropped_by_stdm shape catches the case
+        before planner_ran_no_gateway_logs's stricter check."""
+        out_drop = _classify_session_shape(
+            sessions_count=1, steps_total=10, llm_step_count=4,
+            steps_with_generation_id=0, gw_req_count=0,
+        )
+        self.assertEqual(out_drop, "gateway_requests_dropped_by_stdm")
+        # Single-row diff — set steps_with_generation_id > 0 — picks the
+        # other shape, confirming the two are distinguishable.
+        out_logs = _classify_session_shape(
+            sessions_count=1, steps_total=10, llm_step_count=4,
+            steps_with_generation_id=4, gw_req_count=0,
+        )
+        self.assertEqual(out_logs, "planner_ran_no_gateway_logs")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/investigating-agentforce-d360/tools/archive_data_dir.sh
+++ b/skills/investigating-agentforce-d360/tools/archive_data_dir.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Stop-hook helper — archive the most-recently-modified session dir under
+# ~/.claude/data/investigating-agentforce-d360/ into a tarball for
+# compliance / retro purposes.
+#
+# This is a USER-LEVEL hook (in ~/.claude/settings.json), opt-in.
+# Archiving sessions is a per-team preference; users who want it wire it
+# up, users who don't, don't.
+#
+# Behavior:
+#   - Find the most-recently-touched <sid>/ directory under DATA_ROOT
+#   - Tar + gzip it into ~/.claude/data/investigating-agentforce-d360-archive/
+#     with filename <sid>-<YYYY-MM-DD-HHMMSS>.tar.gz
+#   - Silent no-op if no session dir exists, or the latest is already
+#     archived (same mtime as the most-recent archive)
+#   - Never deletes the source; archiving only
+#
+# Exit codes: always 0 — Stop hooks block session exit only if non-zero.
+#
+set -eu
+
+DATA_ROOT="$HOME/.claude/data/investigating-agentforce-d360"
+ARCHIVE_ROOT="$HOME/.claude/data/investigating-agentforce-d360-archive"
+
+[ -d "$DATA_ROOT" ] || exit 0
+
+# Find the most-recently-modified session dir.
+#
+# Layout (per scripts/_shared/paths.py):
+#     DATA_ROOT/<org_id_15>/<agent_api_name>__<agent_version>/<session_id>/
+# That's three levels deep — using `find -mindepth 3 -maxdepth 3` is the
+# portable way to address the right level without globbing the org-id or
+# agent levels (which would archive an entire org's worth of sessions
+# under a filename pretending to be one session id).
+#
+# `find -printf` is GNU-only, so we sort by mtime via `stat` for portability.
+# `find ... -depth 3 -type d` lists the right level on both macOS (BSD find)
+# and Linux (GNU find).
+LATEST=""
+LATEST_MTIME=0
+while IFS= read -r d; do
+    [ -d "$d" ] || continue
+    mt=$(stat -f %m "$d" 2>/dev/null || stat -c %Y "$d" 2>/dev/null || echo 0)
+    if [ "$mt" -gt "$LATEST_MTIME" ]; then
+        LATEST_MTIME=$mt
+        LATEST="$d"
+    fi
+done < <(find "$DATA_ROOT" -mindepth 3 -maxdepth 3 -type d 2>/dev/null)
+
+[ -n "$LATEST" ] || exit 0
+[ -d "$LATEST" ] || exit 0
+
+SID=$(basename "$LATEST")
+TS=$(date +"%Y-%m-%d-%H%M%S")
+mkdir -p "$ARCHIVE_ROOT"
+TARBALL="$ARCHIVE_ROOT/${SID}-${TS}.tar.gz"
+
+# Skip if an archive for this sid created within the last minute already
+# exists — avoids redundant tarring on rapid session starts/stops.
+#
+# `-mmin -1` is the portable "modified within the last 1 minute" form on
+# both BSD find (macOS) and GNU find (Linux). Earlier `-mtime -1m` was a
+# silent foot-gun: BSD interpreted `m` as MONTHS (matched ~30 days), and
+# GNU rejected the unit suffix entirely.
+RECENT=$(find "$ARCHIVE_ROOT" -name "${SID}-*.tar.gz" -mmin -1 2>/dev/null | head -1)
+[ -n "$RECENT" ] && exit 0
+
+# Tar the session dir relative to its parent (the agent dir) so the archive
+# unpacks as just `<session_id>/` without the org/agent path prefix. `--`
+# guards against any future SID that ever started with `-`. On failure,
+# remove the partial tarball so the next hook invocation retries cleanly
+# instead of treating a corrupt 0-byte file as a recent dedup hit.
+PARENT=$(dirname "$LATEST")
+if ! tar --no-absolute-names -C "$PARENT" -czf "$TARBALL" -- "$SID" 2>/dev/null; then
+    rm -f "$TARBALL" 2>/dev/null
+fi
+exit 0

--- a/skills/investigating-agentforce-d360/tools/grant_allowlist.py
+++ b/skills/investigating-agentforce-d360/tools/grant_allowlist.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""First-run setup: grant allowlist rules + seed runtime dir + touch sentinel.
+
+Idempotent. Called by the skill's Phase 0 on first invocation (sentinel
+absent). On every subsequent run the skill skips calling this script
+entirely because the sentinel file already exists.
+
+Three actions:
+ 1. Merge the canonical rules into ~/.claude/settings.json permissions.allow.
+    Only adds missing entries; preserves any rules already present.
+    Atomic write: staged tmp file in the same directory + os.replace().
+    On corrupt JSON, the original is copied aside to .corrupt.backup and
+    the script exits 2 without modifying anything — Claude Code refusing
+    to start on a blanked permission list is worse than refusing to grant.
+ 2. mkdir -p ~/.claude/data/investigating-agentforce-d360/ + write .gitignore
+    (`*`) iff the current content is not already exactly `*`. STDM artifacts
+    carry org-specific ids and user content; preventing accidental git
+    commits is load-bearing.
+ 3. Touch the versioned sentinel at
+    ~/.claude/.investigating-agentforce-d360.allowlist-done.v1
+    (suffix tracks the rule-set version — bump on rule changes so existing
+    installs re-run grant to pick up new rules).
+
+Usage:
+    python3 ~/.claude/skills/investigating-agentforce-d360/tools/grant_allowlist.py
+
+Inputs:
+    none (all paths hardcoded under $HOME/.claude/)
+
+Outputs:
+    side effects: settings.json rewritten, data/.gitignore seeded,
+                  sentinel touched
+    stdout: one progress line per action
+    exit 0: full success (including "nothing to do" when all rules present)
+    exit 1: write failure (disk full, permission denied)
+    exit 2: settings.json unparseable (refuses to wipe)
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+
+HOME = pathlib.Path.home()
+SETTINGS = HOME / ".claude" / "settings.json"
+DATA = HOME / ".claude" / "data" / "investigating-agentforce-d360"
+SKILL = HOME / ".claude" / "skills" / "investigating-agentforce-d360"
+
+# Bump sentinel suffix when NEEDED changes so existing installs re-run
+# grant to pick up new rules.
+SENTINEL = HOME / ".claude" / ".investigating-agentforce-d360.allowlist-done.v1"
+LEGACY_SENTINELS: list[pathlib.Path] = []
+
+# Canonical allowlist rules. Every skill path is scoped — no blanket
+# python3:*. The shell-introspection block (ls/grep/head/tail/wc/stat)
+# scopes to the skill + data dirs to avoid leaking access elsewhere.
+# `~` isn't expanded by the permission matcher — literal absolute paths.
+NEEDED: list[str] = [
+    # skill source + data: full RW on dir itself AND descendants
+    f"Read({SKILL})",
+    f"Read({SKILL}/**)",
+    f"Edit({SKILL}/**)",
+    f"Write({SKILL}/**)",
+    f"Read({DATA})",
+    f"Read({DATA}/**)",
+    f"Write({DATA}/**)",
+
+    # first-time bootstrap: mkdir the roots themselves and any descendants
+    f"Bash(mkdir -p {SKILL})",
+    f"Bash(mkdir -p {SKILL}/**)",
+    f"Bash(mkdir -p {DATA})",
+    f"Bash(mkdir -p {DATA}/**)",
+
+    # /tmp — scratch for ad-hoc work
+    "Read(/tmp/**)",
+    "Write(/tmp/**)",
+    "Bash(ls /tmp/**)",
+    "Bash(ls -lh /tmp/**)",
+    "Bash(cat /tmp/**)",
+    "Bash(head * /tmp/**)",
+    "Bash(head -c * /tmp/**)",
+    "Bash(tail * /tmp/**)",
+    "Bash(rm -f /tmp/**)",
+    "Bash(rm -rf /tmp/sf-*)",
+    "Bash(cat > /tmp/* <<*)",
+
+    # python entrypoints (any args)
+    f"Bash(python3 {SKILL}/scripts/*.py:*)",
+
+    # sf CLI — single shape used by scripts/dc.py
+    "Bash(sf org display --target-org * --json)",
+
+    # read-only shell introspection within the two dirs
+    f"Bash(ls {DATA})",
+    f"Bash(ls {DATA}/**)",
+    f"Bash(ls {SKILL})",
+    f"Bash(ls {SKILL}/**)",
+    f"Bash(grep * {DATA}/**)",
+    f"Bash(grep * {SKILL}/**)",
+    f"Bash(head * {DATA}/**)",
+    f"Bash(head * {SKILL}/**)",
+    f"Bash(tail * {DATA}/**)",
+    f"Bash(tail * {SKILL}/**)",
+    f"Bash(wc -l {DATA}/**)",
+    f"Bash(wc -l {SKILL}/**)",
+    f"Bash(stat * {DATA}/**)",
+    f"Bash(stat * {SKILL}/**)",
+]
+
+# Rules to drop on each grant pass. Empty in v1; populated on rule-set changes.
+LEGACY_RULES_TO_REMOVE: list[str] = []
+
+
+def _load_settings() -> dict:
+    """Load ~/.claude/settings.json. Corrupt JSON → exit 2, don't overwrite."""
+    if not SETTINGS.is_file():
+        print(f"grant_allowlist: creating {SETTINGS}")
+        return {}
+    try:
+        return json.loads(SETTINGS.read_text())
+    except json.JSONDecodeError as e:
+        backup = SETTINGS.with_suffix(".json.corrupt.backup")
+        shutil.copy2(SETTINGS, backup)
+        print(
+            f"grant_allowlist: settings.json unparseable ({e}); backed up to "
+            f"{backup}; refusing to write.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _atomic_write(path: pathlib.Path, content: str) -> None:
+    """Write content to path atomically (tmp in same dir + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def merge_allowlist() -> int:
+    settings = _load_settings()
+    perms = settings.setdefault("permissions", {})
+    allow = perms.setdefault("allow", [])
+    if not isinstance(allow, list):
+        print(
+            "grant_allowlist: permissions.allow is not a list; refusing to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Drop legacy rules. Idempotent — second run finds nothing to remove.
+    removed: list[str] = []
+    for legacy in LEGACY_RULES_TO_REMOVE:
+        while legacy in allow:
+            allow.remove(legacy)
+            removed.append(legacy)
+
+    existing = set(allow)
+    added = [r for r in NEEDED if r not in existing]
+
+    if not added and not removed:
+        print(f"grant_allowlist: all {len(NEEDED)} rules already present")
+        return 0
+
+    allow.extend(added)
+    _atomic_write(SETTINGS, json.dumps(settings, indent=2) + "\n")
+    if added:
+        print(f"grant_allowlist: merged {len(added)} new rule(s) into {SETTINGS}")
+        for r in added:
+            print(f"  + {r}")
+    if removed:
+        print(f"grant_allowlist: removed {len(removed)} legacy rule(s) from {SETTINGS}")
+        for r in removed:
+            print(f"  - {r}")
+    return len(added) + len(removed)
+
+
+def seed_data_gitignore() -> None:
+    DATA.mkdir(parents=True, exist_ok=True)
+    gi = DATA / ".gitignore"
+    if gi.is_file() and gi.read_text().strip() == "*":
+        print(f"grant_allowlist: {gi} already correct")
+        return
+    gi.write_text("*\n")
+    print(f"grant_allowlist: seeded {gi}")
+
+
+def touch_sentinel() -> None:
+    SENTINEL.parent.mkdir(parents=True, exist_ok=True)
+    SENTINEL.touch()
+    print(f"grant_allowlist: touched sentinel {SENTINEL}")
+    # Clean up legacy sentinel paths so subsequent runs trigger re-grant
+    # on the next version bump without leaving stale files around.
+    for legacy in LEGACY_SENTINELS:
+        if legacy.is_file():
+            try:
+                legacy.unlink()
+                print(f"grant_allowlist: removed legacy sentinel {legacy}")
+            except OSError:
+                pass
+
+
+def main() -> int:
+    try:
+        merge_allowlist()
+        seed_data_gitignore()
+        touch_sentinel()
+    except OSError as e:
+        print(f"grant_allowlist: I/O error: {e}", file=sys.stderr)
+        return 1
+    print("grant_allowlist: done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the **`investigating-agentforce-d360`** skill — a standalone Apache-2.0 skill that traces a single Agentforce session via Salesforce Data Cloud.

- **DC-only**: pulls 24 STDM + GenAI DMOs via the Data Cloud Query REST API. Zero Splunk dependency, zero sibling-skill dependency.
- **3-stage pipeline**: `fetch_dc.py` → `assemble_dc.py` → `render_dc.py`.
- **Output**: hierarchical session tree (Interaction → Step → Generation → GatewayRequest) + a human-readable markdown summary with up to 11 sections.
- **Discovery**: when the user has no session id, `discover_sessions.py` finds candidates by time / agent / channel / outcome / conversation text and prints a numbered picker.
- **Resolution**: `resolve_session.py` accepts both Agent Session UUIDs (`019d…`) and MessagingSession ids (`0Mw…`).

This is the **second** of four skills in the Agentforce session-investigation family being migrated from an internal hub plugin to `forcedotcom/sf-skills`. Sibling skill `investigating-agentforce-architecture` shipped in [#278](https://github.com/forcedotcom/sf-skills/pull/278) (same migration pattern, complementary design-time scope).

## What this skill answers

| User says | Skill does |
|---|---|
| `trace session 019dface-...` | Run the 3-stage pipeline against the given org alias |
| `summarize what happened in 0MwTESTMSG12345AAA` | Resolve messaging id → UUID, then run the pipeline |
| `find escalated sessions today on Messaging in <org>` | Run discovery, print a numbered picker, user picks one |

## What it does NOT answer

- Design-time architecture questions (topic/action tree, flow inventory) → use `investigating-agentforce-architecture`
- Runtime planner availability (which topics were eligible for the classifier on a given turn) → DC alone can't answer this; the skill explicitly tells the operator when their question lies outside this scope

## Skill layout

```
investigating-agentforce-d360/
├── SKILL.md (181 lines)
├── README.md
├── scripts/
│   ├── _shared/  (paths, fs_guard, sql)
│   ├── fetch_dc.py / assemble_dc.py / render_dc.py
│   ├── discover_sessions.py / resolve_session.py
│   ├── dc.py / storage.py / config.py
│   └── tests/  (367 tests + 18 subtests)
├── tools/
│   ├── grant_allowlist.py  (idempotent first-run permission grant)
│   └── archive_data_dir.sh (opt-in stop-hook)
├── references/
│   ├── artifacts.md
│   ├── dc_dmo_fields.md
│   └── dc_pipeline_contract.md
└── assets/dc/  (26 .sql templates)
```

73 files, ~15.6K LOC.

## Quality gates

- **`pytest scripts/tests/`**: 367 passed, 18 subtests, 0 failures
- **`npm run validate:skills`**: 62/62 passed (was 61, +1 for d360)
- **Live end-to-end**: 3 distinct real Salesforce sessions exercising both the full-tree branch and the STDM-lag gateway-direct branch
- **4 independent code-review rounds** (code correctness, security, deep markdown, architecture/over-engineering critic) — all findings addressed
- **Customer-data hygiene**: no live tenant/session/org ids; synthetic fixtures look obviously synthetic (`019dface-…`, `0MwTESTMSG…`, `00DTESTORG…`, `MyAgent`); no internal sprint markers (`Fix N.x`, `Bug #N`, `Batch X`); no hub/sibling-skill references; no internal Salesforce hostnames or W-IDs in source

## Test plan

- [ ] `npm run validate:skills` passes (validator enforces frontmatter shape — already passing locally)
- [ ] Domain reviewer can run `python3 -m pytest skills/investigating-agentforce-d360/scripts/tests/ -v` (no special setup; pure-Python, no network)
- [ ] Domain reviewer can invoke the skill against a Data Cloud-enabled org with `sf` CLI authenticated and a known session id

## Related

- W-22707610 (this PR)
- Sibling skill: [forcedotcom/sf-skills#278](https://github.com/forcedotcom/sf-skills/pull/278) (`investigating-agentforce-architecture`, W-22704206)

cc @hsinghbisht-sfdc — same maintainer who merged sibling PR #278; same migration pattern.