### PR TITLE
docs(W-23363336): add stability disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository provides a curated collection of Salesforce agent skills for bui
 
 The skills are contributed by Salesforce and the broader community. It’s optimized for Agentforce Vibes and can be used with any AI tool that supports skills.
 
+> ⚠️ **Expect frequent changes.** The Salesforce skills library is evolving rapidly as we refine patterns and incorporate feedback. Skills may be renamed, restructured, or removed between releases — they do not follow the same stability guarantees as GA platform APIs. If you’ve forked or synced the repository, be prepared for upstream changes that may conflict with local modifications. This repository is always the source of truth.
+
 ## 🗂️ Structure
 
 ```


### PR DESCRIPTION
@W-23363336@

## Summary
- Adds a stability disclaimer to README.md setting expectations for developers who fork or sync the repo
- Skills are under active development and don't carry GA-level stability guarantees
- Skill names, structure, and availability may change without notice

## Context
Cherry-picked from internal repo (commit by Gaurang Mathur on sf-skills-internal develop branch).

## Test plan
- [x] Only README.md modified — single line addition
- [x] No functional changes