### PR TITLE
fix: @W-22259678@ update stale skill name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The skills are contributed by Salesforce and the broader community. It’s optim
 ```
 sf-skills/
 ├── skills/               # Directory-based executable workflows
-│   ├── generating-apex/
-│   ├── generating-custom-object/
-│   ├── generating-flow/
+│   ├── platform-apex-generate/
+│   ├── platform-custom-object-generate/
+│   ├── automation-flow-generate/
 │   └── ...
 ├── samples/              # Synced sample apps (e.g. from npm)
 │   └── ui-bundle-template-app-react-sample-b2e/

--- a/samples/ui-bundle-template-app-react-sample-b2e/AGENT.md
+++ b/samples/ui-bundle-template-app-react-sample-b2e/AGENT.md
@@ -146,7 +146,7 @@ Do not consider a task complete until all three steps have been run successfully
 
 ### Data access (Salesforce)
 
-**Before writing any code that connects to Salesforce, you MUST invoke the `using-ui-bundle-salesforce-data` skill. Do not write any data access code without consulting it first.**
+**Before writing any code that connects to Salesforce, you MUST invoke the `experience-ui-bundle-salesforce-data-access` skill. Do not write any data access code without consulting it first.**
 
 This applies to: GraphQL queries/mutations, REST calls, SDK initialization, custom hooks that fetch data, or any code that imports from `@salesforce/platform-sdk`.
 

--- a/samples/ui-bundle-template-app-react-sample-b2x/AGENT.md
+++ b/samples/ui-bundle-template-app-react-sample-b2x/AGENT.md
@@ -146,7 +146,7 @@ Do not consider a task complete until all three steps have been run successfully
 
 ### Data access (Salesforce)
 
-**Before writing any code that connects to Salesforce, you MUST invoke the `using-ui-bundle-salesforce-data` skill. Do not write any data access code without consulting it first.**
+**Before writing any code that connects to Salesforce, you MUST invoke the `experience-ui-bundle-salesforce-data-access` skill. Do not write any data access code without consulting it first.**
 
 This applies to: GraphQL queries/mutations, REST calls, SDK initialization, custom hooks that fetch data, or any code that imports from `@salesforce/platform-sdk`.
 


### PR DESCRIPTION
## Summary
@W-22259678@

- Updates README.md folder structure to use current skill naming convention (`platform-apex-generate`, `platform-custom-object-generate`, `automation-flow-generate`)
- Fixes stale `using-ui-bundle-salesforce-data` references in both b2e and b2x sample AGENT.md files to `experience-ui-bundle-salesforce-data-access`

## Test plan
- [ ] Verify no broken skill invocations from sample AGENT.md files
- [ ] Confirm README structure reflects current `skills/` directory naming