### PR TITLE
feat: prefer raw-Markdown (.html→.md) over Playwright for developer.salesforce.com docs

### DIFF
--- a/skills/fetching-salesforce-docs/README.md
+++ b/skills/fetching-salesforce-docs/README.md
@@ -28,6 +28,14 @@ This skill does not include:
 - deciding when to follow child links from broad official guide pages
 - rejecting weak results such as shells, landing pages, and third-party summaries
 
+## Markdown shortcut (developer.salesforce.com)
+
+Modern developer-guide pages publish a raw-Markdown twin: swap `.html` → `.md` on the same URL
+and fetch it with a **plain web fetch** — no Playwright needed. The page's "Copy as Markdown" /
+"View as Markdown" links expose this. Try it **first** for `developer.salesforce.com/docs/platform/.../guide/*`
+pages. It does **not** work for legacy `atlas.*` pages (those return an HTML shell), and
+`help.salesforce.com` still needs the renderer — use the extractor below for those.
+
 ## Optional utility
 
 A tiny wrapper is available for official Salesforce doc URLs:

--- a/skills/fetching-salesforce-docs/SKILL.md
+++ b/skills/fetching-salesforce-docs/SKILL.md
@@ -95,7 +95,19 @@ This is especially important for:
 
 ### 5. For `developer.salesforce.com`
 
-Use this playbook:
+**Try the Markdown variant first — it needs no browser.** Modern developer-guide pages now
+publish a raw-Markdown twin: swap the `.html` extension for `.md` on the same URL and fetch it
+with a **plain web fetch** (the "Copy/View as Markdown" links on the page expose this). It returns
+clean Markdown (headings, fenced code, links) with no JS shell, so it's faster and lighter than
+Playwright. Example: `…/guide/js-dynamic-components.html` → `…/guide/js-dynamic-components.md`
+(verified 2026-06-24).
+- **Scope:** confirmed for modern guide pages under `developer.salesforce.com/docs/platform/.../guide/*`.
+  It does **not** work for legacy **`atlas.*`** pages — `.md` there returns an HTML shell, so fall
+  back to browser-rendered extraction for those.
+- If the `.md` fetch 404s or returns a shell ("Salesforce Developers" with no body), drop to the
+  Playwright playbook below.
+
+Otherwise use this playbook:
 - start with the most likely official guide root
 - if the page is JS-heavy, prefer browser-rendered extraction
 - check whether the exact concept appears on the page


### PR DESCRIPTION
**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

Updates the **`fetching-salesforce-docs`** skill (SKILL.md + README.md) to try a **raw-Markdown fetch first** for `developer.salesforce.com` guide pages, before falling back to the existing Playwright extractor.

Modern developer-guide pages now publish a raw-Markdown twin: swap the `.html` extension for `.md` on the same URL and a **plain web fetch** returns clean Markdown (headings, fenced code, links) with no JS shell. Salesforce surfaces this via the "Copy as Markdown" / "View as Markdown" links on each page.

## Why

Browser-rendered (Playwright) extraction is heavy — it needs the isolated runtime and a Chromium download. For the large and growing set of pages that expose a `.md` twin, a plain fetch is faster, lighter, and needs no browser at all. Trying it first keeps the Playwright path as a reliable fallback for everything else.

## Notes

- **Scope documented in the change:** confirmed for modern guide pages under `developer.salesforce.com/docs/platform/.../guide/*`. It does **not** work for legacy `atlas.*` pages (`.md` returns an HTML shell) or `help.salesforce.com` — those still use the existing playbook/extractor, so the change adds a fast path without removing any coverage.
- Verified 2026-06-24 against e.g. `…/guide/js-dynamic-components.html` → `…/guide/js-dynamic-components.md` (clean Markdown) and confirmed `atlas.*` returns a shell.
- Docs-only change to one skill; frontmatter untouched, SKILL.md stays at 220 lines (within the 500-line spec limit). No script or `requirements.txt` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)