### PR TITLE
feat(experience-lwc-generate): add native lightning/modal example, ma…

### DIFF
--- a/skills/experience-lwc-generate/SKILL.md
+++ b/skills/experience-lwc-generate/SKILL.md
@@ -168,7 +168,8 @@ Local Dev commands install just-in-time on first run. They are long-running proc
 - [assets/jest-test/componentName.test.js.example](assets/jest-test/componentName.test.js.example) — Jest test template (copy and rename, remove `.example` suffix)
 - [assets/message-channel/lmsPublisher.js](assets/message-channel/lmsPublisher.js) — LMS publisher pattern
 - [assets/message-channel/lmsSubscriber.js](assets/message-channel/lmsSubscriber.js) — LMS subscriber pattern
-- [assets/modal-component/modalComponent.js](assets/modal-component/modalComponent.js) — modal with focus trap and ESC handling
+- [assets/native-modal-component/nativeModalComponent.js](assets/native-modal-component/nativeModalComponent.js) — default modal pattern using the native `lightning/modal` service
+- [assets/modal-component/modalComponent.js](assets/modal-component/modalComponent.js) — custom composable modal (focus trap, ESC handling); only for cases `lightning/modal` can't cover
 - [assets/record-picker/recordPicker.js](assets/record-picker/recordPicker.js) — record picker with search
 - [assets/state-store/store.js](assets/state-store/store.js) — reactive state store for cross-component state
 - [assets/typescript-component/typescriptComponent.ts](assets/typescript-component/typescriptComponent.ts) — TypeScript-enabled component (Spring '26)

--- a/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.html
+++ b/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.html
@@ -1,0 +1,21 @@
+<template>
+    <lightning-modal-header label={label}></lightning-modal-header>
+
+    <lightning-modal-body>
+        <p>{content}</p>
+        <slot></slot>
+    </lightning-modal-body>
+
+    <lightning-modal-footer>
+        <lightning-button
+            label="Cancel"
+            onclick={handleCancel}
+            class="slds-m-right_x-small">
+        </lightning-button>
+        <lightning-button
+            variant="brand"
+            label="Save"
+            onclick={handleSave}>
+        </lightning-button>
+    </lightning-modal-footer>
+</template>

--- a/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.js
+++ b/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.js
@@ -1,0 +1,62 @@
+/**
+ * NATIVE MODAL TEMPLATE (lightning/modal)
+ *
+ * Uses the platform's built-in modal service instead of a hand-rolled
+ * backdrop/focus-trap implementation. LightningModal already provides:
+ * - focus trap and initial focus
+ * - ESC-to-close
+ * - ARIA roles/labels
+ * - size variants (small / medium / large / full)
+ * - a promise-based result returned from open()
+ *
+ * Supported in Lightning Experience, the Salesforce app, and Experience
+ * Builder sites (confirm current support for your specific site template
+ * before relying on it as the only implementation).
+ *
+ * Replace: nativeModalComponent → yourModalName
+ * Replace: NativeModalComponent → YourModalName
+ *
+ * ── How a parent opens this modal ──────────────────────────────────────
+ * import YourModalName from 'c/yourModalName';
+ *
+ * async handleOpenModal() {
+ *     const result = await YourModalName.open({
+ *         size: 'small',                    // small | medium | large | full
+ *         description: 'Accessible description of the modal purpose',
+ *         label: 'Confirm Action',          // passed through as @api label
+ *         content: 'Are you sure?'          // any custom @api input props
+ *     });
+ *
+ *     if (result === 'save') {
+ *         // user confirmed
+ *     }
+ * }
+ * ────────────────────────────────────────────────────────────────────────
+ */
+import { api } from 'lwc';
+import LightningModal from 'lightning/modal';
+
+export default class NativeModalComponent extends LightningModal {
+    // ═══════════════════════════════════════════════════════════════════════
+    // PUBLIC API (@api) - Passed in via YourModalName.open({ ... })
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @api label;
+    @api content;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // EVENT HANDLERS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    handleCancel() {
+        // Resolve the promise returned by open() with a falsy/known value
+        this.close('cancel');
+    }
+
+    handleSave() {
+        // Resolve the promise returned by open() with the result the
+        // caller needs. Close is explicit, so validation can prevent it:
+        // guard this call behind your own validity check before closing.
+        this.close('save');
+    }
+}

