### PR TITLE
feat: make experience-ui-bundle-project-generate framework-agnostic with react and angular references

### DIFF
--- a/skills/experience-ui-bundle-project-generate/SKILL.md
+++ b/skills/experience-ui-bundle-project-generate/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: experience-ui-bundle-project-generate
-description: "Generates a minimal, ready-to-develop SFDX starter project from template instead of hand-scaffolding files. Use this skill when starting a brand-new Salesforce React UI bundle app and the initial project must be scaffolded — trigger phrases include create, start, or scaffold a new React UI bundle app, generate a starter project, or use a prebuilt/starter template. DO NOT TRIGGER when: editing, styling, or adding pages or components to an EXISTING app (use experience-ui-bundle-frontend-generate); configuring ui-bundle.json or metadata files (use experience-ui-bundle-metadata-generate); deploying to an org (use experience-ui-bundle-deploy); or when the user explicitly says they want to hand-scaffold from scratch."
+description: "Generates a minimal, ready-to-develop SFDX starter project from template instead of hand-scaffolding files. Use this skill when starting a brand-new Salesforce UI bundle app (any supported frontend framework) and the initial project must be scaffolded — trigger phrases include create, start, or scaffold a new UI bundle app, generate a starter project, or use a prebuilt/starter template. DO NOT TRIGGER when: editing, styling, or adding pages or components to an EXISTING app (use experience-ui-bundle-frontend-generate); configuring ui-bundle.json or metadata files (use experience-ui-bundle-metadata-generate); deploying to an org (use experience-ui-bundle-deploy); or when the user explicitly says they want to hand-scaffold from scratch."
 metadata:
-  version: "1.1"
+  version: "1.2"
   relatedSkills:
     - "experience-ui-bundle-app-coordinate"
     - "experience-ui-bundle-metadata-generate"
@@ -20,20 +20,24 @@ metadata:
 
 # Using a UI Bundle Template
 
-Before building a Salesforce React UI bundle app from scratch, offer the user a **prebuilt starter template**. The Salesforce CLI generates these — a complete, deployable SFDX project (React UI bundle + toolchain + an `npm run setup` automation) — in one command. Starting from a starter is faster and less error-prone than hand-scaffolding.
+Before building a Salesforce UI bundle app from scratch, offer the user a **prebuilt starter template**. The Salesforce CLI generates these — a complete, deployable SFDX project (UI bundle + toolchain + an `npm run setup` automation) — in one command. Starting from a starter is faster and less error-prone than hand-scaffolding.
 
 The CLI command is `sf template generate project`.
 
 ## Step 1: Offer the choice
 
-The following are the templates. Ask the user which one fits, or whether they want to start from scratch.
+**Determine the framework.** It is normally already decided by the calling context — either passed down by the root/coordinator skill that invoked this one, or stated in the user's request. Use that.
 
-| Template | `--template` flag | Best for |
-|----------|-------------------|----------|
-| Internal starter | `reactinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes Agentforce chat. No login flow or public. |
-| External starter | `reactexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Full auth support (login, registration, reset, profile) -- external users sign in with their own accounts. |
+The frameworks this skill supports are exactly the reference files under [`references/`](references/), each named `<framework>-project-generate.md` (so `react` → `references/react-project-generate.md`). This is the single source of truth — adding a framework means adding a reference file, nothing here changes.
 
-**If the user prefers to start from scratch** (or neither fits), stop here and let `experience-ui-bundle-app-coordinate` scaffold a new project. This skill is opt-in — do not force a template.
+- **If the framework is known** — open `references/<framework>-project-generate.md`.
+- **If it is unknown** (a standalone run where nobody said which) — list `references/`, derive the supported set by stripping the `-project-generate.md` suffix from each filename, and ask the user to pick one of those. If the user names a framework with no matching reference file, it is not supported here — hand off to `experience-ui-bundle-app-coordinate` to scaffold from scratch.
+
+Each reference lists that framework's `--template` flags and what each starter contains. Pick the one that fits the user's audience (internal vs. external).
+
+**If the user prefers to start from scratch** (or neither template fits), stop here and let `experience-ui-bundle-app-coordinate` scaffold a new project. This skill is opt-in — do not force a template.
+
+Once the user picks, carry the chosen `--template` flag into Step 2.
 
 ## Step 2: Generate the project into the target root
 
