### PR TITLE
fix: allow nested YAML lists in metadata sub-keys (sync with internal) @W-23173617@

### DIFF
--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -420,7 +420,8 @@ Wrap values that contain \`: \` (colon + space), such as long descriptions with 
 /**
  * Extracts nested key-value pairs from the `metadata:` block in raw frontmatter.
  * Returns `null` if no metadata block, `"scalar"` if metadata has an inline value,
- * `"list"` if it contains YAML list items, or a `Record` of sub-keys.
+ * `"list"` if direct children are YAML list items, or a `Record` of sub-keys.
+ * Nested lists under sub-keys (e.g. cliTools: [{tool:"sf"}]) are allowed.
  */
 function parseMetadataBlock(rawFrontmatter: string): Record<string, string> | "scalar" | "list" | null {
   const lines = rawFrontmatter.split(/\r?\n/)
@@ -431,12 +432,16 @@ function parseMetadataBlock(rawFrontmatter: string): Record<string, string> | "s
   const inlineValue = metaLine.slice(metaLine.indexOf(":") + 1).trim()
   if (inlineValue && !inlineValue.startsWith("#")) return "scalar"
 
+  let directIndent: number | null = null
   const result: Record<string, string> = {}
   for (let i = metaIdx + 1; i < lines.length; i++) {
     const line = lines[i]
     if (!line.startsWith(" ") && !line.startsWith("\t")) break
+    const indent = line.length - line.trimStart().length
+    if (directIndent === null) directIndent = indent
     const trimmed = line.trim()
-    if (trimmed.startsWith("- ")) return "list"
+    if (indent === directIndent && trimmed.startsWith("- ")) return "list"
+    if (indent !== directIndent) continue
     const colonIdx = trimmed.indexOf(":")
     if (colonIdx === -1) continue
     const key = trimmed.slice(0, colonIdx).trim()


### PR DESCRIPTION
@W-23173617@
## Summary

- Syncs `parseMetadataBlock()` in `scripts/validate-skills.ts` with the internal repo (`sf-skills-internal`)
- The public version incorrectly rejected any `- ` line inside the `metadata:` block, including valid nested lists under sub-keys like `cliTools`
- The internal repo already has this fix — this PR brings parity

## Problem

The `release-skills.yml` workflow failed ([run #28168727658](https://github.com/forcedotcom/sf-skills/actions/runs/28168727658)) because `getting-metadata-api-context` uses a valid `cliTools` list-of-maps format that the public validator rejects:

```yaml
metadata:
  version: "1.0"
  cliTools:
    - tool: ["jq"]      # ← public validator sees this as "metadata is a list"
      semver: ">=1.6"
```

## Fix

Track the indentation level of direct children of `metadata:`. Only flag `"list"` when `- ` appears at that top level — nested lists under sub-keys are allowed.

## Test plan

- [ ] `npm run validate:skills` passes on current main (including `getting-metadata-api-context`)
- [ ] Re-run `release-skills.yml` after merge to cut 1.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)