--- a/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.js-meta.xml
+++ b/skills/experience-lwc-generate/assets/native-modal-component/nativeModalComponent.js-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    NATIVE MODAL TEMPLATE - METADATA
+
+    Modals that extend lightning/modal are opened imperatively via
+    YourModalName.open({ ... }) from another component's JS — they are
+    not placed declaratively on a page, so isExposed stays false and no
+    targets are declared.
+-->
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/skills/experience-lwc-generate/references/component-patterns.md
+++ b/skills/experience-lwc-generate/references/component-patterns.md
@@ -612,7 +612,9 @@ const BATCH_CREATE = gql`
 
 ## Modal Component Pattern
 
-Based on [James Simone's composable modal pattern](https://www.jamessimone.net/blog/joys-of-apex/lwc-composable-modal/).
+**Default to the native `lightning/modal` service** — see [assets/native-modal-component](../assets/native-modal-component/nativeModalComponent.js). It ships focus trap, ESC-to-close, ARIA, and size variants out of the box, so there's nothing to reinvent. Confirm it's supported on the target surface (some Experience Builder site templates historically lagged Lightning Experience support) before falling back to a custom implementation.
+
+Only reach for a custom composable modal below when `lightning/modal` genuinely can't cover the case (e.g. a confirmed gap on your site template, or composition needs beyond what `LightningModal` slots support). It's based on [James Simone's composable modal pattern](https://www.jamessimone.net/blog/joys-of-apex/lwc-composable-modal/); see [assets/modal-component](../assets/modal-component/modalComponent.js) for the fuller version with cleanup and multi-slot composition. Prefer a `save`/`cancel` `CustomEvent` over a function-reference `@api` prop for the save handler — function references can't be passed from Aura markup, which breaks on Aura-based Experience Builder pages.
 
 ```javascript
 // composableModal.js


### PR DESCRIPTION
## What changed

Added a new `assets/native-modal-component/` bundle to `experience-lwc-generate` (`nativeModalComponent.js`, `.html`, `.js-meta.xml`) demonstrating the native `lightning/modal` service (`LightningModal`) — header/body/footer via `lightning-modal-*` subcomponents, `@api` inputs, and explicit `close()` per action, with a usage snippet showing how a parent opens it via `YourModalName.open({...})`.

Updated `SKILL.md`'s asset index and `references/component-patterns.md`'s Modal Component Pattern section to list the native modal as the default pattern, and re-labeled the existing hand-rolled composable modal (`assets/modal-component/`) as a fallback for cases `lightning/modal` can't cover.

## Why

The existing modal asset only showed a ~200-line custom composable modal (focus trap, ESC handling, backdrop) based on an older blog pattern, even though this skill's own reference doc already lists `lightning/modal` as the native solution and says "avoid reinventing what base components already provide." The custom pattern also passes a save handler as a function reference via `@api`, which doesn't work when the component sits on an Aura-based Experience Builder page. Native `lightning/modal` gets focus trap, ESC-to-close, ARIA, and size variants for free, and current Salesforce docs confirm it's usable in Aura-based Experience Builder sites, so it should be the default example rather than the fallback.

## Notes

- Didn't remove `assets/modal-component/`, since it's still useful where `lightning/modal` isn't available (e.g. an unconfirmed gap on some LWR site templates) — flagged it as fallback instead of deleting it.
- Not yet validated end-to-end in an actual Experience Builder site; would be good for a reviewer with org access to confirm `lightning/modal` behavior on their site template of choice.
- Didn't touch the function-reference `@api modalSaveHandler` anti-pattern in the existing custom modal — left as a follow-up since fixing it means changing that component's public API.

---

## Skills

### Manual checklist

**Description quality**
- [x] Describes what the skill does and the expected output
- [x] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [x] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [x] Clear goal statement
- [x] Step-by-step workflow
- [x] Validation rules for generated output
- [x] Defined output / artifact

**Context efficiency**
- [x] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [x] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