@@ -47,8 +51,8 @@ The project contents must land **directly at the target root `$DEST`** — so `s
 NAME=MyApp   # project name the user chose; also names the UI bundle
 DEST=.       # target root directory (the contents land directly here, no NAME/ wrapper)
 
-# choose ONE template flag based on the user's pick from Step 1
-TEMPLATE=reactinternalapp   # or reactexternalapp
+# the --template flag from the framework reference chosen in Step 1
+TEMPLATE=reactinternalapp   # example placeholder — replace with the flag from your Step-1 reference
 
 mkdir -p "$DEST"
 sf template generate project --name "$NAME" --template "$TEMPLATE" --output-dir "$DEST"
@@ -69,7 +73,7 @@ After generation, confirm the contents landed at the root (not in a `$NAME/` sub
 test -f "$DEST/sfdx-project.json" && echo "OK: project root landed" || echo "FAILED"
 ```
 
-`sfdx-project.json` must sit at `$DEST/sfdx-project.json`. The project also contains `package.json`, `force-app/main/default/uiBundles/$NAME/` (the React/Vite bundle), `scripts/`, `config/`, and `README.md`. If `sfdx-project.json` is missing or is one level down in `$DEST/$NAME/`, the flatten did not run — re-check before continuing.
+`sfdx-project.json` must sit at `$DEST/sfdx-project.json`. The project also contains `package.json`, `force-app/main/default/uiBundles/$NAME/` (the UI bundle), `scripts/`, `config/`, and `README.md`. See the framework reference from Step 1 for the specific bundle contents. If `sfdx-project.json` is missing or is one level down in `$DEST/$NAME/`, the flatten did not run — re-check before continuing.
 
 ## Step 3: Install dependencies (you do this — do NOT hand off uninstalled)
 
