### PR TITLE
Fixes #288 - article extraction on domains developer.salesforce.com -…

### DIFF
--- a/skills/fetching-salesforce-docs/scripts/extract_salesforce_doc.py
+++ b/skills/fetching-salesforce-docs/scripts/extract_salesforce_doc.py
@@ -240,6 +240,10 @@ def extract_official_salesforce_doc(url: str, timeout_seconds: int, use_stealth:
                   }
 
                   const selectorConfigs = [
+                    { selector: '.body.refbody', strategy: 'dev-refbody', base: 310 },
+                    { selector: '.body.conbody', strategy: 'dev-conbody', base: 310 },
+                    { selector: '.body.taskbody', strategy: 'dev-taskbody', base: 310 },
+                    { selector: '.body', strategy: 'dev-body', base: 300 },
                     { selector: 'article', strategy: 'article', base: 260 },
                     { selector: 'main', strategy: 'main', base: 220 },
                     { selector: '[role="main"]', strategy: 'role-main', base: 220 },


### PR DESCRIPTION
… (added selectors)

**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

**SKILL fetching-salesforce-docs**
Added selectors to `extract_salesforce_doc.py` so that article extraction for domains https://developer.salesforce.com/* works as expected. 


## Why

The previous version of the script was not extracting the article's contents correctly.

## Skills

fetching-salesforce-docs


