### PR TITLE
Add .git2gus/config.json @W-23821699@

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,0 +1,15 @@
+{
+  "productTag": "a1aEE000002EUebYAG",
+  "productTagLabels": {
+    "area:plugins": "a1aEE000002VQOTYA4",
+    "area:skills": "a1aEE000002EUebYAG"
+  },
+  "defaultBuild": "offcore.tooling.65",
+  "issueTypeLabels": {
+    "feature": "USER STORY",
+    "regression": "BUG P1",
+    "bug": "BUG P3"
+  },
+  "hideWorkItemUrl": "true",
+  "statusWhenClosed": "CLOSED"
+}


### PR DESCRIPTION
## Summary
- Add `.git2gus/config.json` to enable Git2Gus work-item integration for this repo
- Product tag defaults to the Metadata Experts Skills Core team, with `area:plugins`/`area:skills` labels mapping to the DX Agent Plugins and Metadata Experts Skills Core teams respectively (co-owned)

## Test plan
- [ ] Confirm Git2Gus picks up work item references in commits/PRs using this config

@W-23821699@

🤖 Generated with [Claude Code](https://claude.com/claude-code)