### PR TITLE
fix(security): harden five agentic helper-script injection sinks @W-23533877@

### DIFF
--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -6,7 +6,7 @@
 //   npm run validate:skills                                        # validate all skills
 //   npm run validate:skills -- --changed --base=origin/main       # validate only skills changed vs base
 
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 import fs from "fs"
 import path from "path"
 import { parseArgs } from "util"
@@ -458,7 +458,12 @@ function parseMetadataBlock(rawFrontmatter: string): Record<string, string> | "s
  * valid and requires no structural validation.
  */
 function getChangedSkillDirs(base: string): string[] {
-  const output = execSync(`git diff --name-only ${base}...HEAD`, { encoding: "utf8" })
+  // `base` is passed as a single argv element (not interpolated into a shell
+  // string), so a crafted --base value cannot inject shell commands. git will
+  // reject an invalid revision, but nothing executes.
+  const output = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+    encoding: "utf8",
+  })
   return [
     ...new Set(
       output

--- a/skills/dx-code-analyzer-configure/scripts/validate-config.sh
+++ b/skills/dx-code-analyzer-configure/scripts/validate-config.sh
@@ -37,10 +37,11 @@ fi
 # Basic YAML syntax check (if python3 available)
 if command -v python3 &> /dev/null; then
     echo "Checking YAML syntax..."
-    if python3 -c "
+    if python3 - "$CONFIG_FILE" 2>&1 <<'PYEOF'; then
 import yaml, sys
+config_file = sys.argv[1]
 try:
-    with open('${CONFIG_FILE}', 'r') as f:
+    with open(config_file, 'r') as f:
         config = yaml.safe_load(f)
     if config is None:
         print('WARNING: Config file is empty or contains only comments')
@@ -50,10 +51,10 @@ try:
         sys.exit(1)
     print('YAML syntax: OK')
 except yaml.YAMLError as e:
-    print(f'ERROR: Invalid YAML syntax')
+    print('ERROR: Invalid YAML syntax')
     print(f'  {e}')
     sys.exit(1)
-" 2>&1; then
+PYEOF
         echo ""
     else
         echo ""
@@ -69,16 +70,19 @@ echo "Checking known fields..."
 VALID_TOP_LEVEL="config_root log_folder log_level rules engines ignores suppressions"
 
 if command -v python3 &> /dev/null; then
-    python3 -c "
+    python3 - "$CONFIG_FILE" "$VALID_TOP_LEVEL" 2>&1 <<'PYEOF'
 import yaml, sys
 
-with open('${CONFIG_FILE}', 'r') as f:
+config_file = sys.argv[1]
+valid_top_level = sys.argv[2]
+
+with open(config_file, 'r') as f:
     config = yaml.safe_load(f)
 
 if config is None:
     sys.exit(0)
 
-valid_fields = set('${VALID_TOP_LEVEL}'.split())
+valid_fields = set(valid_top_level.split())
 unknown = set(config.keys()) - valid_fields
 if unknown:
     print(f'WARNING: Unknown top-level fields: {sorted(unknown)}')
@@ -100,12 +104,12 @@ if 'engines' in config and config['engines']:
 # Check ignores section
 if 'ignores' in config and config['ignores']:
     if 'files' not in config['ignores']:
-        print('WARNING: ignores section should contain a \"files\" list')
+        print('WARNING: ignores section should contain a "files" list')
     elif not isinstance(config['ignores']['files'], list):
         print('ERROR: ignores.files must be a list of glob patterns')
         sys.exit(1)
     else:
-        print(f'Ignore patterns: {len(config[\"ignores\"][\"files\"])} patterns configured')
+        print(f'Ignore patterns: {len(config["ignores"]["files"])} patterns configured')
 
 # Check rules section
 if 'rules' in config and config['rules']:
@@ -120,7 +124,7 @@ if 'rules' in config and config['rules']:
                             print(f'WARNING: rules.{engine}.{rule_name}.severity = {sev} (expected 1-5 or Critical/High/Moderate/Low/Info)')
 
 print('')
-" 2>&1
+PYEOF
 fi
 
 # Run sf code-analyzer config validation (if sf CLI available)

--- a/skills/dx-code-analyzer-run/scripts/apply-fixes.js
+++ b/skills/dx-code-analyzer-run/scripts/apply-fixes.js
@@ -15,14 +15,39 @@ const filePath = process.argv[2];
 const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
 const runDir = data.runDir || "";
 
-// Group fixes by file
+// Fix targets are confined to the current working directory (the project being
+// fixed). loc.file and runDir come from the results JSON and are untrusted;
+// resolving each target against cwd and rejecting anything that escapes it
+// stops a crafted results file from writing arbitrary paths (e.g. /etc/passwd
+// or ../../outside-project).
+const baseDir = process.cwd();
+
+function safeResolve(candidate) {
+  if (typeof candidate !== "string" || !candidate) return null;
+  let rel = candidate;
+  // Engine output often uses absolute paths under the scan runDir; normalize
+  // those to project-relative before confinement.
+  if (runDir && rel.startsWith(runDir)) rel = rel.substring(runDir.length + 1);
+  const resolved = path.resolve(baseDir, rel);
+  const within = path.relative(baseDir, resolved);
+  if (within === "" || within.startsWith("..") || path.isAbsolute(within)) {
+    return null;
+  }
+  return resolved;
+}
+
+// Group fixes by confined, absolute file path
 const fileFixesMap = new Map();
+let fixesSkippedUnsafe = 0;
 data.violations.forEach(v => {
   if (v.fixes && v.fixes.length > 0) {
     v.fixes.forEach(fix => {
       const loc = fix.location;
-      let filePath = loc.file;
-      if (runDir && filePath.startsWith(runDir)) filePath = filePath.substring(runDir.length + 1);
+      const filePath = safeResolve(loc.file);
+      if (!filePath) {
+        fixesSkippedUnsafe++;
+        return;
+      }
 
       if (!fileFixesMap.has(filePath)) fileFixesMap.set(filePath, []);
       fileFixesMap.get(filePath).push({
@@ -83,4 +108,4 @@ fileFixesMap.forEach((fixes, filePath) => {
   }
 });
 
-console.log(JSON.stringify({ success: true, filesModified, fixesApplied, fixesSkipped, totalFixableFiles: fileFixesMap.size }));
+console.log(JSON.stringify({ success: true, filesModified, fixesApplied, fixesSkipped, fixesSkippedUnsafe, totalFixableFiles: fileFixesMap.size }));

--- a/skills/dx-code-analyzer-run/scripts/describe-rule.js
+++ b/skills/dx-code-analyzer-run/scripts/describe-rule.js
@@ -15,7 +15,33 @@
 //       resource:    https://...
 //       description: Some description text
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
+
+/**
+ * Run `sf code-analyzer rules ...` safely.
+ *
+ * Arguments are passed as an argv array (NOT a shell string), so a rule name
+ * or --engine value can never be interpreted as shell syntax. Returns the
+ * command's stdout as text; never throws (a non-zero exit still yields the
+ * output the caller wants to parse).
+ */
+function runCodeAnalyzerRules(extraArgs) {
+  try {
+    return execFileSync("sf", ["code-analyzer", "rules", ...extraArgs], {
+      encoding: "utf8",
+      timeout: 60000,
+      maxBuffer: 2 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    return (
+      err.stdout ||
+      err.stderr ||
+      (err.output && err.output.filter(Boolean).join("")) ||
+      ""
+    );
+  }
+}
 
 function printUsage() {
   console.error(`Usage: node describe-rule.js <rule-name> [--engine <engine>]
@@ -52,25 +78,21 @@ for (let i = 1; i < args.length; i++) {
 // Build the rule selector for the lookup
 const selector = engine ? `${engine}:${ruleName}` : ruleName;
 
-// Run `sf code-analyzer rules` with --view detail to get full rule info
-let rawOutput;
-try {
-  const cmd = `sf code-analyzer rules --rule-selector "${selector}" --view detail 2>&1`;
-  rawOutput = execSync(cmd, {
-    encoding: "utf8",
-    timeout: 60000,
-    maxBuffer: 2 * 1024 * 1024,
-  });
-} catch (err) {
-  // execSync throws on non-zero exit, but we still want the output
-  rawOutput = err.stdout || err.stderr || (err.output && err.output.join("")) || "";
-  if (!rawOutput) {
-    console.log(JSON.stringify({
-      status: "error",
-      message: `Failed to run sf code-analyzer rules: ${err.message}`,
-    }));
-    process.exit(0);
-  }
+// Run `sf code-analyzer rules` with --view detail to get full rule info.
+// `selector` is passed as a single argv element, so it cannot inject shell
+// commands even if it contains metacharacters.
+const rawOutput = runCodeAnalyzerRules([
+  "--rule-selector",
+  selector,
+  "--view",
+  "detail",
+]);
+if (!rawOutput) {
+  console.log(JSON.stringify({
+    status: "error",
+    message: `Failed to run sf code-analyzer rules for selector "${selector}"`,
+  }));
+  process.exit(0);
 }
 
 // Parse the detail view output
@@ -224,12 +246,16 @@ function parseDetailOutput(output) {
 function tryGrepFallback(ruleName, engine) {
   try {
     const sel = engine || "Recommended";
-    const cmd = `sf code-analyzer rules --rule-selector "${sel}" 2>&1 | grep -i "${ruleName}"`;
-    const grepOutput = execSync(cmd, {
-      encoding: "utf8",
-      timeout: 60000,
-      maxBuffer: 2 * 1024 * 1024,
-    });
+    const output = runCodeAnalyzerRules(["--rule-selector", sel]);
+
+    // Case-insensitive substring filter done in JS. Previously this shelled out
+    // to `... | grep -i "${ruleName}"`, interpolating the untrusted rule name
+    // into a shell command; matching here removes that injection sink.
+    const needle = ruleName.toLowerCase();
+    const grepOutput = output
+      .split("\n")
+      .filter((line) => line.toLowerCase().includes(needle))
+      .join("\n");
 
     if (!grepOutput.trim()) return null;
 
@@ -273,12 +299,7 @@ function tryGrepFallback(ruleName, engine) {
 function tryFuzzyFallback(ruleName, engine) {
   try {
     const sel = engine || "Recommended";
-    const cmd = `sf code-analyzer rules --rule-selector "${sel}" 2>&1`;
-    const output = execSync(cmd, {
-      encoding: "utf8",
-      timeout: 60000,
-      maxBuffer: 2 * 1024 * 1024,
-    });
+    const output = runCodeAnalyzerRules(["--rule-selector", sel]);
 
     // Extract rule names from table output
     // Lines with rule data have: index  name  engine  severity  tags

--- a/skills/integration-connectivity-generate/scripts/configure-named-credential.sh
+++ b/skills/integration-connectivity-generate/scripts/configure-named-credential.sh
@@ -190,14 +190,14 @@ try {
     // Create the credential (first-time setup)
     ConnectApi.NamedCredentials.createCredential(newCredentials);
     System.debug('✓ External Credential configured successfully!');
-    System.debug('Principal: $PRINCIPAL_NAME');
+    System.debug('Principal: $PRINCIPAL_NAME_ESCAPED');
 } catch (Exception e) {
     // If already exists, try patching instead
     if (e.getMessage().contains('already exists')) {
         try {
             ConnectApi.NamedCredentials.patchCredential(newCredentials);
             System.debug('✓ External Credential updated successfully!');
-            System.debug('Principal: $PRINCIPAL_NAME');
+            System.debug('Principal: $PRINCIPAL_NAME_ESCAPED');
         } catch (Exception e2) {
             System.debug('✗ Error updating credential: ' + e2.getMessage());
             throw e2;


### PR DESCRIPTION
## Summary

Hardens five agent-invoked helper scripts against command/code injection and
arbitrary file write, found by the HRAS / AgenticSAST security scan of this repo.
Each sink is reachable only across a local AI-agent trust boundary (a poisoned
repo, tampered engine output, or prompt-injected tool args on a developer/CI
host) — validated **P3**, not internet-reachable — but the sinks are genuine, so
they are fixed at the source here.

## Fixes

| File | Issue | Fix |
|------|-------|-----|
| `skills/dx-code-analyzer-run/scripts/describe-rule.js` | OS command injection via `ruleName` / `--engine` into three `execSync` shell strings (CWE-78) | Run `sf` through an `execFileSync` argv array and filter matches in JS — no shell, no `grep` subprocess |
| `skills/dx-code-analyzer-run/scripts/apply-fixes.js` | Arbitrary file write via `location.file` from the results JSON (CWE-22/73) | Confine every fix target to the working directory; skip and count path-escaping writes (`fixesSkippedUnsafe`) |
| `skills/dx-code-analyzer-configure/scripts/validate-config.sh` | Python code injection: config path interpolated into `python3 -c` (CWE-94) | Pass the path via `argv` through a quoted heredoc; Python reads `sys.argv[1]` |
| `scripts/validate-skills.ts` | OS command injection via `--base` into a `git diff` shell string (CWE-78) | `execFileSync("git", ["diff", "--name-only", \`${base}...HEAD\`])` — `base` is a single argv element |
| `skills/integration-connectivity-generate/scripts/configure-named-credential.sh` | Apex injection via unescaped `$PRINCIPAL_NAME` in two `System.debug` lines (CWE-94) | Use the already-escaped `$PRINCIPAL_NAME_ESCAPED` on both lines |

## Verification

- `describe-rule.js`: `node --check` passes; a `ruleName` of `x"; touch …; "` no longer executes.
- `apply-fixes.js`: `/etc/…`, absolute, and `../../` targets are skipped (counted); in-project fixes still apply.
- `validate-config.sh`: a file whose name embeds a Python payload is opened as a literal path — payload does not run; valid configs still validate.
- `configure-named-credential.sh` / `validate-config.sh`: `bash -n` clean.

No behavior change otherwise — same outputs, logic, timeouts, and fallbacks.

@W-23533877@