@@ -89,7 +93,7 @@ for b in "$DEST"/force-app/main/default/uiBundles/*/; do
 done
 ```
 
-> First-run install of the bundle is the heavy step (tailwind, radix-ui, recharts, vite, etc.); expect a short wait. If an install fails, surface it — don't hand off a half-installed project.
+> First-run install of the bundle is the heavy step; expect a short wait. If an install fails, surface it — don't hand off a half-installed project.
 
 ## Step 4: Confirm and hand off
 

--- a/skills/experience-ui-bundle-project-generate/SKILL.md
+++ b/skills/experience-ui-bundle-project-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: experience-ui-bundle-project-generate
-description: "Generates a minimal, ready-to-develop SFDX starter project from template instead of hand-scaffolding files. Use this skill when starting a brand-new Salesforce UI bundle app (any supported frontend framework) and the initial project must be scaffolded — trigger phrases include create, start, or scaffold a new UI bundle app, generate a starter project, or use a prebuilt/starter template. DO NOT TRIGGER when: editing, styling, or adding pages or components to an EXISTING app (use experience-ui-bundle-frontend-generate); configuring ui-bundle.json or metadata files (use experience-ui-bundle-metadata-generate); deploying to an org (use experience-ui-bundle-deploy); or when the user explicitly says they want to hand-scaffold from scratch."
+description: "Generates a minimal, ready-to-develop SFDX starter project from template instead of hand-scaffolding files. Use this skill when starting a brand-new Salesforce UI bundle app (React or Angular) and the initial project must be scaffolded — trigger phrases include create, start, or scaffold a new UI bundle app, generate a starter project, or use a prebuilt/starter template. DO NOT TRIGGER when: editing, styling, or adding pages or components to an EXISTING app (use experience-ui-bundle-frontend-generate); configuring ui-bundle.json or metadata files (use experience-ui-bundle-metadata-generate); deploying to an org (use experience-ui-bundle-deploy); or when the user explicitly says they want to hand-scaffold from scratch."
 metadata:
   version: "1.2"
   relatedSkills:
@@ -28,10 +28,10 @@ The CLI command is `sf template generate project`.
 
 **Determine the framework.** It is normally already decided by the calling context — either passed down by the root/coordinator skill that invoked this one, or stated in the user's request. Use that.
 
-The frameworks this skill supports are exactly the reference files under [`references/`](references/), each named `<framework>-project-generate.md` (so `react` → `references/react-project-generate.md`). This is the single source of truth — adding a framework means adding a reference file, nothing here changes.
+The frameworks this skill supports are exactly the reference files under `<SKILL_DIR>/references/`, each named `<framework>-project-generate.md` (so `react` → `<SKILL_DIR>/references/react-project-generate.md`). This is the single source of truth — adding a framework means adding a reference file, nothing here changes.
 
-- **If the framework is known** — open `references/<framework>-project-generate.md`.
-- **If it is unknown** (a standalone run where nobody said which) — list `references/`, derive the supported set by stripping the `-project-generate.md` suffix from each filename, and ask the user to pick one of those. If the user names a framework with no matching reference file, it is not supported here — hand off to `experience-ui-bundle-app-coordinate` to scaffold from scratch.
+- **If the framework is known** — open `<SKILL_DIR>/references/<framework>-project-generate.md`.
+- **If it is unknown** (a standalone run where nobody said which) — list `<SKILL_DIR>/references/`, derive the supported set by stripping the `-project-generate.md` suffix from each filename, and ask the user to pick one of those. If the user names a framework with no matching reference file, it is not supported here — hand off to `experience-ui-bundle-app-coordinate` to scaffold from scratch.
 
 Each reference lists that framework's `--template` flags and what each starter contains. Pick the one that fits the user's audience (internal vs. external).
 

--- a/skills/experience-ui-bundle-project-generate/references/angular-project-generate.md
+++ b/skills/experience-ui-bundle-project-generate/references/angular-project-generate.md
@@ -1,0 +1,25 @@
+# Angular UI Bundle Starter Templates
+
+Reference for the **Angular** path of `experience-ui-bundle-project-generate`. Pick the `--template` flag that fits the user's audience, then return to Step 2 of `SKILL.md`.
+
+## Template options
+
+| Template | `--template` flag | Best for |
+|----------|-------------------|----------|
+| Internal starter | `angularinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes Agentforce chat. No login flow or public access. |
+| External starter | `angularexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
+
+> The customer-typed CLI template names are `angularinternalapp` / `angularexternalapp`.
+
+## What the bundle contains
+
+The generated UI bundle under `force-app/main/default/uiBundles/$NAME/` is an **Angular** app (Angular 21.2.x):
+
+- **Build:** Angular CLI driven by `angular.json` with the `@angular/build:application` builder (esbuild-based). Salesforce platform integration is wired through the `@salesforce/angular-plugin-ui-bundle` esbuild plugin (via `@angular-builders/custom-esbuild`) — registered in `angular.json` `plugins[]` / `middlewares[]`, which handle API-version substitution, the org proxy, and Live Preview / `SFDC_ENV` / base-href injection.
+- **Components:** standalone components + signals + native control flow (`@if`/`@for`); each component is a `.component.ts` + `.component.html` pair (`templateUrl`).
+- **App wiring:** entry `src/main.ts`; `src/app/app.component.ts` + `.html`; `src/app/app.config.ts` (`APP_BASE_HREF` + `SFDC_ENV.basePath`); `src/app/app.routes.ts`. Pages under `src/pages/` (e.g. `home/`, `not-found/`) as component/template pairs.
+- **UI library:** 16 shared primitives + layout on **Angular Material M3** (`mat.theme()`) + **CDK 21.2.x**, styled with **shadcn design tokens** (remap the `--mat-sys-*` variables) and **Tailwind 4.0**.
+- **Data layer:** injectable GraphQL client `src/api/graphql-client.service.ts`. GraphQL type codegen is optional and manual (not chained to the build).
+- **Metadata & config:** `ui-bundle.json`, `*.uibundle-meta.xml`, `tsconfig.*`, `eslint.config.js`, `README.md`.
+
+The `--internal` vs `--external` split matches the two flags above: internal ships the Agentforce Conversation Client and skips auth; external ships the full authentication flow (login, register, forgot/reset password, profile).

--- a/skills/experience-ui-bundle-project-generate/references/angular-project-generate.md
+++ b/skills/experience-ui-bundle-project-generate/references/angular-project-generate.md
@@ -6,10 +6,8 @@ Reference for the **Angular** path of `experience-ui-bundle-project-generate`. P
 
 | Template | `--template` flag | Best for |
 |----------|-------------------|----------|
-| Internal starter | `angularinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes Agentforce chat. No login flow or public access. |
-| External starter | `angularexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
-
-> The customer-typed CLI template names are `angularinternalapp` / `angularexternalapp`.
+| Internal starter | `angularinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes agent chat container. No login flow or public access. |
+| External starter | `angularexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Includes agent chat container. Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
 
 ## What the bundle contains
 
@@ -21,5 +19,3 @@ The generated UI bundle under `force-app/main/default/uiBundles/$NAME/` is an **
 - **UI library:** 16 shared primitives + layout on **Angular Material M3** (`mat.theme()`) + **CDK 21.2.x**, styled with **shadcn design tokens** (remap the `--mat-sys-*` variables) and **Tailwind 4.0**.
 - **Data layer:** injectable GraphQL client `src/api/graphql-client.service.ts`. GraphQL type codegen is optional and manual (not chained to the build).
 - **Metadata & config:** `ui-bundle.json`, `*.uibundle-meta.xml`, `tsconfig.*`, `eslint.config.js`, `README.md`.
-
-The `--internal` vs `--external` split matches the two flags above: internal ships the Agentforce Conversation Client and skips auth; external ships the full authentication flow (login, register, forgot/reset password, profile).

--- a/skills/experience-ui-bundle-project-generate/references/react-project-generate.md
+++ b/skills/experience-ui-bundle-project-generate/references/react-project-generate.md
@@ -6,8 +6,8 @@ Reference for the **React** path of `experience-ui-bundle-project-generate`. Pic
 
 | Template | `--template` flag | Best for |
 |----------|-------------------|----------|
-| Internal starter | `reactinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes Agentforce chat. No login flow or public access. |
-| External starter | `reactexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
+| Internal starter | `reactinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes agent chat container. No login flow or public access. |
+| External starter | `reactexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Includes agent chat container. Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
 
 ## What the bundle contains
 
@@ -18,5 +18,3 @@ The generated UI bundle under `force-app/main/default/uiBundles/$NAME/` is a **R
 - `.tsx` pages/components; app entry `src/App.tsx`, pages under `src/pages/`.
 - GraphQL client (`src/api/graphqlClient.ts`) + codegen (`codegen.yml`), `useAsyncData` data util.
 - `ui-bundle.json`, `*.uibundle-meta.xml`, project config, `README.md`.
-
-The `--internal` vs `--external` split matches the two flags above: internal ships the Agentforce chat and skips auth; external ships the full authentication flow.

--- a/skills/experience-ui-bundle-project-generate/references/react-project-generate.md
+++ b/skills/experience-ui-bundle-project-generate/references/react-project-generate.md
@@ -1,0 +1,22 @@
+# React UI Bundle Starter Templates
+
+Reference for the **React** path of `experience-ui-bundle-project-generate`. Pick the `--template` flag that fits the user's audience, then return to Step 2 of `SKILL.md`.
+
+## Template options
+
+| Template | `--template` flag | Best for |
+|----------|-------------------|----------|
+| Internal starter | `reactinternalapp` | Starter for internal, employee-facing Salesforce apps (e.g. support consoles, ops dashboards, internal admin apps) — users are already-authenticated employees. Includes Agentforce chat. No login flow or public access. |
+| External starter | `reactexternalapp` | Starter for customer/partner-facing Salesforce apps/sites (e.g. portals, communities, storefront, public sites). Full auth support (login, registration, reset, profile) — external users sign in with their own accounts. |
+
+## What the bundle contains
+
+The generated UI bundle under `force-app/main/default/uiBundles/$NAME/` is a **React/Vite** app:
+
+- React + Vite toolchain, TypeScript, `vite.config.ts`.
+- shadcn/ui primitives (`src/components/ui/`), Tailwind.
+- `.tsx` pages/components; app entry `src/App.tsx`, pages under `src/pages/`.
+- GraphQL client (`src/api/graphqlClient.ts`) + codegen (`codegen.yml`), `useAsyncData` data util.
+- `ui-bundle.json`, `*.uibundle-meta.xml`, project config, `README.md`.
+
+The `--internal` vs `--external` split matches the two flags above: internal ships the Agentforce chat and skips auth; external ships the full authentication flow.


### PR DESCRIPTION
…ndle-project-generate skill

**References:** [Contributing guide](../CONTRIBUTING.md) · [Skill authoring guide](../README.md) · [Agent Skills spec](https://agentskills.io/specification)

## What changed

<!-- Briefly describe what skill(s) were added, updated, or removed. -->

## Why

<!-- What gap does this fill, or what problem does it solve? -->

## Notes

<!-- Anything reviewers should know — testing approach, follow-ups, open questions. -->

---

## Skills

### Manual checklist

**Description quality**
- [ ] Describes what the skill does and the expected output
- [ ] Includes relevant Salesforce domain keywords (Apex, LWC, SOQL, metadata types, etc.)
- [ ] Trigger phrases are specific enough for Vibes to select this skill reliably

**Instructions**
- [ ] Clear goal statement
- [ ] Step-by-step workflow
- [ ] Validation rules for generated output
- [ ] Defined output / artifact

**Context efficiency**
- [ ] Core instructions are concise — supporting material lives in `templates/`, `examples/`, or `docs/` subdirectories
- [ ] No unnecessary background explanation in the body

### Automated checks

Enforced by CI ([`npm run validate:skills`](../scripts/validate-skills.ts)) per the [Agent Skills spec](https://agentskills.io/specification):

- Directory is one level deep, named in kebab-case (max 64 chars), contains `SKILL.md`
- Frontmatter `name` matches directory name; `description` is present, ≥ 20 words, ≤ 1024 characters, and includes trigger language
- Body is non-empty and under 500 lines
- Name uses gerund form ⚠ (warning — does not block merge)
