### PR TITLE
feat: add 'synchronize' type to PR title validation (W-23251216)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -2,7 +2,7 @@ name: Validate PR Title
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     branches: [main]
 
 jobs:


### PR DESCRIPTION
Just adds the `synchronize` event to the validate-pr.yml job to properly leverage the new checks added in @W-23251216@