### PR TITLE
ci: retire obsolete skills-released dispatch to cline-fork @W-23853883@

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -100,12 +100,3 @@ jobs:
           npm publish --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Notify cline-fork
-        if: ${{ steps.changelog.outputs.skipped == 'false' && steps.release.outputs.id != '' && steps.publish.outcome == 'success' }}
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.IDEE_GH_TOKEN }}
-          repository: forcedotcom/cline-fork
-          event-type: skills-released
-          client-payload: '{"version": "${{ steps.changelog.outputs.version }}"}'


### PR DESCRIPTION
## What changed

Removed the `Notify cline-fork` step from `.github/workflows/release-skills.yml` — the final step that fired a `repository_dispatch` (`skills-released`) at `forcedotcom/cline-fork` after each publish.

## Why

- `cline-fork` is the retired v3 Agentforce Vibes fork; its `bump-skills.yml` consumer no longer runs, so the dispatch is a no-op.
- The v4 extension (`salesforcedx-vscode-einstein-gpt`) never consumed `skills-released` — it now keeps `@salesforce/afv-skills` current via **Dependabot** (pull-based npm polling), so no publish-side push is needed. See [salesforcedx-vscode-einstein-gpt#2721](https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt/pull/2721).
- Dispatching to an archived repo returns 403, so this step can red-fail the `release-skills` run *after* a successful npm publish — misleading noise.

## Notes

- If Dependabot proves unreliable, the fallback is a fresh dispatch targeting the **v4** repo (paired with a consumer workflow there), not a revert of this cline-fork hook. Tracked in @W-23853883@.
- No functional change to publishing: `Publish to npm` is now the final step; `IDEE_GH_TOKEN` / `NPM_TOKEN` usage elsewhere is untouched.

---

## Skills

N/A — CI workflow cleanup; no skill added, changed, or removed, so the `validate:skills` gate and the checklist below don't apply.
